### PR TITLE
Implement dynamic category and status detail pages with UI updates

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -32,6 +32,82 @@ const nextConfig: NextConfig = {
         destination: '/upgrade',
         permanent: true,
       },
+      // Explore drilldown shortcuts
+      {
+        source: '/draft',
+        destination: '/explore/details/status/draft',
+        permanent: false,
+      },
+      {
+        source: '/review',
+        destination: '/explore/details/status/review',
+        permanent: false,
+      },
+      {
+        source: '/last-call',
+        destination: '/explore/details/status/last-call',
+        permanent: false,
+      },
+      {
+        source: '/final',
+        destination: '/explore/details/status/final',
+        permanent: false,
+      },
+      {
+        source: '/living',
+        destination: '/explore/details/status/living',
+        permanent: false,
+      },
+      {
+        source: '/stagnant',
+        destination: '/explore/details/status/stagnant',
+        permanent: false,
+      },
+      {
+        source: '/withdrawn',
+        destination: '/explore/details/status/withdrawn',
+        permanent: false,
+      },
+      {
+        source: '/core',
+        destination: '/explore/details/category/core',
+        permanent: false,
+      },
+      {
+        source: '/networking',
+        destination: '/explore/details/category/networking',
+        permanent: false,
+      },
+      {
+        source: '/interface',
+        destination: '/explore/details/category/interface',
+        permanent: false,
+      },
+      {
+        source: '/meta',
+        destination: '/explore/details/category/meta',
+        permanent: false,
+      },
+      {
+        source: '/informational',
+        destination: '/explore/details/category/informational',
+        permanent: false,
+      },
+      {
+        source: '/repo/eips',
+        destination: '/explore/details/repo/eips',
+        permanent: false,
+      },
+      {
+        source: '/repo/ercs',
+        destination: '/explore/details/repo/ercs',
+        permanent: false,
+      },
+      {
+        source: '/repo/rips',
+        destination: '/explore/details/repo/rips',
+        permanent: false,
+      },
       // Canonical proposal detail routes are plural repo paths: /eips/:number, /ercs/:number, /rips/:number
       // Keep legacy singular detail links working across the app and shared links.
       {
@@ -57,7 +133,7 @@ const nextConfig: NextConfig = {
       },
       {
         source: '/erc',
-        destination: '/standards?repo=ercs',
+        destination: '/explore/details/category/erc',
         permanent: true,
       },
       {

--- a/src/app/(public)/_components/social-community-updates.tsx
+++ b/src/app/(public)/_components/social-community-updates.tsx
@@ -74,69 +74,41 @@ const communityDiscussions = [
   },
 ];
 
-const upcomingEvents = [
-  {
-    id: 1,
-    title: 'ACDT #73',
-    date: 'Mar 9, 2026',
-    time: 'Recent meeting',
-    url: 'https://github.com/ethereum/pm/issues/1956',
-    icon: Users,
-    type: 'Testing',
-  },
-  {
-    id: 2,
-    title: 'ACDT #72',
-    date: 'Mar 2, 2026',
-    time: 'Recent meeting',
-    url: 'https://github.com/ethereum/pm/issues/1948',
-    icon: MessageSquare,
-    type: 'Testing',
-  },
-  {
-    id: 3,
-    title: 'ACDE #231',
-    date: 'Feb 26, 2026',
-    time: 'Recent meeting',
-    url: 'https://github.com/ethereum/pm/issues/1931',
-    icon: Calendar,
-    type: 'Execution',
-  },
-  {
-    id: 4,
-    title: 'ACDC #175',
-    date: 'Feb 19, 2026',
-    time: 'Recent meeting',
-    url: 'https://github.com/ethereum/pm/issues/1930',
-    icon: Calendar,
-    type: 'Consensus',
-  },
-];
+type UpcomingEvent = {
+  id: number;
+  title: string;
+  date: string;
+  time: string;
+  url: string;
+  icon: React.ComponentType<{ className?: string }>;
+  type: string;
+  sortTs: number;
+};
 
 const communityChannels = [
   {
-    name: 'Discord',
-    description: 'Real-time governance and standards discussions',
-    members: '12.5k',
-    url: 'https://discord.gg/ethereum',
-    icon: MessageCircle,
+    name: 'Ethereum Magicians (EIPs)',
+    description: 'Primary forum for EIP proposal discussions and feedback.',
+    meta: 'Forum',
+    url: 'https://ethereum-magicians.org/c/eips/14',
+    icon: Hash,
+    color: 'violet',
+  },
+  {
+    name: 'Ethereum Research (Protocol)',
+    description: 'Deep protocol research threads connected to standards work.',
+    meta: 'Research',
+    url: 'https://ethresear.ch/c/protocol/14',
+    icon: MessageSquare,
     color: 'indigo',
   },
   {
-    name: 'GitHub Discussions',
-    description: 'Proposal feedback and technical design debate',
-    members: '8.3k',
-    url: 'https://github.com/ethereum/EIPs/discussions',
+    name: 'Ethereum PM (AllCoreDevs)',
+    description: 'Official meeting agendas, updates, and coordination issues.',
+    meta: 'Agendas',
+    url: 'https://github.com/ethereum/pm/issues',
     icon: Github,
     color: 'slate',
-  },
-  {
-    name: 'Ethereum Magicians',
-    description: 'Long-form EIP and governance conversations',
-    members: '15.2k',
-    url: 'https://ethereum-magicians.org/',
-    icon: Hash,
-    color: 'violet',
   },
 ];
 
@@ -183,6 +155,102 @@ type SocialCommunityUpdatesProps = {
 };
 
 export default function SocialCommunityUpdates({ showCommunityResources = true }: SocialCommunityUpdatesProps) {
+  const [upcomingEvents, setUpcomingEvents] = React.useState<UpcomingEvent[]>([]);
+  const [eventsLoading, setEventsLoading] = React.useState(true);
+  const [eventsSyncedAt, setEventsSyncedAt] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    const parseMeetingDate = (raw: string): Date | null => {
+      const monthPattern = /\b(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2}),?\s+(\d{4})\b/i;
+      const isoPattern = /\b(\d{4})-(\d{2})-(\d{2})\b/;
+      const monthMatch = raw.match(monthPattern);
+      if (monthMatch) {
+        const d = new Date(`${monthMatch[1]} ${monthMatch[2]}, ${monthMatch[3]} UTC`);
+        return Number.isNaN(d.getTime()) ? null : d;
+      }
+      const isoMatch = raw.match(isoPattern);
+      if (isoMatch) {
+        const d = new Date(`${isoMatch[1]}-${isoMatch[2]}-${isoMatch[3]}T00:00:00.000Z`);
+        return Number.isNaN(d.getTime()) ? null : d;
+      }
+      return null;
+    };
+
+    const parseTimeLabel = (raw: string) => {
+      const match = raw.match(/\b(\d{1,2}:\d{2})\s*(UTC|GMT)\b/i);
+      if (!match) return 'Agenda open';
+      return `${match[1]} ${match[2].toUpperCase()}`;
+    };
+
+    const typeAndIcon = (title: string): { type: string; icon: UpcomingEvent['icon'] } => {
+      const t = title.toLowerCase();
+      if (t.includes('acde') || t.includes('execution')) return { type: 'Execution', icon: Calendar };
+      if (t.includes('acdc') || t.includes('consensus')) return { type: 'Consensus', icon: Users };
+      if (t.includes('acdt') || t.includes('testing')) return { type: 'Testing', icon: MessageSquare };
+      return { type: 'Protocol', icon: Calendar };
+    };
+
+    (async () => {
+      setEventsLoading(true);
+      try {
+        const res = await fetch('https://api.github.com/repos/ethereum/pm/issues?state=open&per_page=40&sort=updated&direction=desc');
+        if (!res.ok) throw new Error(`GitHub response ${res.status}`);
+        const data: Array<{
+          number: number;
+          title: string;
+          body: string | null;
+          html_url: string;
+          updated_at: string;
+          pull_request?: unknown;
+        }> = await res.json();
+
+        const now = new Date();
+        const todayUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+        const items = data
+          .filter((row) => !row.pull_request)
+          .filter((row) => /(acd|all core devs|protocol|breakout|interop|allwalletdevs|eipip)/i.test(row.title))
+          .map((row) => {
+            const combined = `${row.title}\n${row.body ?? ''}`;
+            const parsedDate = parseMeetingDate(combined);
+            const { type, icon } = typeAndIcon(row.title);
+            const sortTs = parsedDate?.getTime() ?? new Date(row.updated_at).getTime();
+            return {
+              id: row.number,
+              title: row.title,
+              date: parsedDate
+                ? parsedDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+                : 'TBD',
+              time: parseTimeLabel(combined),
+              url: row.html_url,
+              icon,
+              type,
+              sortTs,
+              hasFutureDate: parsedDate ? parsedDate.getTime() >= todayUtc.getTime() : false,
+            };
+          })
+          .filter((item) => item.hasFutureDate || item.date === 'TBD')
+          .sort((a, b) => a.sortTs - b.sortTs)
+          .slice(0, 6)
+          .map(({ hasFutureDate: _drop, ...rest }) => rest);
+
+        if (!cancelled) setUpcomingEvents(items);
+      } catch (err) {
+        if (!cancelled) setUpcomingEvents([]);
+      } finally {
+        if (!cancelled) {
+          setEventsLoading(false);
+          setEventsSyncedAt(new Date().toISOString());
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <section className="w-full" id="social-community">
       <div className="mb-4 flex items-start justify-between gap-3">
@@ -285,7 +353,7 @@ export default function SocialCommunityUpdates({ showCommunityResources = true }
                 <div className="min-w-0 flex-1">
                   <p className="text-sm font-semibold text-foreground">{channel.name}</p>
                   <p className="text-xs text-muted-foreground">{channel.description}</p>
-                  <p className="mt-1 text-xs text-muted-foreground">{channel.members}</p>
+                  <p className="mt-1 text-xs text-muted-foreground">{channel.meta}</p>
                 </div>
                 <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition group-hover:opacity-100" />
               </a>
@@ -309,7 +377,22 @@ export default function SocialCommunityUpdates({ showCommunityResources = true }
             </div>
             <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition group-hover:opacity-100" />
           </a>
-          {upcomingEvents.map((event) => {
+          {eventsSyncedAt ? (
+            <p className="text-[11px] text-muted-foreground">
+              Last synced {new Date(eventsSyncedAt).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+            </p>
+          ) : null}
+          {eventsLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div key={`upcoming-event-skeleton-${i}`} className="h-16 animate-pulse rounded-md border border-border bg-muted/40" />
+              ))}
+            </div>
+          ) : upcomingEvents.length === 0 ? (
+            <div className="rounded-md border border-border bg-muted/40 px-3 py-4 text-xs text-muted-foreground">
+              No upcoming meeting agendas found right now. Check the full PM issue list.
+            </div>
+          ) : upcomingEvents.map((event) => {
             const Icon = event.icon;
             return (
               <a key={event.id} href={event.url} target="_blank" rel="noopener noreferrer" className="group flex items-start gap-3 rounded-lg border border-border bg-card/60 p-3 transition hover:border-primary/40">
@@ -318,7 +401,7 @@ export default function SocialCommunityUpdates({ showCommunityResources = true }
                 </div>
                 <div className="min-w-0 flex-1">
                   <p className="text-sm font-medium text-foreground">{event.title}</p>
-                  <p className="text-xs text-muted-foreground">{event.date} · {event.type}</p>
+                  <p className="text-xs text-muted-foreground">{event.date} · {event.time} · {event.type}</p>
                 </div>
                 <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition group-hover:opacity-100" />
               </a>

--- a/src/app/explore/_components/status-category-grid.tsx
+++ b/src/app/explore/_components/status-category-grid.tsx
@@ -66,6 +66,10 @@ function formatLastUpdated(dateStr: string | null): string {
   return `${Math.floor(diffDays / 30)} months ago`;
 }
 
+function toSlug(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
 export function StatusCategoryGrid() {
   const [statusCounts, setStatusCounts] = useState<StatusCount[]>([]);
   const [categoryCounts, setCategoryCounts] = useState<CategoryCount[]>([]);
@@ -150,6 +154,22 @@ export function StatusCategoryGrid() {
           ))}
         </div>
 
+        <div className="mb-6 flex flex-wrap items-center gap-2">
+          {categoryCounts.map((cat) => (
+            <Link
+              key={`category-drilldown-${cat.category}`}
+              href={`/explore/details/category/${toSlug(cat.category)}`}
+              className={cn(
+                "inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-medium transition-all",
+                "border-border bg-card/70 text-muted-foreground hover:border-primary/35 hover:text-foreground"
+              )}
+            >
+              {cat.category}
+              <span className="text-[11px] opacity-75">({cat.count})</span>
+            </Link>
+          ))}
+        </div>
+
         {/* Status Cards Grid */}
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
           {orderedStatuses.map((status, index) => {
@@ -161,7 +181,7 @@ export function StatusCategoryGrid() {
             return (
               <Link
                 key={status}
-                href={`/explore/status?status=${status.toLowerCase().replace(' ', '-')}${selectedCategory ? `&category=${selectedCategory}` : ''}`}
+                href={`/explore/details/status/${toSlug(status)}${selectedCategory ? `?category=${encodeURIComponent(selectedCategory)}` : ''}`}
               >
                 <motion.div
                   initial={{ opacity: 0, y: 20 }}

--- a/src/app/explore/details/[dimension]/[slug]/page.tsx
+++ b/src/app/explore/details/[dimension]/[slug]/page.tsx
@@ -1,0 +1,856 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, ArrowUpDown, Clock3, ExternalLink, Filter, GitFork, GitPullRequest, Search, Sparkles, Star, Eye } from 'lucide-react';
+import ReactECharts from 'echarts-for-react';
+import { client } from '@/lib/orpc';
+import { CopyLinkButton } from '@/components/header';
+import { LastUpdated } from '@/components/analytics/LastUpdated';
+import { cn } from '@/lib/utils';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+type DetailDimension = 'status' | 'category' | 'repo';
+type SortOption = 'updated_desc' | 'updated_asc' | 'days_desc' | 'days_asc' | 'number_asc';
+
+type DetailOverview = {
+  valid: boolean;
+  dimension: DetailDimension;
+  slug: string;
+  label: string;
+  total: number;
+  recentChanges30d: number;
+  lastUpdated: string | null;
+};
+
+type DetailTimeline = {
+  valid: boolean;
+  dimension: DetailDimension;
+  slug: string;
+  label: string;
+  months: string[];
+  statusSeries: Array<{ month: string; status: string; count: number }>;
+  totals: Array<{ month: string; count: number; touched: number }>;
+  updatedAt: string | null;
+};
+
+type DetailProposals = {
+  valid: boolean;
+  dimension: DetailDimension;
+  slug: string;
+  label: string;
+  total: number;
+  totalPages: number;
+  page: number;
+  pageSize: number;
+  rows: Array<{
+    id: number;
+    number: number;
+    title: string;
+    author: string | null;
+    status: string;
+    category: string | null;
+    type: string | null;
+    repo: string;
+    kind: 'EIP' | 'ERC' | 'RIP';
+    updatedAt: string | null;
+    daysInStatus: number | null;
+  }>;
+};
+
+type ReviewRow = {
+  prNumber: string;
+  title: string;
+  reviewer: string;
+  submittedAt: string;
+  repoShort: string;
+};
+
+type RepoGithubStats = {
+  valid: boolean;
+  repo: string;
+  githubRepo: string | null;
+  stars: number | null;
+  forks: number | null;
+  watchlist: number | null;
+  openIssues: number;
+  openPRs: number;
+  totalOpen: number;
+  updatedAt: string | null;
+};
+
+const statusOrder = ['Draft', 'Review', 'Last Call', 'Final', 'Living', 'Stagnant', 'Withdrawn', 'Unknown'];
+const statusColors: Record<string, string> = {
+  Draft: '#64748b',
+  Review: '#3b82f6',
+  'Last Call': '#f59e0b',
+  Final: '#10b981',
+  Living: '#06b6d4',
+  Stagnant: '#f97316',
+  Withdrawn: '#ef4444',
+  Unknown: '#94a3b8',
+};
+
+const badgeColors: Record<string, string> = {
+  Draft: 'bg-slate-500/15 text-slate-700 dark:text-slate-300 border-slate-500/30',
+  Review: 'bg-blue-500/15 text-blue-700 dark:text-blue-300 border-blue-500/30',
+  'Last Call': 'bg-amber-500/15 text-amber-700 dark:text-amber-300 border-amber-500/30',
+  Final: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-emerald-500/30',
+  Living: 'bg-cyan-500/15 text-cyan-700 dark:text-cyan-300 border-cyan-500/30',
+  Stagnant: 'bg-orange-500/15 text-orange-700 dark:text-orange-300 border-orange-500/30',
+  Withdrawn: 'bg-red-500/15 text-red-700 dark:text-red-300 border-red-500/30',
+  Unknown: 'bg-muted text-muted-foreground border-border',
+};
+
+function toMonthLabel(month: string) {
+  const [y, m] = month.split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, 1)).toLocaleDateString('en-US', { month: 'short', year: '2-digit' });
+}
+
+function formatDate(value: string | null) {
+  if (!value) return '—';
+  return new Date(value).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function formatDateTime(value: string) {
+  return new Date(value).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+function formatMetric(value: number | null) {
+  return value == null ? '—' : value.toLocaleString();
+}
+
+function repoLabel(repo: string) {
+  if (repo === 'eips') return 'EIPs';
+  if (repo === 'ercs') return 'ERCs';
+  if (repo === 'rips') return 'RIPs';
+  return repo.toUpperCase();
+}
+
+function repoToGithub(repo: string) {
+  if (repo === 'ercs') return 'ethereum/ERCs';
+  if (repo === 'rips') return 'ethereum/RIPs';
+  return 'ethereum/EIPs';
+}
+
+function proposalHref(row: DetailProposals['rows'][number]) {
+  if (row.kind === 'ERC') return `/erc/${row.number}`;
+  if (row.kind === 'RIP') return `/rip/${row.number}`;
+  return `/eip/${row.number}`;
+}
+
+function headerTitle(dimension: DetailDimension, label: string) {
+  if (dimension === 'status') return `Status: ${label}`;
+  if (dimension === 'category') return `Category: ${label}`;
+  return `Repository: ${label}`;
+}
+
+function toRepoFilterForReviews(dimension: DetailDimension, slug: string): 'eips' | 'ercs' | 'rips' | undefined {
+  if (dimension !== 'repo') return undefined;
+  const normalized = slug.toLowerCase();
+  if (normalized === 'eips' || normalized === 'ercs' || normalized === 'rips') return normalized;
+  return undefined;
+}
+
+function toSlug(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+export default function ExploreDetailPage({
+  params,
+}: {
+  params: Promise<{ dimension: string; slug: string }>;
+}) {
+  const resolvedParams = React.use(params);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const dimension = (resolvedParams.dimension || '').toLowerCase() as DetailDimension;
+  const slug = decodeURIComponent(resolvedParams.slug || '');
+  const validDimension = dimension === 'status' || dimension === 'category' || dimension === 'repo';
+
+  const [overview, setOverview] = useState<DetailOverview | null>(null);
+  const [timeline, setTimeline] = useState<DetailTimeline | null>(null);
+  const [reviews, setReviews] = useState<ReviewRow[]>([]);
+  const [repoStats, setRepoStats] = useState<RepoGithubStats | null>(null);
+  const [table, setTable] = useState<DetailProposals | null>(null);
+  const [statusOptions, setStatusOptions] = useState<Array<{ status: string; count: number }>>([]);
+  const [categoryOptions, setCategoryOptions] = useState<Array<{ category: string; count: number }>>([]);
+
+  const [q, setQ] = useState(() => searchParams.get('q') ?? '');
+  const [statusFilter, setStatusFilter] = useState(() => searchParams.get('status') ?? '');
+  const [categoryFilter, setCategoryFilter] = useState(() => searchParams.get('category') ?? '');
+  const [sort, setSort] = useState<SortOption>(() => {
+    const value = searchParams.get('sort');
+    return value === 'updated_asc' || value === 'days_desc' || value === 'days_asc' || value === 'number_asc'
+      ? value
+      : 'updated_desc';
+  });
+  const [page, setPage] = useState(() => {
+    const raw = Number(searchParams.get('page') ?? '1');
+    return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 1;
+  });
+  const [windowMonths, setWindowMonths] = useState<6 | 12 | 24>(() => {
+    const raw = Number(searchParams.get('months') ?? '12');
+    return raw === 6 || raw === 24 ? raw : 12;
+  });
+
+  const [loadingOverview, setLoadingOverview] = useState(true);
+  const [loadingTimeline, setLoadingTimeline] = useState(true);
+  const [loadingReviews, setLoadingReviews] = useState(true);
+  const [loadingRepoStats, setLoadingRepoStats] = useState(false);
+  const [loadingTable, setLoadingTable] = useState(true);
+
+  const fromMonth = useMemo(() => {
+    const now = new Date();
+    const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - (windowMonths - 1), 1));
+    return `${start.getUTCFullYear()}-${String(start.getUTCMonth() + 1).padStart(2, '0')}`;
+  }, [windowMonths]);
+
+  const toMonth = useMemo(() => {
+    const now = new Date();
+    return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+  }, []);
+
+  useEffect(() => {
+    setPage(1);
+  }, [q, statusFilter, categoryFilter, sort]);
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (q.trim()) params.set('q', q.trim());
+    if (statusFilter) params.set('status', statusFilter);
+    if (categoryFilter) params.set('category', categoryFilter);
+    if (sort !== 'updated_desc') params.set('sort', sort);
+    if (page > 1) params.set('page', String(page));
+    if (windowMonths !== 12) params.set('months', String(windowMonths));
+    const next = params.toString() ? `${pathname}?${params.toString()}` : pathname;
+    router.replace(next, { scroll: false });
+  }, [q, statusFilter, categoryFilter, sort, page, windowMonths, pathname, router]);
+
+  useEffect(() => {
+    if (!validDimension) return;
+    let cancelled = false;
+    (async () => {
+      setLoadingOverview(true);
+      try {
+        const data = await client.explore.getDetailOverview({ dimension, slug });
+        if (!cancelled) setOverview(data as DetailOverview);
+      } catch (err) {
+        console.error('Failed to load detail overview:', err);
+      } finally {
+        if (!cancelled) setLoadingOverview(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [dimension, slug, validDimension]);
+
+  useEffect(() => {
+    if (!validDimension || dimension !== 'repo') {
+      setRepoStats(null);
+      setLoadingRepoStats(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      setLoadingRepoStats(true);
+      try {
+        const data = await client.explore.getDetailRepoGithubStats({ slug });
+        if (!cancelled) setRepoStats(data as RepoGithubStats);
+      } catch (err) {
+        console.error('Failed to load repo GitHub stats:', err);
+      } finally {
+        if (!cancelled) setLoadingRepoStats(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [dimension, slug, validDimension]);
+
+  useEffect(() => {
+    if (!validDimension) return;
+    let cancelled = false;
+    (async () => {
+      setLoadingTimeline(true);
+      try {
+        const data = await client.explore.getDetailTimeline({ dimension, slug, fromMonth, toMonth });
+        if (!cancelled) setTimeline(data as DetailTimeline);
+      } catch (err) {
+        console.error('Failed to load detail timeline:', err);
+      } finally {
+        if (!cancelled) setLoadingTimeline(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [dimension, slug, fromMonth, toMonth, validDimension]);
+
+  useEffect(() => {
+    if (!validDimension) return;
+    let cancelled = false;
+    (async () => {
+      setLoadingReviews(true);
+      try {
+        const data = await client.analytics.getEditorReviewsLast24h({
+          repo: toRepoFilterForReviews(dimension, slug),
+          limit: 12,
+        });
+        if (!cancelled) setReviews(data as ReviewRow[]);
+      } catch (err) {
+        console.error('Failed to load 24h editor reviews:', err);
+      } finally {
+        if (!cancelled) setLoadingReviews(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [dimension, slug, validDimension]);
+
+  useEffect(() => {
+    if (!validDimension) return;
+    let cancelled = false;
+    (async () => {
+      setLoadingTable(true);
+      try {
+        const data = await client.explore.getDetailProposals({
+          dimension,
+          slug,
+          q: q.trim() || undefined,
+          status: statusFilter || undefined,
+          category: categoryFilter || undefined,
+          sort,
+          page,
+          pageSize: 20,
+        });
+        if (!cancelled) setTable(data as DetailProposals);
+      } catch (err) {
+        console.error('Failed to load detail proposals:', err);
+      } finally {
+        if (!cancelled) setLoadingTable(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [dimension, slug, q, statusFilter, categoryFilter, sort, page, validDimension]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [statuses, categories] = await Promise.all([
+          client.explore.getStatusCounts({}),
+          client.explore.getCategoryCounts({}),
+        ]);
+        if (!cancelled) {
+          setStatusOptions(statuses as Array<{ status: string; count: number }>);
+          setCategoryOptions(categories as Array<{ category: string; count: number }>);
+        }
+      } catch (err) {
+        console.error('Failed to load detail filter options:', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const timelineOption = useMemo(() => {
+    if (!timeline || !timeline.valid || timeline.months.length === 0) return null;
+    const months = timeline.months;
+    const orderedStatuses = Array.from(
+      new Set(
+        timeline.statusSeries
+          .map((row) => row.status)
+          .sort((a, b) => (statusOrder.indexOf(a) === -1 ? 999 : statusOrder.indexOf(a)) - (statusOrder.indexOf(b) === -1 ? 999 : statusOrder.indexOf(b)))
+      )
+    );
+    const statusMap = new Map<string, Map<string, number>>();
+    orderedStatuses.forEach((status) => statusMap.set(status, new Map()));
+    for (const row of timeline.statusSeries) {
+      statusMap.get(row.status)?.set(row.month, row.count);
+    }
+    const totalMap = new Map(timeline.totals.map((row) => [row.month, row.count]));
+
+    return {
+      grid: { left: 40, right: 16, top: 40, bottom: 28 },
+      tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+      legend: {
+        top: 0,
+        itemWidth: 10,
+        itemHeight: 10,
+      },
+      xAxis: {
+        type: 'category',
+        data: months.map(toMonthLabel),
+      },
+      yAxis: {
+        type: 'value',
+        minInterval: 1,
+        splitLine: { lineStyle: { type: 'dashed' } },
+      },
+      series: [
+        ...orderedStatuses.map((status) => ({
+          name: status,
+          type: 'bar',
+          stack: 'status',
+          data: months.map((month) => statusMap.get(status)?.get(month) ?? 0),
+          itemStyle: { color: statusColors[status] || statusColors.Unknown },
+        })),
+        {
+          name: 'Total',
+          type: 'line',
+          smooth: true,
+          symbolSize: 6,
+          data: months.map((month) => totalMap.get(month) ?? 0),
+          lineStyle: { width: 2, color: '#22d3ee' },
+          itemStyle: { color: '#22d3ee' },
+        },
+      ],
+    };
+  }, [timeline]);
+
+  if (!validDimension) {
+    return (
+      <div className="mx-auto w-full px-3 py-10 sm:px-4 lg:px-5 xl:px-6">
+        <div className="rounded-xl border border-border bg-card/60 p-6 text-center">
+          <p className="text-lg font-semibold text-foreground">Unsupported detail dimension.</p>
+          <p className="mt-1 text-sm text-muted-foreground">Use status, category, or repo detail routes.</p>
+          <Link href="/explore" className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline">
+            Back to Explore <ArrowLeft className="h-3 w-3" />
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const title = overview?.label ? headerTitle(dimension, overview.label) : headerTitle(dimension, slug);
+
+  if (!loadingOverview && overview && !overview.valid) {
+    return (
+      <div className="mx-auto w-full px-3 py-10 sm:px-4 lg:px-5 xl:px-6">
+        <div className="rounded-xl border border-border bg-card/60 p-6 text-center">
+          <p className="text-lg font-semibold text-foreground">Bucket not found for this drilldown.</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Try another status, category, or repository from Explore.
+          </p>
+          <Link href="/explore" className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline">
+            Back to Explore <ArrowLeft className="h-3 w-3" />
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative min-h-screen w-full bg-background">
+      <section id="explore-detail-header" className="w-full pt-5 pb-4">
+        <div className="mx-auto w-full px-3 sm:px-4 lg:px-5 xl:px-6">
+          <Link href="/explore" className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground">
+            <ArrowLeft className="h-4 w-4" />
+            Back to Explore
+          </Link>
+
+          <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h1 className="dec-title persona-title text-3xl font-semibold tracking-tight sm:text-4xl">{title}</h1>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Detailed drilldown for this {dimension} bucket with trends, 24h reviews, and proposal-level rows.
+              </p>
+              {dimension === 'category' && (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Type is grouped under Category in v4.
+                </p>
+              )}
+            </div>
+            <CopyLinkButton sectionId="explore-detail-header" className="h-8 w-8 rounded-md" />
+          </div>
+
+          <div className="mt-4 grid gap-2 sm:grid-cols-3">
+            <div className="rounded-lg border border-border bg-card/60 px-3 py-2">
+              <p className="text-[11px] uppercase tracking-wider text-muted-foreground">Total proposals</p>
+              <p className="mt-1 text-2xl font-semibold text-foreground">{loadingOverview ? '—' : (overview?.total ?? 0).toLocaleString()}</p>
+            </div>
+            <div className="rounded-lg border border-border bg-card/60 px-3 py-2">
+              <p className="text-[11px] uppercase tracking-wider text-muted-foreground">Status changes (30d)</p>
+              <p className="mt-1 text-2xl font-semibold text-foreground">{loadingOverview ? '—' : (overview?.recentChanges30d ?? 0).toLocaleString()}</p>
+            </div>
+            <div className="rounded-lg border border-border bg-card/60 px-3 py-2">
+              <p className="text-[11px] uppercase tracking-wider text-muted-foreground">Last updated</p>
+              <p className="mt-1 text-sm font-medium text-foreground">{formatDate(overview?.lastUpdated ?? null)}</p>
+              {overview?.lastUpdated ? (
+                <LastUpdated timestamp={overview.lastUpdated} prefix="Updated" className="mt-1 bg-muted/40 text-xs" />
+              ) : null}
+            </div>
+          </div>
+
+          {dimension === 'repo' ? (
+            <div className="mt-3 rounded-2xl border border-border/80 bg-gradient-to-br from-card/90 via-card/75 to-muted/30 p-4 shadow-sm">
+              <div className="mb-3 flex items-center justify-between gap-2">
+                <p className="text-sm font-semibold tracking-tight text-foreground">
+                  GitHub Stats — {overview?.label ?? slug}
+                </p>
+                {repoStats?.githubRepo ? (
+                  <a
+                    href={`https://github.com/${repoStats.githubRepo}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 px-2.5 py-1 text-xs text-primary transition hover:bg-primary/15"
+                  >
+                    Open repository <ExternalLink className="h-3 w-3" />
+                  </a>
+                ) : null}
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                <div className="rounded-xl border border-border/80 bg-gradient-to-br from-sky-500/[0.08] to-sky-500/[0.02] px-3.5 py-3">
+                  <p className="inline-flex items-center gap-1.5 text-[11px] uppercase tracking-wider text-muted-foreground">
+                    <GitFork className="h-3.5 w-3.5 text-sky-500" />
+                    Forks
+                  </p>
+                  <p className="mt-1 text-2xl font-semibold tracking-tight text-foreground">
+                    {loadingRepoStats ? '—' : formatMetric(repoStats?.forks ?? null)}
+                  </p>
+                </div>
+                <div className="rounded-xl border border-border/80 bg-gradient-to-br from-cyan-500/[0.08] to-cyan-500/[0.02] px-3.5 py-3">
+                  <p className="inline-flex items-center gap-1.5 text-[11px] uppercase tracking-wider text-muted-foreground">
+                    <Eye className="h-3.5 w-3.5 text-cyan-500" />
+                    Watchlist
+                  </p>
+                  <p className="mt-1 text-2xl font-semibold tracking-tight text-foreground">
+                    {loadingRepoStats ? '—' : formatMetric(repoStats?.watchlist ?? null)}
+                  </p>
+                </div>
+                <div className="rounded-xl border border-border/80 bg-gradient-to-br from-amber-500/[0.10] to-amber-500/[0.03] px-3.5 py-3">
+                  <p className="inline-flex items-center gap-1.5 text-[11px] uppercase tracking-wider text-muted-foreground">
+                    <Star className="h-3.5 w-3.5 text-amber-500" />
+                    Stars
+                  </p>
+                  <p className="mt-1 text-2xl font-semibold tracking-tight text-foreground">
+                    {loadingRepoStats ? '—' : formatMetric(repoStats?.stars ?? null)}
+                  </p>
+                </div>
+                <div className="rounded-xl border border-border/80 bg-gradient-to-br from-emerald-500/[0.10] to-emerald-500/[0.03] px-3.5 py-3">
+                  <p className="inline-flex items-center gap-1.5 text-[11px] uppercase tracking-wider text-muted-foreground">
+                    <GitPullRequest className="h-3.5 w-3.5 text-emerald-500" />
+                    Open Issues & PR
+                  </p>
+                  <p className="mt-1 text-2xl font-semibold tracking-tight text-foreground">
+                    {loadingRepoStats ? '—' : (repoStats?.totalOpen ?? 0).toLocaleString()}
+                  </p>
+                  {!loadingRepoStats && repoStats ? (
+                    <p className="mt-1 text-[11px] text-muted-foreground">
+                      {repoStats.openIssues.toLocaleString()} issues · {repoStats.openPRs.toLocaleString()} PRs
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+              {repoStats?.updatedAt ? (
+                <div className="mt-3 border-t border-border/70 pt-3">
+                  <LastUpdated timestamp={repoStats.updatedAt} prefix="Stats updated" className="bg-muted/40 text-xs" />
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      <hr className="border-border/70" />
+
+      <section id="explore-detail-timeline" className="w-full py-5">
+        <div className="mx-auto w-full px-3 sm:px-4 lg:px-5 xl:px-6">
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <h2 className="dec-title text-2xl font-semibold tracking-tight text-foreground">Over Time</h2>
+              <p className="text-sm text-muted-foreground">Proposal movement and status mix over time.</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="text-xs text-muted-foreground">Window</label>
+              <select
+                value={windowMonths}
+                onChange={(e) => setWindowMonths(Number(e.target.value) as 6 | 12 | 24)}
+                className="h-8 rounded-md border border-border bg-card/60 px-2.5 text-xs text-foreground"
+              >
+                <option value={6}>6 months</option>
+                <option value={12}>12 months</option>
+                <option value={24}>24 months</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-border bg-card/60 p-3">
+            {loadingTimeline ? (
+              <div className="h-[320px] animate-pulse rounded-lg bg-muted" />
+            ) : !timelineOption ? (
+              <div className="flex h-[320px] items-center justify-center rounded-lg border border-border/70 bg-muted/30 text-sm text-muted-foreground">
+                No timeline data for this bucket.
+              </div>
+            ) : (
+              <ReactECharts option={timelineOption as object} style={{ height: 320, width: '100%' }} opts={{ renderer: 'svg' }} />
+            )}
+            {timeline?.updatedAt ? (
+              <div className="mt-3 border-t border-border/70 pt-3">
+                <LastUpdated timestamp={timeline.updatedAt} prefix="Updated" showAbsolute className="bg-muted/40 text-xs" />
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      <hr className="border-border/70" />
+
+      <section id="explore-detail-editor-reviews-24h" className="w-full py-5">
+        <div className="mx-auto w-full px-3 sm:px-4 lg:px-5 xl:px-6">
+          <div className="mb-3">
+            <h2 className="dec-title text-2xl font-semibold tracking-tight text-foreground">Editor Reviews (Last 24 Hours)</h2>
+            <p className="text-sm text-muted-foreground">Recent review actions by editors across open review activity.</p>
+          </div>
+
+          <div className="rounded-xl border border-border bg-card/60 p-3">
+            {loadingReviews ? (
+              <div className="space-y-2">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <div key={`reviews-skeleton-${i}`} className="h-14 animate-pulse rounded-lg bg-muted" />
+                ))}
+              </div>
+            ) : reviews.length === 0 ? (
+              <div className="rounded-lg border border-border bg-muted/30 px-3 py-8 text-center text-sm text-muted-foreground">
+                No editor reviews found in the last 24 hours.
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {reviews.map((row, idx) => (
+                  <a
+                    key={`review-row-${row.repoShort}-${row.prNumber}-${idx}`}
+                    href={`/pr/${repoToGithub(row.repoShort)}/${row.prNumber}`}
+                    className="block rounded-lg border border-border bg-card/70 px-3 py-2.5 transition hover:border-primary/35 hover:bg-primary/[0.04]"
+                  >
+                    <div className="mb-1 flex items-center justify-between gap-2">
+                      <p className="text-sm font-medium text-foreground">{row.reviewer}</p>
+                      <span className="rounded-full border border-border bg-muted/50 px-2 py-0.5 text-[10px] text-muted-foreground">
+                        {repoLabel(row.repoShort)} PR #{row.prNumber}
+                      </span>
+                    </div>
+                    <p className="line-clamp-1 text-sm text-muted-foreground">{row.title || `PR #${row.prNumber}`}</p>
+                    <p className="mt-1 text-[11px] text-muted-foreground">{formatDateTime(row.submittedAt)}</p>
+                  </a>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <hr className="border-border/70" />
+
+      <section id="explore-detail-proposals-table" className="w-full py-5">
+        <div className="mx-auto w-full px-3 sm:px-4 lg:px-5 xl:px-6">
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <h2 className="dec-title text-2xl font-semibold tracking-tight text-foreground">Detailed Proposals</h2>
+              <p className="text-sm text-muted-foreground">Search, filter, and inspect proposal rows in this bucket.</p>
+            </div>
+            <div className="rounded-full border border-border bg-muted/40 px-3 py-1 text-xs text-muted-foreground">
+              {(table?.total ?? 0).toLocaleString()} rows
+            </div>
+          </div>
+
+          <div className="mb-2 grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
+            <label className="sm:col-span-2">
+              <span className="mb-1 inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                <Search className="h-3 w-3" />
+                Search
+              </span>
+              <input
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                placeholder="Title / number / author"
+                className="h-9 w-full rounded-md border border-border bg-card/60 px-3 text-sm text-foreground"
+              />
+            </label>
+
+            <label>
+              <span className="mb-1 inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                <Filter className="h-3 w-3" />
+                Status
+              </span>
+              <select value={statusFilter} onChange={(e) => setStatusFilter(e.target.value)} className="h-9 w-full rounded-md border border-border bg-card/60 px-3 text-sm text-foreground">
+                <option value="">All statuses</option>
+                {statusOptions.map((opt) => (
+                  <option key={`status-opt-${opt.status}`} value={opt.status}>
+                    {opt.status}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label>
+              <span className="mb-1 inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                <Sparkles className="h-3 w-3" />
+                Category
+              </span>
+              <select value={categoryFilter} onChange={(e) => setCategoryFilter(e.target.value)} className="h-9 w-full rounded-md border border-border bg-card/60 px-3 text-sm text-foreground">
+                <option value="">All categories</option>
+                {categoryOptions.map((opt) => (
+                  <option key={`category-opt-${opt.category}`} value={opt.category}>
+                    {opt.category}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label>
+              <span className="mb-1 inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                <ArrowUpDown className="h-3 w-3" />
+                Sort
+              </span>
+              <select value={sort} onChange={(e) => setSort(e.target.value as SortOption)} className="h-9 w-full rounded-md border border-border bg-card/60 px-3 text-sm text-foreground">
+                <option value="updated_desc">Updated ↓</option>
+                <option value="updated_asc">Updated ↑</option>
+                <option value="days_desc">Days in status ↓</option>
+                <option value="days_asc">Days in status ↑</option>
+                <option value="number_asc">Number ↑</option>
+              </select>
+            </label>
+          </div>
+
+          <div className="overflow-hidden rounded-xl border border-border bg-card/60">
+            <div className="hidden md:block">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border/70 bg-muted/40 text-left text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                    <th className="px-3 py-2.5">Proposal</th>
+                    <th className="px-3 py-2.5">Title</th>
+                    <th className="px-3 py-2.5">Repo</th>
+                    <th className="px-3 py-2.5">Status</th>
+                    <th className="px-3 py-2.5">Category</th>
+                    <th className="px-3 py-2.5">Updated</th>
+                    <th className="px-3 py-2.5">Days</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {loadingTable ? (
+                    Array.from({ length: 8 }).map((_, i) => (
+                      <tr key={`detail-table-skeleton-${i}`} className="border-b border-border/60">
+                        <td colSpan={7} className="px-3 py-2.5">
+                          <div className="h-4 animate-pulse rounded bg-muted" />
+                        </td>
+                      </tr>
+                    ))
+                  ) : table?.rows.length === 0 ? (
+                    <tr>
+                      <td colSpan={7} className="px-3 py-8 text-center text-sm text-muted-foreground">
+                        No proposals found for this bucket.
+                      </td>
+                    </tr>
+                  ) : (
+                    table?.rows.map((row) => (
+                      <tr key={`detail-row-${row.id}`} className="border-b border-border/60 transition-colors hover:bg-muted/40">
+                        <td className="px-3 py-2.5">
+                          <Link href={proposalHref(row)} className="inline-flex items-center gap-1 font-medium text-primary hover:underline">
+                            {row.kind}-{row.number}
+                            <ExternalLink className="h-3 w-3 opacity-70" />
+                          </Link>
+                        </td>
+                        <td className="max-w-[420px] truncate px-3 py-2.5 text-foreground">{row.title}</td>
+                        <td className="px-3 py-2.5">
+                          <Link href={`/explore/details/repo/${toSlug(row.repo)}`} className="text-muted-foreground hover:text-foreground hover:underline">
+                            {repoLabel(row.repo)}
+                          </Link>
+                        </td>
+                        <td className="px-3 py-2.5">
+                          <Link
+                            href={`/explore/details/status/${toSlug(row.status)}`}
+                            className={cn('inline-flex rounded-full border px-2 py-0.5 text-[11px] font-medium', badgeColors[row.status] || badgeColors.Unknown)}
+                          >
+                            {row.status}
+                          </Link>
+                        </td>
+                        <td className="px-3 py-2.5">
+                          {row.category ? (
+                            <Link
+                              href={`/explore/details/category/${toSlug(row.category)}`}
+                              className="text-muted-foreground hover:text-foreground hover:underline"
+                            >
+                              {row.category}
+                            </Link>
+                          ) : (
+                            <span className="text-muted-foreground">—</span>
+                          )}
+                        </td>
+                        <td className="px-3 py-2.5 text-muted-foreground">{formatDate(row.updatedAt)}</td>
+                        <td className="px-3 py-2.5 text-muted-foreground">
+                          <span className="inline-flex items-center gap-1">
+                            <Clock3 className="h-3.5 w-3.5" />
+                            {row.daysInStatus == null ? '—' : `${row.daysInStatus}d`}
+                          </span>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="space-y-2 p-2 md:hidden">
+              {loadingTable ? (
+                Array.from({ length: 6 }).map((_, i) => (
+                  <div key={`mobile-detail-skeleton-${i}`} className="h-20 animate-pulse rounded-lg bg-muted" />
+                ))
+              ) : table?.rows.length === 0 ? (
+                <div className="rounded-lg border border-border bg-muted/30 px-3 py-7 text-center text-sm text-muted-foreground">
+                  No proposals found for this bucket.
+                </div>
+              ) : (
+                table?.rows.map((row) => (
+                  <div key={`mobile-detail-${row.id}`} className="rounded-lg border border-border bg-card/70 p-2.5">
+                    <div className="mb-1 flex items-center justify-between gap-2">
+                      <Link href={proposalHref(row)} className="text-sm font-semibold text-primary hover:underline">
+                        {row.kind}-{row.number}
+                      </Link>
+                      <span className={cn('inline-flex rounded-full border px-2 py-0.5 text-[10px]', badgeColors[row.status] || badgeColors.Unknown)}>
+                        {row.status}
+                      </span>
+                    </div>
+                    <p className="line-clamp-2 text-sm text-foreground">{row.title}</p>
+                    <p className="mt-1 text-[11px] text-muted-foreground">
+                      {repoLabel(row.repo)} • {row.category || '—'} • {row.daysInStatus == null ? '—' : `${row.daysInStatus}d`}
+                    </p>
+                  </div>
+                ))
+              )}
+            </div>
+
+            <div className="flex items-center justify-between border-t border-border/70 bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+              <span>
+                Page {table?.page ?? page} / {table?.totalPages ?? 1}
+              </span>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setPage((prev) => Math.max(1, prev - 1))}
+                  disabled={(table?.page ?? page) <= 1}
+                  className="rounded-md border border-border bg-muted/60 px-2 py-1 disabled:opacity-40"
+                >
+                  Prev
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPage((prev) => Math.min(table?.totalPages ?? 1, prev + 1))}
+                  disabled={(table?.page ?? page) >= (table?.totalPages ?? 1)}
+                  className="rounded-md border border-border bg-muted/60 px-2 py-1 disabled:opacity-40"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/explore/status/_components/status-eip-table.tsx
+++ b/src/app/explore/status/_components/status-eip-table.tsx
@@ -60,6 +60,10 @@ function formatDate(date: string | null): string {
   return new Date(date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
+function toSlug(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
 export function StatusEIPTable({
   eips,
   total,
@@ -164,20 +168,30 @@ export function StatusEIPTable({
                   </span>
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap">
-                  <span className={cn(
-                    "text-sm font-medium",
-                    categoryColors[eip.category || ''] || 'text-muted-foreground'
-                  )}>
-                    {eip.category || '-'}
-                  </span>
+                  {eip.category ? (
+                    <Link
+                      href={`/explore/details/category/${toSlug(eip.category)}`}
+                      className={cn(
+                        "text-sm font-medium hover:underline",
+                        categoryColors[eip.category || ''] || 'text-muted-foreground'
+                      )}
+                    >
+                      {eip.category}
+                    </Link>
+                  ) : (
+                    <span className="text-sm text-muted-foreground">-</span>
+                  )}
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap">
-                  <span className={cn(
-                    "inline-flex px-2.5 py-1 rounded-full text-xs font-medium border",
-                    statusColors[eip.status] || statusColors['Draft']
-                  )}>
+                  <Link
+                    href={`/explore/details/status/${toSlug(eip.status)}`}
+                    className={cn(
+                      "inline-flex rounded-full border px-2.5 py-1 text-xs font-medium hover:opacity-90",
+                      statusColors[eip.status] || statusColors['Draft']
+                    )}
+                  >
                     {eip.status}
-                  </span>
+                  </Link>
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap">
                   <span className={cn(

--- a/src/app/explore/status/_components/status-filter-bar.tsx
+++ b/src/app/explore/status/_components/status-filter-bar.tsx
@@ -158,6 +158,9 @@ export function StatusFilterBar({
               <label className="mb-2 block text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
                 Type
               </label>
+              <p className="mb-2 text-[11px] text-muted-foreground">
+                Type is grouped under Category in Explore v4 detail pages.
+              </p>
               <div className="flex flex-wrap gap-2">
                 {types.map((type) => (
                   <button

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -428,6 +428,7 @@ function AppSidebarContent() {
 
   // Scroll spy state (kept for future use)
   const [activeSection, setActiveSection] = React.useState("");
+  const [pageSectionItems, setPageSectionItems] = React.useState<SidebarSubItem[]>([]);
   const [membershipTier, setMembershipTier] = React.useState<string>("free");
   const [isAdmin, setIsAdmin] = React.useState(false);
   const [hash, setHash] = React.useState(() => 
@@ -453,6 +454,56 @@ function AppSidebarContent() {
   React.useEffect(() => {
     setHash(window.location.hash);
   }, [pathname, searchParams]);
+
+  // Normalized search param string for reactive comparison
+  const currentSearchStr = React.useMemo(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.sort();
+    return params.toString();
+  }, [searchParams]);
+
+  React.useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    const toTitle = (raw: string) =>
+      raw
+        .replace(/[-_]+/g, " ")
+        .replace(/\s+/g, " ")
+        .trim()
+        .replace(/\b\w/g, (c) => c.toUpperCase());
+
+    const build = () => {
+      const query = currentSearchStr ? `?${currentSearchStr}` : "";
+      const seen = new Set<string>();
+      const seenTitles = new Set<string>();
+      const collected: SidebarSubItem[] = [];
+      const nodes = Array.from(document.querySelectorAll<HTMLElement>("section[id], [data-sidebar-section][id]"));
+
+      for (const node of nodes) {
+        const id = (node.id || "").trim();
+        if (!id || seen.has(id)) continue;
+        seen.add(id);
+        const fromData = node.getAttribute("data-sidebar-label")?.trim();
+        const heading = node.querySelector<HTMLElement>("h1, h2, h3");
+        const title = fromData || heading?.textContent?.trim() || toTitle(id);
+        const titleKey = title.toLowerCase().replace(/\s+/g, " ").trim();
+        if (seenTitles.has(titleKey)) continue;
+        seenTitles.add(titleKey);
+        collected.push({
+          title,
+          href: `${pathname}${query}#${id}`,
+          sectionId: id,
+        });
+      }
+
+      setPageSectionItems(collected);
+    };
+
+    build();
+    const observer = new MutationObserver(() => build());
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [pathname, currentSearchStr]);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -485,13 +536,6 @@ function AppSidebarContent() {
       return { ...section, items };
     });
   }, [orderedSections, isAdmin]);
-
-  // Normalized search param string for reactive comparison
-  const currentSearchStr = React.useMemo(() => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.sort();
-    return params.toString();
-  }, [searchParams]);
 
   // ========================================================================
   // Collapsible management
@@ -545,34 +589,12 @@ function AppSidebarContent() {
   // Scroll spy — active page only (hash sections for any route)
   // ========================================================================
 
-  const activeParentItem = React.useMemo(() => {
-    const allItems = visibleSections.flatMap((section) => section.items);
-
-    return (
-      allItems.find((item) => {
-        if (!item.items?.length) return false;
-        return item.items.some((sub) => {
-          const url = new URL(sub.href, "http://localhost");
-          const hrefPath = url.pathname;
-          const hrefParams = new URLSearchParams(url.search);
-          hrefParams.sort();
-          return pathname === hrefPath && hrefParams.toString() === currentSearchStr;
-        });
-      }) ?? null
-    );
-  }, [visibleSections, pathname, currentSearchStr]);
-
   const trackedSections = React.useMemo(() => {
-    if (!activeParentItem?.items?.length) return [];
-    return activeParentItem.items
-      .map((sub) => {
-        const url = new URL(sub.href, "http://localhost");
-        const id = sub.sectionId || url.hash.replace(/^#/, "");
-        const hrefPath = url.pathname;
-        return id && hrefPath === pathname ? id : null;
-      })
+    if (pageSectionItems.length === 0) return [];
+    return pageSectionItems
+      .map((sub) => sub.sectionId || new URL(sub.href, "http://localhost").hash.replace(/^#/, ""))
       .filter((x): x is string => !!x);
-  }, [activeParentItem, pathname]);
+  }, [pageSectionItems]);
 
   React.useEffect(() => {
     if (trackedSections.length === 0) {
@@ -715,10 +737,12 @@ function AppSidebarContent() {
   };
 
   const renderItem = (item: SidebarItem) => {
-    const hasSubItems = item.items && item.items.length > 0;
-    const isItemOpen = openItem === item.title;
     const isActive = isParentPathActive(item.href);
-    const isChildActive = hasActiveChild(item.items);
+    const contextualSections = isActive ? pageSectionItems : [];
+    const mergedSubItems = [...(item.items ?? []), ...contextualSections];
+    const hasSubItems = mergedSubItems.length > 0;
+    const isItemOpen = openItem === item.title;
+    const isChildActive = hasActiveChild(mergedSubItems);
     const isHighlighted = isActive || isChildActive;
     const effectivePersona = persona ?? DEFAULT_PERSONA;
     const personaPriority = PERSONA_ITEM_PRIORITY[effectivePersona] ?? [];
@@ -790,6 +814,14 @@ function AppSidebarContent() {
               >
                 <SidebarMenuSub className="ml-0 border-l-2 border-border/80 pl-6 pt-2">
                   {item.items?.map(renderSubItem)}
+                  {contextualSections.length > 0 && (
+                    <>
+                      <div className="mb-1 mt-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/90">
+                        Sections
+                      </div>
+                      {contextualSections.map(renderSubItem)}
+                    </>
+                  )}
                 </SidebarMenuSub>
               </CollapsibleContent>
             )}

--- a/src/components/inline-brand-loader.tsx
+++ b/src/components/inline-brand-loader.tsx
@@ -15,28 +15,28 @@ export function InlineBrandLoader({
   className,
 }: InlineBrandLoaderProps) {
   const dimension = size === 'sm' ? 28 : 36;
+  const frame = size === 'sm' ? 44 : 56;
+  const ring = size === 'sm' ? 52 : 66;
 
   return (
-    <div className={cn('flex flex-col items-center justify-center gap-2', className)}>
-      <div className="relative">
-        <div className={cn(
-          'absolute inset-0 rounded-full border border-primary/35',
-          size === 'sm' ? 'scale-125' : 'scale-130',
-        )} />
-        <div className={cn(
-          'absolute inset-0 rounded-full border-2 border-transparent border-t-primary/70 animate-spin',
-          size === 'sm' ? 'scale-[1.55]' : 'scale-[1.6]',
-        )} />
-        <ThemedLogoGif
-          alt="EIPsInsight"
-          width={dimension}
-          height={dimension}
-          unoptimized
-          className="rounded-full shadow-[0_0_14px_rgb(var(--persona-accent-rgb)/0.28)]"
-        />
+    <div className={cn('flex flex-col items-center justify-center gap-2.5', className)}>
+      <div className="relative flex items-center justify-center" style={{ width: ring, height: ring }}>
+        <div className="absolute inset-0 rounded-full border border-primary/25 bg-primary/[0.03]" />
+        <div className="absolute inset-0 animate-spin rounded-full border-2 border-primary/20 border-t-primary/75 border-r-primary/55" />
+        <div
+          className="relative z-10 flex items-center justify-center rounded-full border border-border/80 bg-card/90 shadow-[0_0_20px_rgb(var(--persona-accent-rgb)/0.16)]"
+          style={{ width: frame, height: frame }}
+        >
+          <ThemedLogoGif
+            alt="EIPsInsight"
+            width={dimension}
+            height={dimension}
+            unoptimized
+            className="object-contain"
+          />
+        </div>
       </div>
-      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className={cn('text-muted-foreground', size === 'sm' ? 'text-xs' : 'text-sm')}>{label}</span>
     </div>
   );
 }
-

--- a/src/server/orpc/procedures/explore.ts
+++ b/src/server/orpc/procedures/explore.ts
@@ -379,6 +379,53 @@ const ROLE_FILTER_TIME_RANGES = ['30d', '90d', '365d', 'all'] as const;
 type RoleFilterRepo = (typeof ROLE_FILTER_REPOS)[number];
 type RoleFilterCategory = (typeof ROLE_FILTER_CATEGORIES)[number];
 type RoleFilterRange = (typeof ROLE_FILTER_TIME_RANGES)[number];
+type DetailDimension = 'status' | 'category' | 'repo';
+
+const DETAIL_DIMENSIONS = ['status', 'category', 'repo'] as const;
+
+function slugifyDetailLabel(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+async function resolveDetailTarget(dimension: DetailDimension, slug: string): Promise<{
+  valid: boolean;
+  label: string;
+  repoKey: 'eips' | 'ercs' | 'rips' | null;
+}> {
+  const normalizedSlug = slugifyDetailLabel(slug);
+  if (dimension === 'repo') {
+    const repoMap: Record<string, { label: string; repoKey: 'eips' | 'ercs' | 'rips' }> = {
+      eips: { label: 'EIPs', repoKey: 'eips' },
+      ercs: { label: 'ERCs', repoKey: 'ercs' },
+      rips: { label: 'RIPs', repoKey: 'rips' },
+    };
+    const hit = repoMap[normalizedSlug];
+    if (!hit) return { valid: false, label: slug, repoKey: null };
+    return { valid: true, label: hit.label, repoKey: hit.repoKey };
+  }
+
+  if (dimension === 'status') {
+    const statuses = await getStatusCountsCached(null);
+    const hit = statuses.find((row) => slugifyDetailLabel(row.status) === normalizedSlug);
+    if (!hit) return { valid: false, label: slug, repoKey: null };
+    return { valid: true, label: hit.status, repoKey: null };
+  }
+
+  const categories = await getCategoryCountsCached();
+  const hit = categories.find((row) => slugifyDetailLabel(row.category) === normalizedSlug);
+  if (!hit) return { valid: false, label: slug, repoKey: null };
+  return { valid: true, label: hit.category, repoKey: null };
+}
+
+function repoKeyToGithubRepo(repoKey: 'eips' | 'ercs' | 'rips') {
+  if (repoKey === 'ercs') return 'ethereum/ERCs';
+  if (repoKey === 'rips') return 'ethereum/RIPs';
+  return 'ethereum/EIPs';
+}
 
 const CANONICAL_EDITOR_SET = new Set(CANONICAL_EIP_EDITOR_LOWER);
 const CANONICAL_REVIEWER_SET = new Set(CANONICAL_EIP_REVIEWER_LOWER);
@@ -966,6 +1013,581 @@ export const exploreProcedures = {
         .filter(s => !statusOrder.includes(s.status))
         .map(s => ({ status: s.status, count: s.count }));
       return [...ordered, ...extras];
+    }),
+
+  getDetailOverview: optionalAuthProcedure
+    .input(z.object({
+      dimension: z.enum(DETAIL_DIMENSIONS),
+      slug: z.string().min(1),
+    }))
+    .handler(async ({ input }) => {
+      const target = await resolveDetailTarget(input.dimension, input.slug);
+      if (!target.valid) {
+        return {
+          valid: false,
+          dimension: input.dimension,
+          slug: slugifyDetailLabel(input.slug),
+          label: input.slug,
+          total: 0,
+          recentChanges30d: 0,
+          lastUpdated: null as string | null,
+        };
+      }
+
+      const params: unknown[] = [];
+      const eventParams: unknown[] = [];
+      let paramIdx = 1;
+      const eipFilters: string[] = ['e.eip_number NOT IN (2512, 3297, 1047)'];
+      const eventFilters: string[] = ['e.eip_number NOT IN (2512, 3297, 1047)'];
+
+      if (input.dimension === 'status') {
+        eipFilters.push(`COALESCE(NULLIF(s.status, ''), 'Unknown') = $${paramIdx}`);
+        eventFilters.push(`COALESCE(NULLIF(s.status, ''), 'Unknown') = $${paramIdx}`);
+        params.push(target.label);
+        eventParams.push(target.label);
+        paramIdx += 1;
+      } else if (input.dimension === 'category') {
+        eipFilters.push(`COALESCE(NULLIF(TRIM(s.category), ''), NULLIF(TRIM(s.type), ''), 'Unknown') = $${paramIdx}`);
+        eventFilters.push(`COALESCE(NULLIF(TRIM(s.category), ''), NULLIF(TRIM(s.type), ''), 'Unknown') = $${paramIdx}`);
+        params.push(target.label);
+        eventParams.push(target.label);
+        paramIdx += 1;
+      } else if (input.dimension === 'repo' && target.repoKey) {
+        eipFilters.push(`LOWER(SPLIT_PART(COALESCE(r.name, ''), '/', 2)) = $${paramIdx}`);
+        eventFilters.push(`LOWER(SPLIT_PART(COALESCE(r.name, ''), '/', 2)) = $${paramIdx}`);
+        params.push(target.repoKey);
+        eventParams.push(target.repoKey);
+        paramIdx += 1;
+      }
+
+      const includeRipRows =
+        (input.dimension === 'status') ||
+        (input.dimension === 'category' && ['rip', 'rips'].includes(target.label.toLowerCase())) ||
+        (input.dimension === 'repo' && target.repoKey === 'rips');
+
+      const ripWhereParts: string[] = ['rip.rip_number <> 0'];
+      if (input.dimension === 'status') {
+        ripWhereParts.push(`COALESCE(rip.status, 'Unknown') = $${paramIdx}`);
+        params.push(target.label);
+        paramIdx += 1;
+      }
+      const ripWhere = ripWhereParts.join(' AND ');
+
+      const overviewRows = await prisma.$queryRawUnsafe<Array<{ total: bigint; last_updated: Date | null }>>(
+        `
+        WITH base AS (
+          SELECT s.updated_at AS updated_at
+          FROM eip_snapshots s
+          JOIN eips e ON e.id = s.eip_id
+          LEFT JOIN repositories r ON r.id = s.repository_id
+          WHERE ${eipFilters.join(' AND ')}
+          ${includeRipRows ? `
+          UNION ALL
+          SELECT COALESCE((SELECT MAX(rc.commit_date) FROM rip_commits rc WHERE rc.rip_id = rip.id), rip.created_at) AS updated_at
+          FROM rips rip
+          WHERE ${ripWhere}
+          ` : ''}
+        )
+        SELECT COUNT(*)::bigint AS total, MAX(updated_at) AS last_updated
+        FROM base
+        `,
+        ...params
+      );
+
+      const recentChangeRows = await prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
+        `
+        SELECT COUNT(*)::bigint AS count
+        FROM eip_status_events se
+        JOIN eips e ON e.id = se.eip_id
+        LEFT JOIN eip_snapshots s ON s.eip_id = e.id
+        LEFT JOIN repositories r ON r.id = se.repository_id
+        WHERE se.changed_at >= NOW() - INTERVAL '30 days'
+          AND ${eventFilters.join(' AND ')}
+        `,
+        ...eventParams
+      );
+
+      return {
+        valid: true,
+        dimension: input.dimension,
+        slug: slugifyDetailLabel(input.slug),
+        label: target.label,
+        total: Number(overviewRows[0]?.total ?? 0),
+        recentChanges30d: Number(recentChangeRows[0]?.count ?? 0),
+        lastUpdated: overviewRows[0]?.last_updated?.toISOString() ?? null,
+      };
+    }),
+
+  getDetailTimeline: optionalAuthProcedure
+    .input(z.object({
+      dimension: z.enum(DETAIL_DIMENSIONS),
+      slug: z.string().min(1),
+      fromMonth: z.string().regex(/^\d{4}-\d{2}$/).optional(),
+      toMonth: z.string().regex(/^\d{4}-\d{2}$/).optional(),
+    }))
+    .handler(async ({ input }) => {
+      const target = await resolveDetailTarget(input.dimension, input.slug);
+      if (!target.valid) {
+        return {
+          valid: false,
+          dimension: input.dimension,
+          slug: slugifyDetailLabel(input.slug),
+          label: input.slug,
+          months: [] as string[],
+          statusSeries: [] as Array<{ month: string; status: string; count: number }>,
+          totals: [] as Array<{ month: string; count: number; touched: number }>,
+          updatedAt: null as string | null,
+        };
+      }
+
+      const toMonth = input.toMonth ?? new Date().toISOString().slice(0, 7);
+      const fromMonth = input.fromMonth ?? (() => {
+        const end = new Date(`${toMonth}-01T00:00:00.000Z`);
+        const start = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth() - 11, 1));
+        return `${start.getUTCFullYear()}-${String(start.getUTCMonth() + 1).padStart(2, '0')}`;
+      })();
+      const fromDate = `${fromMonth}-01`;
+      const [toYear, toMon] = toMonth.split('-').map(Number);
+      const toExclusive = new Date(Date.UTC(toYear, toMon, 1)).toISOString().slice(0, 10);
+
+      const params: unknown[] = [fromDate, toExclusive];
+      let paramIdx = 3;
+      const filters: string[] = ['e.eip_number NOT IN (2512, 3297, 1047)'];
+
+      if (input.dimension === 'status') {
+        filters.push(`COALESCE(NULLIF(s.status, ''), 'Unknown') = $${paramIdx}`);
+        params.push(target.label);
+        paramIdx += 1;
+      } else if (input.dimension === 'category') {
+        filters.push(`COALESCE(NULLIF(TRIM(s.category), ''), NULLIF(TRIM(s.type), ''), 'Unknown') = $${paramIdx}`);
+        params.push(target.label);
+        paramIdx += 1;
+      } else if (input.dimension === 'repo' && target.repoKey) {
+        filters.push(`LOWER(SPLIT_PART(COALESCE(r.name, ''), '/', 2)) = $${paramIdx}`);
+        params.push(target.repoKey);
+        paramIdx += 1;
+      }
+
+      const timelineRows = await prisma.$queryRawUnsafe<Array<{
+        month: string;
+        status: string | null;
+        count: bigint;
+        touched: bigint;
+        total: bigint;
+        latest_changed_at: Date | null;
+      }>>(
+        `
+        WITH month_series AS (
+          SELECT TO_CHAR(m, 'YYYY-MM') AS month
+          FROM generate_series($1::date, ($2::date - INTERVAL '1 month')::date, INTERVAL '1 month') m
+        ),
+        monthly AS (
+          SELECT
+            TO_CHAR(date_trunc('month', se.changed_at), 'YYYY-MM') AS month,
+            COALESCE(NULLIF(se.to_status, ''), 'Unknown') AS status,
+            COUNT(*)::bigint AS count,
+            COUNT(DISTINCT se.eip_id)::bigint AS touched,
+            MAX(se.changed_at) AS latest_changed_at
+          FROM eip_status_events se
+          JOIN eips e ON e.id = se.eip_id
+          LEFT JOIN eip_snapshots s ON s.eip_id = e.id
+          LEFT JOIN repositories r ON r.id = se.repository_id
+          WHERE se.changed_at >= $1::date
+            AND se.changed_at < $2::date
+            AND ${filters.join(' AND ')}
+          GROUP BY 1, 2
+        ),
+        totals AS (
+          SELECT month, SUM(count)::bigint AS total, SUM(touched)::bigint AS touched
+          FROM monthly
+          GROUP BY month
+        )
+        SELECT
+          ms.month,
+          m.status,
+          COALESCE(m.count, 0::bigint) AS count,
+          COALESCE(m.touched, 0::bigint) AS touched,
+          COALESCE(t.total, 0::bigint) AS total,
+          m.latest_changed_at
+        FROM month_series ms
+        LEFT JOIN monthly m ON m.month = ms.month
+        LEFT JOIN totals t ON t.month = ms.month
+        ORDER BY ms.month ASC, m.status ASC
+        `,
+        ...params
+      );
+
+      const updatedAt = timelineRows.reduce<Date | null>((latest, row) => {
+        if (!row.latest_changed_at) return latest;
+        if (!latest || row.latest_changed_at > latest) return row.latest_changed_at;
+        return latest;
+      }, null);
+
+      const months = Array.from(new Set(timelineRows.map((row) => row.month)));
+      const totalsMap = new Map<string, { count: number; touched: number }>();
+      for (const row of timelineRows) {
+        if (!totalsMap.has(row.month)) {
+          totalsMap.set(row.month, {
+            count: Number(row.total ?? 0),
+            touched: Number(row.touched ?? 0),
+          });
+        }
+      }
+
+      return {
+        valid: true,
+        dimension: input.dimension,
+        slug: slugifyDetailLabel(input.slug),
+        label: target.label,
+        months,
+        statusSeries: timelineRows
+          .filter((row) => Boolean(row.status))
+          .map((row) => ({
+            month: row.month,
+            status: row.status || 'Unknown',
+            count: Number(row.count ?? 0),
+          })),
+        totals: months.map((month) => ({
+          month,
+          count: totalsMap.get(month)?.count ?? 0,
+          touched: totalsMap.get(month)?.touched ?? 0,
+        })),
+        updatedAt: updatedAt?.toISOString() ?? null,
+      };
+    }),
+
+  getDetailRepoGithubStats: optionalAuthProcedure
+    .input(z.object({
+      slug: z.string().min(1),
+    }))
+    .handler(async ({ input }) => {
+      const target = await resolveDetailTarget('repo', input.slug);
+      if (!target.valid || !target.repoKey) {
+        return {
+          valid: false,
+          repo: input.slug,
+          githubRepo: null as string | null,
+          stars: null as number | null,
+          forks: null as number | null,
+          watchlist: null as number | null,
+          openIssues: 0,
+          openPRs: 0,
+          totalOpen: 0,
+          updatedAt: null as string | null,
+        };
+      }
+
+      const [openRows] = await Promise.all([
+        prisma.$queryRaw<Array<{ open_issues: bigint; open_prs: bigint }>>`
+          SELECT
+            (
+              SELECT COUNT(*)::bigint
+              FROM issues i
+              JOIN repositories r ON r.id = i.repository_id
+              WHERE LOWER(SPLIT_PART(COALESCE(r.name, ''), '/', 2)) = ${target.repoKey}
+                AND LOWER(COALESCE(i.state, '')) = 'open'
+            ) AS open_issues,
+            (
+              SELECT COUNT(*)::bigint
+              FROM pull_requests p
+              JOIN repositories r ON r.id = p.repository_id
+              WHERE LOWER(SPLIT_PART(COALESCE(r.name, ''), '/', 2)) = ${target.repoKey}
+                AND LOWER(COALESCE(p.state, '')) = 'open'
+            ) AS open_prs
+        `,
+      ]);
+
+      const openRow = openRows[0];
+      const openIssues = Number(openRow?.open_issues ?? 0);
+      const openPRs = Number(openRow?.open_prs ?? 0);
+
+      const githubRepo = repoKeyToGithubRepo(target.repoKey);
+      let stars: number | null = null;
+      let forks: number | null = null;
+      let watchlist: number | null = null;
+
+      try {
+        const ghRes = await fetch(`https://api.github.com/repos/${githubRepo}`, {
+          headers: {
+            Accept: 'application/vnd.github+json',
+            'User-Agent': 'eipsinsight-v4',
+          },
+          cache: 'no-store',
+        });
+        if (ghRes.ok) {
+          const gh = await ghRes.json();
+          stars = typeof gh.stargazers_count === 'number' ? gh.stargazers_count : null;
+          forks = typeof gh.forks_count === 'number' ? gh.forks_count : null;
+          watchlist = typeof gh.subscribers_count === 'number'
+            ? gh.subscribers_count
+            : (typeof gh.watchers_count === 'number' ? gh.watchers_count : null);
+        }
+      } catch {
+        // Graceful fallback: DB-powered open issue/PR counts still returned.
+      }
+
+      return {
+        valid: true,
+        repo: target.label,
+        githubRepo,
+        stars,
+        forks,
+        watchlist,
+        openIssues,
+        openPRs,
+        totalOpen: openIssues + openPRs,
+        updatedAt: new Date().toISOString(),
+      };
+    }),
+
+  getDetailProposals: optionalAuthProcedure
+    .input(z.object({
+      dimension: z.enum(DETAIL_DIMENSIONS),
+      slug: z.string().min(1),
+      q: z.string().optional(),
+      status: z.string().optional(),
+      category: z.string().optional(),
+      sort: z.enum(['updated_desc', 'updated_asc', 'days_desc', 'days_asc', 'number_asc']).default('updated_desc'),
+      page: z.number().min(1).default(1),
+      pageSize: z.number().min(1).max(100).default(20),
+    }))
+    .handler(async ({ input }) => {
+      const target = await resolveDetailTarget(input.dimension, input.slug);
+      if (!target.valid) {
+        return {
+          valid: false,
+          dimension: input.dimension,
+          slug: slugifyDetailLabel(input.slug),
+          label: input.slug,
+          total: 0,
+          totalPages: 1,
+          page: input.page,
+          pageSize: input.pageSize,
+          rows: [] as Array<{
+            id: number;
+            number: number;
+            title: string;
+            author: string | null;
+            status: string;
+            category: string | null;
+            type: string | null;
+            repo: string;
+            kind: 'EIP' | 'ERC' | 'RIP';
+            updatedAt: string | null;
+            daysInStatus: number | null;
+          }>,
+        };
+      }
+
+      const baseParams: unknown[] = [];
+      let baseIdx = 1;
+      const eipBaseFilters: string[] = ['e.eip_number NOT IN (2512, 3297, 1047)'];
+
+      if (input.dimension === 'status') {
+        eipBaseFilters.push(`COALESCE(NULLIF(s.status, ''), 'Unknown') = $${baseIdx}`);
+        baseParams.push(target.label);
+        baseIdx += 1;
+      } else if (input.dimension === 'category') {
+        eipBaseFilters.push(`COALESCE(NULLIF(TRIM(s.category), ''), NULLIF(TRIM(s.type), ''), 'Unknown') = $${baseIdx}`);
+        baseParams.push(target.label);
+        baseIdx += 1;
+      } else if (input.dimension === 'repo' && target.repoKey) {
+        eipBaseFilters.push(`LOWER(SPLIT_PART(COALESCE(r.name, ''), '/', 2)) = $${baseIdx}`);
+        baseParams.push(target.repoKey);
+        baseIdx += 1;
+      }
+
+      const includeRipRows =
+        (input.dimension === 'status') ||
+        (input.dimension === 'category' && ['rip', 'rips'].includes(target.label.toLowerCase())) ||
+        (input.dimension === 'repo' && target.repoKey === 'rips');
+
+      const ripBaseFilters: string[] = ['rip.rip_number <> 0'];
+      if (input.dimension === 'status') {
+        ripBaseFilters.push(`COALESCE(rip.status, 'Unknown') = $${baseIdx}`);
+        baseParams.push(target.label);
+        baseIdx += 1;
+      }
+
+      const whereParts: string[] = [];
+      const whereParams: unknown[] = [];
+      let whereIdx = baseIdx;
+
+      if (input.q?.trim()) {
+        whereParts.push(`(CAST(base.number AS TEXT) ILIKE $${whereIdx} OR COALESCE(base.title, '') ILIKE $${whereIdx} OR COALESCE(base.author, '') ILIKE $${whereIdx})`);
+        whereParams.push(`%${input.q.trim()}%`);
+        whereIdx += 1;
+      }
+      if (input.status?.trim()) {
+        whereParts.push(`COALESCE(base.status, '') = $${whereIdx}`);
+        whereParams.push(input.status.trim());
+        whereIdx += 1;
+      }
+      if (input.category?.trim()) {
+        whereParts.push(`COALESCE(base.category, '') = $${whereIdx}`);
+        whereParams.push(input.category.trim());
+        whereIdx += 1;
+      }
+
+      const whereClause = whereParts.length ? `WHERE ${whereParts.join(' AND ')}` : '';
+      const orderByClause = (() => {
+        switch (input.sort) {
+          case 'updated_asc':
+            return 'base.updated_at ASC NULLS LAST';
+          case 'days_desc':
+            return 'base.last_changed_at ASC NULLS LAST';
+          case 'days_asc':
+            return 'base.last_changed_at DESC NULLS LAST';
+          case 'number_asc':
+            return 'base.number ASC';
+          case 'updated_desc':
+          default:
+            return 'base.updated_at DESC NULLS LAST';
+        }
+      })();
+
+      const limit = input.pageSize;
+      const offset = (input.page - 1) * input.pageSize;
+      const allParams = [...baseParams, ...whereParams];
+
+      const rows = await prisma.$queryRawUnsafe<Array<{
+        id: number;
+        number: number;
+        title: string | null;
+        author: string | null;
+        status: string;
+        category: string | null;
+        type: string | null;
+        repo: string;
+        kind: string;
+        updated_at: Date | null;
+        last_changed_at: Date | null;
+      }>>(
+        `
+        WITH base AS (
+          SELECT
+            s.eip_id AS id,
+            e.eip_number AS number,
+            e.title,
+            e.author,
+            COALESCE(NULLIF(s.status, ''), 'Unknown') AS status,
+            COALESCE(NULLIF(TRIM(s.category), ''), NULLIF(TRIM(s.type), ''), 'Unknown') AS category,
+            s.type AS type,
+            LOWER(SPLIT_PART(COALESCE(r.name, ''), '/', 2)) AS repo,
+            CASE
+              WHEN LOWER(SPLIT_PART(COALESCE(r.name, ''), '/', 2)) = 'rips' THEN 'RIP'
+              WHEN LOWER(SPLIT_PART(COALESCE(r.name, ''), '/', 2)) = 'ercs' OR COALESCE(NULLIF(TRIM(s.category), ''), NULLIF(TRIM(s.type), ''), 'Unknown') = 'ERC' THEN 'ERC'
+              ELSE 'EIP'
+            END AS kind,
+            s.updated_at AS updated_at,
+            (SELECT MAX(changed_at) FROM eip_status_events ese WHERE ese.eip_id = s.eip_id) AS last_changed_at
+          FROM eip_snapshots s
+          JOIN eips e ON e.id = s.eip_id
+          LEFT JOIN repositories r ON r.id = s.repository_id
+          WHERE ${eipBaseFilters.join(' AND ')}
+          ${includeRipRows ? `
+          UNION ALL
+          SELECT
+            (100000000 + rip.id)::int AS id,
+            rip.rip_number AS number,
+            rip.title,
+            NULL::text AS author,
+            COALESCE(rip.status, 'Unknown') AS status,
+            'RIP'::text AS category,
+            NULL::text AS type,
+            'rips'::text AS repo,
+            'RIP'::text AS kind,
+            COALESCE((SELECT MAX(rc.commit_date) FROM rip_commits rc WHERE rc.rip_id = rip.id), rip.created_at) AS updated_at,
+            COALESCE((SELECT MAX(rc.commit_date) FROM rip_commits rc WHERE rc.rip_id = rip.id), rip.created_at) AS last_changed_at
+          FROM rips rip
+          WHERE ${ripBaseFilters.join(' AND ')}
+          ` : ''}
+        )
+        SELECT *
+        FROM base
+        ${whereClause}
+        ORDER BY ${orderByClause}, base.number ASC
+        LIMIT ${limit} OFFSET ${offset}
+        `,
+        ...allParams
+      );
+
+      const countRows = await prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
+        `
+        WITH base AS (
+          SELECT
+            s.eip_id AS id,
+            e.eip_number AS number,
+            e.title,
+            e.author,
+            COALESCE(NULLIF(s.status, ''), 'Unknown') AS status,
+            COALESCE(NULLIF(TRIM(s.category), ''), NULLIF(TRIM(s.type), ''), 'Unknown') AS category,
+            s.type AS type,
+            LOWER(SPLIT_PART(COALESCE(r.name, ''), '/', 2)) AS repo,
+            CASE
+              WHEN LOWER(SPLIT_PART(COALESCE(r.name, ''), '/', 2)) = 'rips' THEN 'RIP'
+              WHEN LOWER(SPLIT_PART(COALESCE(r.name, ''), '/', 2)) = 'ercs' OR COALESCE(NULLIF(TRIM(s.category), ''), NULLIF(TRIM(s.type), ''), 'Unknown') = 'ERC' THEN 'ERC'
+              ELSE 'EIP'
+            END AS kind,
+            s.updated_at AS updated_at,
+            (SELECT MAX(changed_at) FROM eip_status_events ese WHERE ese.eip_id = s.eip_id) AS last_changed_at
+          FROM eip_snapshots s
+          JOIN eips e ON e.id = s.eip_id
+          LEFT JOIN repositories r ON r.id = s.repository_id
+          WHERE ${eipBaseFilters.join(' AND ')}
+          ${includeRipRows ? `
+          UNION ALL
+          SELECT
+            (100000000 + rip.id)::int AS id,
+            rip.rip_number AS number,
+            rip.title,
+            NULL::text AS author,
+            COALESCE(rip.status, 'Unknown') AS status,
+            'RIP'::text AS category,
+            NULL::text AS type,
+            'rips'::text AS repo,
+            'RIP'::text AS kind,
+            COALESCE((SELECT MAX(rc.commit_date) FROM rip_commits rc WHERE rc.rip_id = rip.id), rip.created_at) AS updated_at,
+            COALESCE((SELECT MAX(rc.commit_date) FROM rip_commits rc WHERE rc.rip_id = rip.id), rip.created_at) AS last_changed_at
+          FROM rips rip
+          WHERE ${ripBaseFilters.join(' AND ')}
+          ` : ''}
+        )
+        SELECT COUNT(*)::bigint AS count
+        FROM base
+        ${whereClause}
+        `,
+        ...allParams
+      );
+
+      const total = Number(countRows[0]?.count ?? 0);
+      const totalPages = Math.max(1, Math.ceil(total / input.pageSize));
+
+      return {
+        valid: true,
+        dimension: input.dimension,
+        slug: slugifyDetailLabel(input.slug),
+        label: target.label,
+        total,
+        totalPages,
+        page: input.page,
+        pageSize: input.pageSize,
+        rows: rows.map((row) => ({
+          id: row.id,
+          number: row.number,
+          title: row.title || `${row.kind}-${row.number}`,
+          author: row.author || null,
+          status: row.status,
+          category: row.category,
+          type: row.type,
+          repo: row.repo || 'unknown',
+          kind: row.kind === 'RIP' ? 'RIP' : row.kind === 'ERC' ? 'ERC' : 'EIP',
+          updatedAt: row.updated_at?.toISOString() ?? null,
+          daysInStatus: row.last_changed_at
+            ? Math.floor((Date.now() - new Date(row.last_changed_at).getTime()) / (1000 * 60 * 60 * 24))
+            : null,
+        })),
+      };
     }),
 
   // ============================================


### PR DESCRIPTION
This pull request introduces several improvements to navigation, UI consistency, and sidebar behavior in the application. The main changes include adding new shortcut redirects for easier navigation, enhancing the sidebar to display contextual page sections, and improving the linking and display of categories and statuses throughout the Explore pages.

**Navigation and Routing Enhancements:**

* Added multiple non-permanent shortcut redirects in `next.config.ts` for status and category drilldown pages (e.g., `/draft`, `/review`, `/core`, `/networking`, etc.), making it easier for users to access filtered views directly.
* Changed the `/erc` redirect to point to `/explore/details/category/erc` for consistency with other category routes.

**Sidebar Improvements:**

* The sidebar now dynamically detects and displays page section headings as contextual sub-items, making navigation within detail pages more intuitive. This includes logic to extract section titles from the DOM and update the sidebar accordingly. [[1]](diffhunk://#diff-167140c3830943094d6b84a9cdb9155e4c4762762d1d8245330b48be404758a6R458-R507) [[2]](diffhunk://#diff-167140c3830943094d6b84a9cdb9155e4c4762762d1d8245330b48be404758a6L718-R745) [[3]](diffhunk://#diff-167140c3830943094d6b84a9cdb9155e4c4762762d1d8245330b48be404758a6R817-R824)
* Refactored scroll spy and section tracking logic to use the new contextual section items instead of the previous static approach.

**Explore UI and Linking Consistency:**

* Added a `toSlug` utility and updated links so that category and status names are consistently slugified in URLs. Categories and statuses in tables and grids now link directly to their respective detail pages. [[1]](diffhunk://#diff-e6a920009fbb23973cae23b5168a45555365499f219d54497876e7426047fcd0R69-R72) [[2]](diffhunk://#diff-e6a920009fbb23973cae23b5168a45555365499f219d54497876e7426047fcd0L164-R184) [[3]](diffhunk://#diff-e35f420a7655b54d67c6d62fa7f253a856678a9618252529edb7dff79b9ddbbfR63-R66) [[4]](diffhunk://#diff-e35f420a7655b54d67c6d62fa7f253a856678a9618252529edb7dff79b9ddbbfL167-R194)
* The category filter bar now includes a note clarifying that "Type" is grouped under "Category" in Explore v4 detail pages.
* Added a grid of category drilldown links to the Explore page, each showing the category name and count, for easier navigation.

**UI Polish:**

* Improved the appearance and animation of the `InlineBrandLoader` component for a more polished loading indicator.