### PR TITLE
Enhance analytics procedures with event filtering and deduplication

### DIFF
--- a/src/app/analytics/editors/page.tsx
+++ b/src/app/analytics/editors/page.tsx
@@ -170,7 +170,6 @@ export default function EditorsAnalyticsPage() {
   const [expandedActivityKeys, setExpandedActivityKeys] = useState<Record<string, boolean>>({});
   const [leaderboardHeroView, setLeaderboardHeroView] = useState<"chart" | "list">("chart");
   const [trendPrimaryMetric, setTrendPrimaryMetric] = useState<"actions" | "reviews">("actions");
-  const [trendSecondaryMetric, setTrendSecondaryMetric] = useState<"actions" | "reviews">("reviews");
 
   const repoParam = repoFilter === "all" ? undefined : repoFilter;
   const { from, to } = getTimeWindow(timeRange);
@@ -1180,41 +1179,6 @@ export default function EditorsAnalyticsPage() {
         </div>
         <div className="mt-3 flex items-center justify-between">
           <p className="text-xs text-muted-foreground">{trendMetricMeta(trendPrimaryMetric).footer}</p>
-          <LastUpdated timestamp={dataUpdatedAt} className="text-xs" />
-        </div>
-      </div>
-
-      <div className="rounded-xl border border-border/70 bg-card/60 p-5 backdrop-blur-sm">
-        <div className="mb-3 flex items-center justify-between gap-3">
-          <div>
-            <h2 className="text-lg font-semibold text-foreground">{trendMetricMeta(trendSecondaryMetric).title}</h2>
-            <p className="mt-0.5 text-xs text-muted-foreground">{trendMetricMeta(trendSecondaryMetric).subtitle}</p>
-          </div>
-          <div className="inline-flex rounded-md border border-border bg-muted/30 p-0.5">
-            <button
-              type="button"
-              onClick={() => setTrendSecondaryMetric("actions")}
-              className={`rounded px-2 py-1 text-xs ${trendSecondaryMetric === "actions" ? "bg-card text-foreground" : "text-muted-foreground hover:bg-muted"}`}
-            >
-              All Actions
-            </button>
-            <button
-              type="button"
-              onClick={() => setTrendSecondaryMetric("reviews")}
-              className={`rounded px-2 py-1 text-xs ${trendSecondaryMetric === "reviews" ? "bg-card text-foreground" : "text-muted-foreground hover:bg-muted"}`}
-            >
-              Reviewed PRs
-            </button>
-          </div>
-        </div>
-        <div className="relative h-72 w-full">
-          <ReactECharts option={trendMetricMeta(trendSecondaryMetric).option} style={{ height: "100%", width: "100%" }} opts={{ renderer: "svg" }} notMerge />
-          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-            <span className="text-2xl font-semibold text-foreground/10">EIPsInsight.com</span>
-          </div>
-        </div>
-        <div className="mt-3 flex items-center justify-between">
-          <p className="text-xs text-muted-foreground">{trendMetricMeta(trendSecondaryMetric).footer}</p>
           <LastUpdated timestamp={dataUpdatedAt} className="text-xs" />
         </div>
       </div>

--- a/src/app/analytics/editors/page.tsx
+++ b/src/app/analytics/editors/page.tsx
@@ -169,6 +169,8 @@ export default function EditorsAnalyticsPage() {
   const [visibleActivityCount, setVisibleActivityCount] = useState<number>(20);
   const [expandedActivityKeys, setExpandedActivityKeys] = useState<Record<string, boolean>>({});
   const [leaderboardHeroView, setLeaderboardHeroView] = useState<"chart" | "list">("chart");
+  const [trendPrimaryMetric, setTrendPrimaryMetric] = useState<"actions" | "reviews">("actions");
+  const [trendSecondaryMetric, setTrendSecondaryMetric] = useState<"actions" | "reviews">("reviews");
 
   const repoParam = repoFilter === "all" ? undefined : repoFilter;
   const { from, to } = getTimeWindow(timeRange);
@@ -284,7 +286,8 @@ export default function EditorsAnalyticsPage() {
       setLoading(true);
       setError(null);
       try {
-        const months = timeRange === "7d" ? 3 : timeRange === "this_month" || timeRange === "30d" ? 6 : timeRange === "90d" ? 12 : 24;
+        // Keep trend charts long-horizon so editorial patterns are visible across years.
+        const months = 72;
         
         const [leaderboardData, trendData, reviewedTrendData, categoryData, repoData, dailyStackedData, actionDetails] = await Promise.all([
           leaderboardMode === "monthly"
@@ -589,7 +592,7 @@ export default function EditorsAnalyticsPage() {
     series: trendActors.map((actor, idx) => ({
       name: actor,
       type: "line",
-      smooth: true,
+      smooth: false,
       symbol: "none",
       lineStyle: { width: 2, color: `hsl(${(idx * 360) / Math.max(trendActors.length, 1)}, 70%, 55%)` },
       data: monthlyTrend.map((p) => Number(p[actor] || 0)),
@@ -619,12 +622,29 @@ export default function EditorsAnalyticsPage() {
     series: reviewedTrendActors.map((actor, idx) => ({
       name: actor,
       type: "line",
-      smooth: true,
+      smooth: false,
       symbol: "none",
       lineStyle: { width: 2, color: `hsl(${(idx * 360) / Math.max(reviewedTrendActors.length, 1)}, 70%, 55%)` },
       data: monthlyReviewedTrend.map((p) => Number(p[actor] || 0)),
     })),
   }), [monthlyReviewedTrend, reviewedTrendActors]);
+
+  const trendMetricMeta = useCallback((metric: "actions" | "reviews") => {
+    if (metric === "reviews") {
+      return {
+        title: "PRs Reviewed (Monthly)",
+        subtitle: "Monthly distinct PRs with review events by each editor.",
+        footer: "Counts distinct PRs with review events, not total comments.",
+        option: reviewedTrendOption,
+      };
+    }
+    return {
+      title: "Editor Actions Over Time",
+      subtitle: "Monthly count of all editor actions (reviews, comments, labels, updates).",
+      footer: "Shows monthly total editor actions, not cumulative totals.",
+      option: trendOption,
+    };
+  }, [reviewedTrendOption, trendOption]);
 
   const categoryOption = useMemo(() => ({
     backgroundColor: "transparent",
@@ -1126,22 +1146,40 @@ export default function EditorsAnalyticsPage() {
       <div className="rounded-xl border border-border/70 bg-card/60 p-5 backdrop-blur-sm">
         <div className="mb-3 flex items-center justify-between gap-3">
           <div>
-            <h2 className="text-lg font-semibold text-foreground">Editor Actions Over Time</h2>
-            <p className="mt-0.5 text-xs text-muted-foreground">Monthly count of all editor actions (reviews, comments, labels, updates).</p>
+            <h2 className="text-lg font-semibold text-foreground">{trendMetricMeta(trendPrimaryMetric).title}</h2>
+            <p className="mt-0.5 text-xs text-muted-foreground">{trendMetricMeta(trendPrimaryMetric).subtitle}</p>
           </div>
-          <button onClick={downloadTrendReport} className="inline-flex items-center gap-1 rounded-md border border-border bg-muted/40 px-2.5 py-1 text-xs text-foreground/85 hover:bg-muted/60">
-            <Download className="h-3.5 w-3.5" />
-            Download Reports
-          </button>
+          <div className="flex items-center gap-2">
+            <div className="inline-flex rounded-md border border-border bg-muted/30 p-0.5">
+              <button
+                type="button"
+                onClick={() => setTrendPrimaryMetric("actions")}
+                className={`rounded px-2 py-1 text-xs ${trendPrimaryMetric === "actions" ? "bg-card text-foreground" : "text-muted-foreground hover:bg-muted"}`}
+              >
+                All Actions
+              </button>
+              <button
+                type="button"
+                onClick={() => setTrendPrimaryMetric("reviews")}
+                className={`rounded px-2 py-1 text-xs ${trendPrimaryMetric === "reviews" ? "bg-card text-foreground" : "text-muted-foreground hover:bg-muted"}`}
+              >
+                Reviewed PRs
+              </button>
+            </div>
+            <button onClick={downloadTrendReport} className="inline-flex items-center gap-1 rounded-md border border-border bg-muted/40 px-2.5 py-1 text-xs text-foreground/85 hover:bg-muted/60">
+              <Download className="h-3.5 w-3.5" />
+              Download Reports
+            </button>
+          </div>
         </div>
         <div className="relative h-72 w-full">
-          <ReactECharts option={trendOption} style={{ height: "100%", width: "100%" }} opts={{ renderer: "svg" }} notMerge />
+          <ReactECharts option={trendMetricMeta(trendPrimaryMetric).option} style={{ height: "100%", width: "100%" }} opts={{ renderer: "svg" }} notMerge />
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
             <span className="text-2xl font-semibold text-foreground/10">EIPsInsight.com</span>
           </div>
         </div>
         <div className="mt-3 flex items-center justify-between">
-          <p className="text-xs text-muted-foreground">Shows monthly total editor actions, not cumulative totals.</p>
+          <p className="text-xs text-muted-foreground">{trendMetricMeta(trendPrimaryMetric).footer}</p>
           <LastUpdated timestamp={dataUpdatedAt} className="text-xs" />
         </div>
       </div>
@@ -1149,18 +1187,34 @@ export default function EditorsAnalyticsPage() {
       <div className="rounded-xl border border-border/70 bg-card/60 p-5 backdrop-blur-sm">
         <div className="mb-3 flex items-center justify-between gap-3">
           <div>
-            <h2 className="text-lg font-semibold text-foreground">PRs Reviewed (Monthly)</h2>
-            <p className="mt-0.5 text-xs text-muted-foreground">Monthly distinct PRs with review events by each editor.</p>
+            <h2 className="text-lg font-semibold text-foreground">{trendMetricMeta(trendSecondaryMetric).title}</h2>
+            <p className="mt-0.5 text-xs text-muted-foreground">{trendMetricMeta(trendSecondaryMetric).subtitle}</p>
+          </div>
+          <div className="inline-flex rounded-md border border-border bg-muted/30 p-0.5">
+            <button
+              type="button"
+              onClick={() => setTrendSecondaryMetric("actions")}
+              className={`rounded px-2 py-1 text-xs ${trendSecondaryMetric === "actions" ? "bg-card text-foreground" : "text-muted-foreground hover:bg-muted"}`}
+            >
+              All Actions
+            </button>
+            <button
+              type="button"
+              onClick={() => setTrendSecondaryMetric("reviews")}
+              className={`rounded px-2 py-1 text-xs ${trendSecondaryMetric === "reviews" ? "bg-card text-foreground" : "text-muted-foreground hover:bg-muted"}`}
+            >
+              Reviewed PRs
+            </button>
           </div>
         </div>
         <div className="relative h-72 w-full">
-          <ReactECharts option={reviewedTrendOption} style={{ height: "100%", width: "100%" }} opts={{ renderer: "svg" }} notMerge />
+          <ReactECharts option={trendMetricMeta(trendSecondaryMetric).option} style={{ height: "100%", width: "100%" }} opts={{ renderer: "svg" }} notMerge />
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
             <span className="text-2xl font-semibold text-foreground/10">EIPsInsight.com</span>
           </div>
         </div>
         <div className="mt-3 flex items-center justify-between">
-          <p className="text-xs text-muted-foreground">Counts distinct PRs with review events, not total comments.</p>
+          <p className="text-xs text-muted-foreground">{trendMetricMeta(trendSecondaryMetric).footer}</p>
           <LastUpdated timestamp={dataUpdatedAt} className="text-xs" />
         </div>
       </div>

--- a/src/server/orpc/procedures/analytics.ts
+++ b/src/server/orpc/procedures/analytics.ts
@@ -5157,6 +5157,7 @@ export const analyticsProcedures = {
             em.canonical AS actor,
             pe.pr_number,
             pe.repository_id,
+            pe.event_type,
             LOWER(SPLIT_PART(COALESCE(r.name, ''), '/', 2)) AS repo_short,
             CASE
               WHEN pe.created_at > COALESCE(pr.updated_at, pr.closed_at, pr.merged_at, pr.created_at, pe.created_at) + INTERVAL '30 days'
@@ -5170,21 +5171,32 @@ export const analyticsProcedures = {
           WHERE pe.pr_number > 0
             AND pe.created_at <= NOW()
             AND pe.event_type NOT IN ('subscribed', 'mentioned', 'referenced')
+        ),
+        deduped_events AS (
+          SELECT
+            actor,
+            pr_number,
+            repository_id,
+            event_type,
+            repo_short,
+            date_trunc('second', occurred_at) AS occurred_at
+          FROM raw_events
+          GROUP BY actor, pr_number, repository_id, event_type, repo_short, date_trunc('second', occurred_at)
         )
         SELECT
-          re.actor AS actor,
+          de.actor AS actor,
           COUNT(*)::bigint AS total_actions,
-          COUNT(DISTINCT re.pr_number)::bigint AS prs_touched,
-          COUNT(*) FILTER (WHERE re.repo_short = 'eips')::bigint AS eips_actions,
-          COUNT(*) FILTER (WHERE re.repo_short = 'ercs')::bigint AS ercs_actions,
-          COUNT(*) FILTER (WHERE re.repo_short = 'rips')::bigint AS rips_actions,
-          MAX(re.occurred_at) AS latest_occurred_at
-        FROM raw_events re
-        WHERE re.occurred_at >= $2::date
-          AND re.occurred_at < $3::date
-          AND ($5::int[] IS NULL OR re.repository_id = ANY($5))
-        GROUP BY re.actor
-        ORDER BY total_actions DESC, prs_touched DESC, re.actor ASC
+          COUNT(DISTINCT CONCAT(de.repository_id::text, ':', de.pr_number::text))::bigint AS prs_touched,
+          COUNT(*) FILTER (WHERE de.repo_short = 'eips')::bigint AS eips_actions,
+          COUNT(*) FILTER (WHERE de.repo_short = 'ercs')::bigint AS ercs_actions,
+          COUNT(*) FILTER (WHERE de.repo_short = 'rips')::bigint AS rips_actions,
+          MAX(de.occurred_at) AS latest_occurred_at
+        FROM deduped_events de
+        WHERE de.occurred_at >= $2::date
+          AND de.occurred_at < $3::date
+          AND ($5::int[] IS NULL OR de.repository_id = ANY($5))
+        GROUP BY de.actor
+        ORDER BY total_actions DESC, prs_touched DESC, de.actor ASC
         LIMIT $4
         `,
         allEditors, monthStart, nextMonth, input.limit, repoIds, CANONICAL_EIP_EDITOR_LOWER

--- a/src/server/orpc/procedures/analytics.ts
+++ b/src/server/orpc/procedures/analytics.ts
@@ -793,6 +793,7 @@ const getEditorsLeaderboardCached = unstable_cache(
         LEFT JOIN repositories r ON r.id = pe.repository_id
         WHERE ($1::text IS NULL OR LOWER(SPLIT_PART(r.name, '/', 2)) = LOWER($1))
           AND pe.pr_number > 0
+          AND pe.event_type NOT IN ('subscribed', 'mentioned', 'referenced')
       ),
       editor_activity AS (
         SELECT actor, pr_number, repository_id, event_type, occurred_at
@@ -954,6 +955,7 @@ const getEditorsByCategoryCached = unstable_cache(
         JOIN eip_snapshots es ON es.eip_id = e.id
         LEFT JOIN repositories r ON r.id = pe.repository_id
         WHERE pe.actor_role = 'EDITOR'
+          AND pe.event_type NOT IN ('subscribed', 'mentioned', 'referenced')
           AND ($1::text IS NULL OR LOWER(SPLIT_PART(r.name, '/', 2)) = LOWER($1))
           AND ($2::text IS NULL OR pe.created_at >= $2::timestamp)
           AND ($3::text IS NULL OR pe.created_at <= $3::timestamp)
@@ -1010,8 +1012,8 @@ const getEditorsRepoDistributionCached = unstable_cache(
           em.canonical AS actor,
           COALESCE(r.name, 'Unknown') AS repo,
           CASE
-            WHEN pe.created_at > COALESCE(pr.closed_at, pr.merged_at, NOW()) + INTERVAL '30 days'
-              THEN COALESCE(pr.closed_at, pr.merged_at, pr.created_at, pe.created_at)
+            WHEN pe.created_at > COALESCE(pr.updated_at, pr.closed_at, pr.merged_at, pr.created_at, pe.created_at) + INTERVAL '30 days'
+              THEN COALESCE(pr.updated_at, pr.closed_at, pr.merged_at, pr.created_at, pe.created_at)
             ELSE pe.created_at
           END AS occurred_at
         FROM pr_events pe
@@ -1019,6 +1021,8 @@ const getEditorsRepoDistributionCached = unstable_cache(
         LEFT JOIN pull_requests pr ON pr.pr_number = pe.pr_number AND pr.repository_id = pe.repository_id
         LEFT JOIN repositories r ON r.id = pe.repository_id
         WHERE pe.pr_number > 0
+          AND pe.created_at <= NOW()
+          AND pe.event_type NOT IN ('subscribed', 'mentioned', 'referenced')
       ),
       base AS (
         SELECT actor, repo
@@ -3831,14 +3835,16 @@ export const analyticsProcedures = {
             em.canonical AS actor,
             pe.repository_id,
             CASE
-              WHEN pe.created_at > COALESCE(pr.closed_at, pr.merged_at, NOW()) + INTERVAL '30 days'
-                THEN COALESCE(pr.closed_at, pr.merged_at, pr.created_at, pe.created_at)
+              WHEN pe.created_at > COALESCE(pr.updated_at, pr.closed_at, pr.merged_at, pr.created_at, pe.created_at) + INTERVAL '30 days'
+                THEN COALESCE(pr.updated_at, pr.closed_at, pr.merged_at, pr.created_at, pe.created_at)
               ELSE pe.created_at
             END AS occurred_at
           FROM pr_events pe
           JOIN editor_map em ON LOWER(pe.actor) = em.actor_lc
           LEFT JOIN pull_requests pr ON pr.pr_number = pe.pr_number AND pr.repository_id = pe.repository_id
           WHERE pe.pr_number > 0
+            AND pe.created_at <= NOW()
+            AND pe.event_type NOT IN ('subscribed', 'mentioned', 'referenced')
         )
         SELECT
           TO_CHAR(date_trunc('day', re.occurred_at), 'YYYY-MM-DD') AS date,
@@ -3886,28 +3892,42 @@ export const analyticsProcedures = {
         raw_events AS (
           SELECT
             em.canonical AS actor,
+            pe.pr_number,
             pe.repository_id,
+            pe.event_type,
             CASE
-              WHEN pe.created_at > COALESCE(pr.closed_at, pr.merged_at, NOW()) + INTERVAL '30 days'
-                THEN COALESCE(pr.closed_at, pr.merged_at, pr.created_at, pe.created_at)
+              WHEN pe.created_at > COALESCE(pr.updated_at, pr.closed_at, pr.merged_at, pr.created_at, pe.created_at) + INTERVAL '30 days'
+                THEN COALESCE(pr.updated_at, pr.closed_at, pr.merged_at, pr.created_at, pe.created_at)
               ELSE pe.created_at
             END AS occurred_at
           FROM pr_events pe
           JOIN editor_map em ON LOWER(pe.actor) = em.actor_lc
           LEFT JOIN pull_requests pr ON pr.pr_number = pe.pr_number AND pr.repository_id = pe.repository_id
           WHERE pe.pr_number > 0
+            AND pe.created_at <= NOW()
+            AND pe.event_type NOT IN ('subscribed', 'mentioned', 'referenced')
+        ),
+        deduped_events AS (
+          SELECT
+            actor,
+            pr_number,
+            repository_id,
+            event_type,
+            date_trunc('second', occurred_at) AS occurred_at
+          FROM raw_events
+          GROUP BY actor, pr_number, repository_id, event_type, date_trunc('second', occurred_at)
         )
         SELECT
-          TO_CHAR(date_trunc('day', re.occurred_at), 'YYYY-MM-DD') AS date,
-          re.actor,
+          TO_CHAR(date_trunc('day', de.occurred_at), 'YYYY-MM-DD') AS date,
+          de.actor,
           COUNT(*)::bigint AS count
-        FROM raw_events re
-        LEFT JOIN repositories r ON r.id = re.repository_id
-        WHERE ($1::text IS NULL OR re.occurred_at >= $1::timestamp)
-          AND ($2::text IS NULL OR re.occurred_at <= $2::timestamp)
+        FROM deduped_events de
+        LEFT JOIN repositories r ON r.id = de.repository_id
+        WHERE ($1::text IS NULL OR de.occurred_at >= $1::timestamp)
+          AND ($2::text IS NULL OR de.occurred_at < (($2::date + INTERVAL '1 day')::timestamp))
           AND ($3::text IS NULL OR LOWER(SPLIT_PART(r.name, '/', 2)) = LOWER($3))
-        GROUP BY date_trunc('day', re.occurred_at), re.actor
-        ORDER BY date ASC, re.actor ASC
+        GROUP BY date_trunc('day', de.occurred_at), de.actor
+        ORDER BY date ASC, de.actor ASC
       `,
         input.from ?? null,
         input.to ?? null,
@@ -3960,6 +3980,7 @@ export const analyticsProcedures = {
           JOIN editor_map em ON LOWER(pe.actor) = em.actor_lc
           LEFT JOIN pull_requests pr ON pr.pr_number = pe.pr_number AND pr.repository_id = pe.repository_id
           WHERE pe.pr_number > 0
+            AND pe.event_type NOT IN ('subscribed', 'mentioned', 'referenced')
         )
         SELECT
           re.actor,
@@ -4561,14 +4582,16 @@ export const analyticsProcedures = {
               pe.repository_id,
               pe.event_type AS action_type,
               CASE
-                WHEN pe.created_at > COALESCE(pr.closed_at, pr.merged_at, NOW()) + INTERVAL '30 days'
-                  THEN COALESCE(pr.closed_at, pr.merged_at, pr.created_at, pe.created_at)
+                WHEN pe.created_at > COALESCE(pr.updated_at, pr.closed_at, pr.merged_at, pr.created_at, pe.created_at) + INTERVAL '30 days'
+                  THEN COALESCE(pr.updated_at, pr.closed_at, pr.merged_at, pr.created_at, pe.created_at)
                 ELSE pe.created_at
               END AS occurred_at
             FROM pr_events pe
             JOIN editor_map em ON LOWER(pe.actor) = em.actor_lc
             LEFT JOIN pull_requests pr ON pr.pr_number = pe.pr_number AND pr.repository_id = pe.repository_id
             WHERE pe.pr_number > 0
+              AND pe.created_at <= NOW()
+              AND pe.event_type NOT IN ('subscribed', 'mentioned', 'referenced')
           )
           SELECT re.actor, re.pr_number, r.name AS repo_name,
                  TO_CHAR(re.occurred_at, 'YYYY-MM-DD HH24:MI:SS') AS occurred_at,
@@ -4703,26 +4726,40 @@ export const analyticsProcedures = {
         raw_events AS (
           SELECT
             em.canonical AS actor,
+            pe.pr_number,
             pe.repository_id,
+            pe.event_type,
             CASE
-              WHEN pe.created_at > COALESCE(pr.closed_at, pr.merged_at, NOW()) + INTERVAL '30 days'
-                THEN COALESCE(pr.closed_at, pr.merged_at, pr.created_at, pe.created_at)
+              WHEN pe.created_at > COALESCE(pr.updated_at, pr.closed_at, pr.merged_at, pr.created_at, pe.created_at) + INTERVAL '30 days'
+                THEN COALESCE(pr.updated_at, pr.closed_at, pr.merged_at, pr.created_at, pe.created_at)
               ELSE pe.created_at
             END AS occurred_at
           FROM pr_events pe
           JOIN editor_map em ON LOWER(pe.actor) = em.actor_lc
           LEFT JOIN pull_requests pr ON pr.pr_number = pe.pr_number AND pr.repository_id = pe.repository_id
           WHERE pe.pr_number > 0
+            AND pe.created_at <= NOW()
+            AND pe.event_type NOT IN ('subscribed', 'mentioned', 'referenced')
+        ),
+        deduped_events AS (
+          SELECT
+            actor,
+            pr_number,
+            repository_id,
+            event_type,
+            date_trunc('second', occurred_at) AS occurred_at
+          FROM raw_events
+          GROUP BY actor, pr_number, repository_id, event_type, date_trunc('second', occurred_at)
         )
         SELECT
-          TO_CHAR(date_trunc('month', re.occurred_at), 'YYYY-MM') as month,
-          re.actor AS actor,
+          TO_CHAR(date_trunc('month', de.occurred_at), 'YYYY-MM') as month,
+          de.actor AS actor,
           COUNT(*)::bigint as count
-        FROM raw_events re
-        LEFT JOIN repositories r ON r.id = re.repository_id
-        WHERE re.occurred_at >= date_trunc('month', NOW() - INTERVAL '1 month' * $2)
+        FROM deduped_events de
+        LEFT JOIN repositories r ON r.id = de.repository_id
+        WHERE de.occurred_at >= date_trunc('month', NOW() - INTERVAL '1 month' * $2)
           AND ($1::text IS NULL OR LOWER(SPLIT_PART(r.name, '/', 2)) = LOWER($1))
-        GROUP BY date_trunc('month', re.occurred_at), re.actor
+        GROUP BY date_trunc('month', de.occurred_at), de.actor
         ORDER BY month ASC, count DESC
       `,
         input.repo ?? null,
@@ -4775,26 +4812,38 @@ export const analyticsProcedures = {
             em.canonical AS actor,
             pe.pr_number,
             pe.repository_id,
+            pe.event_type,
             CASE
-              WHEN pe.created_at > COALESCE(pr.closed_at, pr.merged_at, NOW()) + INTERVAL '30 days'
-                THEN COALESCE(pr.closed_at, pr.merged_at, pr.created_at, pe.created_at)
+              WHEN pe.created_at > COALESCE(pr.updated_at, pr.closed_at, pr.merged_at, pr.created_at, pe.created_at) + INTERVAL '30 days'
+                THEN COALESCE(pr.updated_at, pr.closed_at, pr.merged_at, pr.created_at, pe.created_at)
               ELSE pe.created_at
             END AS occurred_at
           FROM pr_events pe
           JOIN editor_map em ON LOWER(pe.actor) = em.actor_lc
           LEFT JOIN pull_requests pr ON pr.pr_number = pe.pr_number AND pr.repository_id = pe.repository_id
           WHERE pe.pr_number > 0
+            AND pe.created_at <= NOW()
             AND pe.event_type IN ('reviewed', 'approved', 'changes_requested')
+        ),
+        deduped_reviews AS (
+          SELECT
+            actor,
+            pr_number,
+            repository_id,
+            event_type,
+            date_trunc('second', occurred_at) AS occurred_at
+          FROM raw_reviews
+          GROUP BY actor, pr_number, repository_id, event_type, date_trunc('second', occurred_at)
         )
         SELECT
-          TO_CHAR(date_trunc('month', rr.occurred_at), 'YYYY-MM') as month,
-          rr.actor,
-          COUNT(DISTINCT rr.pr_number)::bigint as count
-        FROM raw_reviews rr
-        LEFT JOIN repositories r ON r.id = rr.repository_id
-        WHERE rr.occurred_at >= date_trunc('month', NOW() - INTERVAL '1 month' * $2)
+          TO_CHAR(date_trunc('month', dr.occurred_at), 'YYYY-MM') as month,
+          dr.actor,
+          COUNT(DISTINCT CONCAT(dr.repository_id::text, ':', dr.pr_number::text))::bigint as count
+        FROM deduped_reviews dr
+        LEFT JOIN repositories r ON r.id = dr.repository_id
+        WHERE dr.occurred_at >= date_trunc('month', NOW() - INTERVAL '1 month' * $2)
           AND ($1::text IS NULL OR LOWER(SPLIT_PART(r.name, '/', 2)) = LOWER($1))
-        GROUP BY date_trunc('month', rr.occurred_at), rr.actor
+        GROUP BY date_trunc('month', dr.occurred_at), dr.actor
         ORDER BY month ASC, count DESC
       `,
         input.repo ?? null,
@@ -5110,8 +5159,8 @@ export const analyticsProcedures = {
             pe.repository_id,
             LOWER(SPLIT_PART(COALESCE(r.name, ''), '/', 2)) AS repo_short,
             CASE
-              WHEN pe.created_at > COALESCE(pr.closed_at, pr.merged_at, NOW()) + INTERVAL '30 days'
-                THEN COALESCE(pr.closed_at, pr.merged_at, pr.created_at, pe.created_at)
+              WHEN pe.created_at > COALESCE(pr.updated_at, pr.closed_at, pr.merged_at, pr.created_at, pe.created_at) + INTERVAL '30 days'
+                THEN COALESCE(pr.updated_at, pr.closed_at, pr.merged_at, pr.created_at, pe.created_at)
               ELSE pe.created_at
             END AS occurred_at
           FROM pr_events pe
@@ -5119,6 +5168,8 @@ export const analyticsProcedures = {
           LEFT JOIN repositories r ON r.id = pe.repository_id
           LEFT JOIN pull_requests pr ON pr.pr_number = pe.pr_number AND pr.repository_id = pe.repository_id
           WHERE pe.pr_number > 0
+            AND pe.created_at <= NOW()
+            AND pe.event_type NOT IN ('subscribed', 'mentioned', 'referenced')
         )
         SELECT
           re.actor AS actor,
@@ -5216,14 +5267,16 @@ export const analyticsProcedures = {
             pe.event_type,
             pe.metadata,
             CASE
-              WHEN pe.created_at > COALESCE(pr.closed_at, pr.merged_at, NOW()) + INTERVAL '30 days'
-                THEN COALESCE(pr.closed_at, pr.merged_at, pr.created_at, pe.created_at)
+              WHEN pe.created_at > COALESCE(pr.updated_at, pr.closed_at, pr.merged_at, pr.created_at, pe.created_at) + INTERVAL '30 days'
+                THEN COALESCE(pr.updated_at, pr.closed_at, pr.merged_at, pr.created_at, pe.created_at)
               ELSE pe.created_at
             END AS occurred_at
           FROM pr_events pe
           JOIN editor_map em ON LOWER(pe.actor) = em.actor_lc
           LEFT JOIN pull_requests pr ON pr.pr_number = pe.pr_number AND pr.repository_id = pe.repository_id
           WHERE pe.pr_number > 0
+            AND pe.created_at <= NOW()
+            AND pe.event_type NOT IN ('subscribed', 'mentioned', 'referenced')
         ),
         leaders AS (
           SELECT


### PR DESCRIPTION
This pull request introduces several improvements to the editors analytics dashboard and its backend data aggregation, focusing on more accurate event tracking and enhanced user interface flexibility. The most significant changes include deduplication of events, filtering out non-action event types, improved time handling for event dates, and a UI update that allows toggling between different trend metrics.

**Backend data accuracy and consistency:**

* Added deduplication of events and reviews in analytics queries to prevent double-counting, grouping by actor, PR, repository, event type, and timestamp. This ensures more accurate reporting of editor actions and reviewed PRs. [[1]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9R3895-R3930) [[2]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9R4729-R4762) [[3]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9R4815-R4846)
* Excluded non-action event types (`'subscribed'`, `'mentioned'`, `'referenced'`) from all analytics queries to focus on meaningful editor activity. [[1]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9R796) [[2]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9R958) [[3]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9L1013-R1025) [[4]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9L3834-R3847) [[5]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9R3983) [[6]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9L4564-R4594)
* Improved event date handling by considering the most recent PR update time (`pr.updated_at`) for events occurring after PR closure, ensuring events are attributed to the correct time window. [[1]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9L1013-R1025) [[2]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9L3834-R3847) [[3]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9R3895-R3930) [[4]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9L4564-R4594) [[5]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9R4729-R4762) [[6]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9R4815-R4846)

**Frontend analytics UI improvements:**

* Replaced static trend charts with a toggle allowing users to switch between "All Actions" and "Reviewed PRs" as the primary metric, including dynamic titles, subtitles, and footers. [[1]](diffhunk://#diff-9bb64009dceca141115a78c960c8fb407dbc757e5640c2ce893c84fa9560c857R172) [[2]](diffhunk://#diff-9bb64009dceca141115a78c960c8fb407dbc757e5640c2ce893c84fa9560c857L622-R647) [[3]](diffhunk://#diff-9bb64009dceca141115a78c960c8fb407dbc757e5640c2ce893c84fa9560c857L1129-R1181)
* Extended the trend chart time horizon to 72 months for better visibility of long-term editorial patterns, and changed line charts to use straight lines instead of smoothed lines for more accurate representation. [[1]](diffhunk://#diff-9bb64009dceca141115a78c960c8fb407dbc757e5640c2ce893c84fa9560c857L287-R289) [[2]](diffhunk://#diff-9bb64009dceca141115a78c960c8fb407dbc757e5640c2ce893c84fa9560c857L592-R594)

These changes collectively provide more accurate and meaningful analytics for editors, while giving users greater control over how trends are visualized.