### PR TITLE
Refactor Editors Analytics layout and enhance CopyLinkButton functionality

### DIFF
--- a/docs/ui-changelog.md
+++ b/docs/ui-changelog.md
@@ -1,0 +1,13 @@
+# UI Changelog
+
+## 2026-04-11
+
+### Homepage — Editor Persona
+- Refined **Editor Quick Access** visuals (cleaner container, better button contrast, tighter card polish) while keeping the same structure and actions.
+- Updated **Monthly Insight & Editor Leaderboard** header so the copy action sits inline with the title; tooltip now reads `Copy section`.
+- Added a new top editor section directly after quick access:
+  - **Editors – Contributions** with `This Month`, `All-Time`, and `Custom Range`.
+  - Updated to mirror the `/analytics/editors` leaderboard hero pattern (`List` / `Chart` toggle + compact rows/chart).
+  - Embedded **stacked repository breakdown** (EIPs/ERCs/RIPs/Other) under the leaderboard block.
+  - Uses standard section header rhythm and copy-link behavior.
+- Restored the bottom **Monthly Insight & Editor Leaderboard** panel behavior so it stays as the monthly snapshot section.

--- a/src/app/(public)/_components/persona-home/EditorCategoryBreakdownSection.tsx
+++ b/src/app/(public)/_components/persona-home/EditorCategoryBreakdownSection.tsx
@@ -55,7 +55,10 @@ export default function EditorCategoryBreakdownSection({
     <section className="mb-6 border-t border-border/70 pt-6" id="editor-category-breakdown">
       <div className="mb-3 flex flex-wrap items-start justify-between gap-2">
         <div>
-          <h2 className={sectionTitleClass}>Category Breakdown</h2>
+          <div className="inline-flex items-center gap-2">
+            <h2 className={sectionTitleClass}>Category Breakdown</h2>
+            <CopyLinkButton sectionId="editor-category-breakdown" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
+          </div>
           <p className={sectionSubtitleClass}>Participants × process stacked distribution for open PRs.</p>
           <p className="mt-1 text-[11px] text-muted-foreground">Month context: {monthLabelText}</p>
         </div>
@@ -71,7 +74,13 @@ export default function EditorCategoryBreakdownSection({
               </option>
             ))}
           </select>
-          <CopyLinkButton sectionId="editor-category-breakdown" className="h-8 w-8 rounded-md" />
+          <Link
+            href="/analytics/prs"
+            className="inline-flex h-8 items-center justify-center gap-1 whitespace-nowrap rounded-md border border-primary/30 bg-primary/10 px-2.5 text-xs font-medium text-primary transition-colors hover:bg-primary/15"
+          >
+            Explore PR Analytics
+            <ArrowRight className="h-3 w-3" />
+          </Link>
         </div>
       </div>
       <div className="mb-3 inline-flex items-center gap-1 rounded-md border border-border bg-muted/60 p-0.5 text-xs">
@@ -151,15 +160,6 @@ export default function EditorCategoryBreakdownSection({
             </button>
           </div>
         </div>
-      </div>
-      <div className="mt-3 flex justify-center">
-        <Link
-          href="/analytics/prs"
-          className="inline-flex h-8 items-center justify-center gap-1 whitespace-nowrap rounded-md border border-primary/30 bg-primary/10 px-2.5 text-xs font-medium text-primary transition-colors hover:bg-primary/15"
-        >
-          Explore PR Analytics
-          <ArrowRight className="h-3 w-3" />
-        </Link>
       </div>
     </section>
   );

--- a/src/app/(public)/_components/persona-home/EditorReviewQueueSection.tsx
+++ b/src/app/(public)/_components/persona-home/EditorReviewQueueSection.tsx
@@ -2,9 +2,10 @@
 
 import React from 'react';
 import Link from 'next/link';
-import { ArrowRight, ExternalLink } from 'lucide-react';
+import { ArrowRight, Download, ExternalLink } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { CopyLinkButton } from '@/components/header';
+import { client } from '@/lib/orpc';
 
 type EditorRepoFilter = '' | 'eips' | 'ercs' | 'rips';
 
@@ -62,14 +63,101 @@ export default function EditorReviewQueueSection({
   boardProcessBadgeMap,
   githubRepoFromShort,
 }: EditorReviewQueueSectionProps) {
+  const [downloadingReport, setDownloadingReport] = React.useState(false);
+  const csvEscape = (value: string | number | null | undefined) => `"${String(value ?? '').replaceAll('"', '""')}"`;
+
+  const downloadReport = React.useCallback(async () => {
+    if (downloadingReport) return;
+    setDownloadingReport(true);
+    try {
+      const pageSize = 500;
+      const firstPage = await client.tools.getOpenPRBoard({
+        repo: editorRepoFilter || undefined,
+        govState: ['Waiting on Editor'],
+        processType: selectedBoardProcesses.length ? selectedBoardProcesses : undefined,
+        page: 1,
+        pageSize,
+      });
+
+      let allRows = firstPage.rows ?? [];
+      if ((firstPage.totalPages ?? 1) > 1) {
+        const remainingPages = await Promise.all(
+          Array.from({ length: firstPage.totalPages - 1 }, (_, idx) =>
+            client.tools.getOpenPRBoard({
+              repo: editorRepoFilter || undefined,
+              govState: ['Waiting on Editor'],
+              processType: selectedBoardProcesses.length ? selectedBoardProcesses : undefined,
+              page: idx + 2,
+              pageSize,
+            }),
+          ),
+        );
+        allRows = allRows.concat(remainingPages.flatMap((page) => page.rows ?? []));
+      }
+
+      if (!allRows.length) return;
+
+    const headers = ['Repo', 'PR Number', 'Title', 'Author', 'Process', 'Participants', 'Wait Days', 'Created At', 'PR Link'];
+    const lines = [headers.join(',')];
+    allRows.forEach((row) => {
+      const values = [
+        row.repoShort.toUpperCase(),
+        row.prNumber,
+        row.title ?? '',
+        row.author ?? '',
+        row.processType,
+        row.govState,
+        row.waitDays,
+        row.createdAt,
+        `https://github.com/${row.repo}/pull/${row.prNumber}`,
+      ];
+      lines.push(values.map(csvEscape).join(','));
+    });
+    const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `editor_review_queue_${(editorRepoFilter || 'all').toLowerCase()}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Failed to export board report CSV:', err);
+    } finally {
+      setDownloadingReport(false);
+    }
+  }, [downloadingReport, editorRepoFilter, selectedBoardProcesses]);
+
   return (
     <section className="mb-6 border-t border-border/70 pt-6" id="editor-review-queue">
       <div className="mb-3 flex items-start justify-between gap-2">
         <div>
-          <h2 className={sectionTitleClass}>Editor Review Queue</h2>
+          <div className="inline-flex items-center gap-2">
+            <h2 className={sectionTitleClass}>Editor Review Queue</h2>
+            <CopyLinkButton sectionId="editor-review-queue" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
+          </div>
           <p className={sectionSubtitleClass}>Open PRs currently waiting on editor action.</p>
         </div>
-        <CopyLinkButton sectionId="editor-review-queue" className="h-8 w-8 rounded-md" />
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={downloadReport}
+            disabled={boardPreviewLoading || boardPreviewTotal === 0 || downloadingReport}
+            aria-label="Download board report CSV"
+            title="Download board report CSV"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-primary/40 bg-primary/10 text-primary transition-colors hover:bg-primary/15 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Download className="h-3.5 w-3.5" />
+          </button>
+          <Link
+            href="/tools/board?status=Waiting+on+Editor&page=1"
+            className="inline-flex h-8 items-center justify-center gap-1 whitespace-nowrap rounded-md border border-primary/30 bg-primary/10 px-2.5 text-xs font-medium text-primary transition-colors hover:bg-primary/15"
+          >
+            Explore Board
+            <ArrowRight className="h-3 w-3" />
+          </Link>
+        </div>
       </div>
 
       <div className="mb-2 inline-flex items-center gap-1 rounded-md border border-border bg-muted/60 p-0.5 text-xs">
@@ -220,15 +308,6 @@ export default function EditorReviewQueueSection({
             </button>
           </div>
         </div>
-      </div>
-      <div className="mt-3 flex justify-center">
-        <Link
-          href="/tools/board?status=Waiting+on+Editor&page=1"
-          className="inline-flex h-8 items-center justify-center gap-1 whitespace-nowrap rounded-md border border-primary/30 bg-primary/10 px-2.5 text-xs font-medium text-primary transition-colors hover:bg-primary/15"
-        >
-          Explore Board
-          <ArrowRight className="h-3 w-3" />
-        </Link>
       </div>
     </section>
   );

--- a/src/app/(public)/_components/social-community-updates.tsx
+++ b/src/app/(public)/_components/social-community-updates.tsx
@@ -72,6 +72,39 @@ const communityDiscussions = [
     url: 'https://ethereum-magicians.org/',
     isHot: false,
   },
+  {
+    id: 6,
+    title: 'EIP-7823: calldata gas economics refinements',
+    platform: 'Ethereum Magicians',
+    category: 'Core',
+    replies: 64,
+    views: 1910,
+    lastActive: '6 hours ago',
+    url: 'https://ethereum-magicians.org/c/eips/14',
+    isHot: true,
+  },
+  {
+    id: 7,
+    title: 'ERC account delegation patterns for consumer wallets',
+    platform: 'Ethereum Magicians',
+    category: 'ERC',
+    replies: 41,
+    views: 1325,
+    lastActive: '10 hours ago',
+    url: 'https://ethereum-magicians.org/c/eips/14',
+    isHot: false,
+  },
+  {
+    id: 8,
+    title: 'EIP process notes: editorial merge policy and review cadence',
+    platform: 'Ethereum PM',
+    category: 'Meta',
+    replies: 22,
+    views: 780,
+    lastActive: '1 day ago',
+    url: 'https://github.com/ethereum/pm/issues',
+    isHot: false,
+  },
 ];
 
 type UpcomingEvent = {
@@ -151,12 +184,26 @@ const getColorClasses = (color: string) => {
 
 type SocialCommunityUpdatesProps = {
   showCommunityResources?: boolean;
+  sectionTitleClass?: string;
+  sectionSubtitleClass?: string;
 };
 
-export default function SocialCommunityUpdates({ showCommunityResources = true }: SocialCommunityUpdatesProps) {
+export default function SocialCommunityUpdates({
+  showCommunityResources = true,
+  sectionTitleClass = 'text-4xl font-semibold tracking-tight sm:text-5xl',
+  sectionSubtitleClass = 'text-sm text-muted-foreground',
+}: SocialCommunityUpdatesProps) {
   const [upcomingEvents, setUpcomingEvents] = React.useState<UpcomingEvent[]>([]);
   const [eventsLoading, setEventsLoading] = React.useState(true);
   const [eventsSyncedAt, setEventsSyncedAt] = React.useState<string | null>(null);
+  const sortedDiscussions = React.useMemo(
+    () =>
+      [...communityDiscussions].sort((a, b) => {
+        if (a.isHot !== b.isHot) return a.isHot ? -1 : 1;
+        return b.replies - a.replies;
+      }),
+    [],
+  );
 
   React.useEffect(() => {
     let cancelled = false;
@@ -190,14 +237,14 @@ export default function SocialCommunityUpdates({ showCommunityResources = true }
     <section className="w-full" id="social-community">
       <div className="mb-4 flex items-start justify-between gap-3">
         <div>
-          <h2 className="dec-title persona-title text-2xl font-semibold tracking-tight sm:text-3xl">
-          Social & Community Updates
-          </h2>
-          <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+          <div className="inline-flex items-center gap-2">
+            <h2 className={sectionTitleClass}>Social & Community Updates</h2>
+            <CopyLinkButton sectionId="social-community" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
+          </div>
+          <p className={cn('mt-1 leading-relaxed', sectionSubtitleClass)}>
             Discussions, channels, and events across the Ethereum standards ecosystem.
           </p>
         </div>
-        <CopyLinkButton sectionId="social-community" className="h-8 w-8 rounded-md" />
       </div>
 
       <div className="mb-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
@@ -228,7 +275,7 @@ export default function SocialCommunityUpdates({ showCommunityResources = true }
       <div className="grid items-start gap-4 xl:grid-cols-[2fr_1fr]">
         <div className="space-y-3">
           <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Active Discussions</h3>
-          {communityDiscussions.map((discussion) => (
+          {sortedDiscussions.map((discussion) => (
             <motion.a
               key={discussion.id}
               href={discussion.url}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -84,6 +84,16 @@ type HomepageEditorRow = {
   prsTouched: number;
 };
 
+type EditorContributionWindow = 'month' | 'all' | 'custom';
+
+type EditorContributionRow = {
+  actor: string;
+  totalActions: number;
+  prsTouched: number;
+  reviews: number;
+  comments: number;
+};
+
 type BoardPreviewRow = {
   prNumber: number;
   title: string | null;
@@ -511,6 +521,29 @@ function monthLabel(monthYear: string) {
   });
 }
 
+function monthRange(monthYear: string) {
+  const [year, month] = monthYear.split('-').map(Number);
+  const start = new Date(Date.UTC(year, month - 1, 1, 0, 0, 0, 0));
+  const end = new Date(Date.UTC(year, month, 0, 23, 59, 59, 999));
+  const toInput = (date: Date) => date.toISOString().slice(0, 10);
+  return {
+    fromInput: toInput(start),
+    toInput: toInput(end),
+    fromQuery: start.toISOString(),
+    toQuery: end.toISOString(),
+  };
+}
+
+function dayStartIso(dateInput: string) {
+  const date = new Date(`${dateInput}T00:00:00.000Z`);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function dayEndIso(dateInput: string) {
+  const date = new Date(`${dateInput}T23:59:59.999Z`);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
 function proposalUrl(repo: string, kind: string, number: number) {
   if (kind === 'ERC' || repo.toLowerCase().includes('erc')) return `/erc/${number}`;
   if (kind === 'RIP' || repo.toLowerCase().includes('rip')) return `/rip/${number}`;
@@ -751,6 +784,14 @@ export default function EIPsHomePage() {
     return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
   }, []);
   const [currentMonthYear, setCurrentMonthYear] = useState(defaultMonthYear);
+  const [editorContribWindow, setEditorContribWindow] = useState<EditorContributionWindow>('all');
+  const [editorContribFrom, setEditorContribFrom] = useState(monthRange(defaultMonthYear).fromInput);
+  const [editorContribTo, setEditorContribTo] = useState(monthRange(defaultMonthYear).toInput);
+  const [editorContributionRows, setEditorContributionRows] = useState<EditorContributionRow[]>([]);
+  const [editorRepoDistributionRows, setEditorRepoDistributionRows] = useState<
+    Array<{ actor: string; repo: string; count: number; pct: number }>
+  >([]);
+  const [editorContribLoading, setEditorContribLoading] = useState(false);
   const monthYearOptions = useMemo(() => {
     const options: Array<{ value: string; label: string }> = [];
     const cursor = new Date();
@@ -791,6 +832,14 @@ export default function EIPsHomePage() {
   useEffect(() => {
     setShowPersonaWorkspace(true);
   }, [activePersona]);
+
+  useEffect(() => {
+    const { fromInput, toInput } = monthRange(currentMonthYear);
+    setEditorContribFrom(fromInput);
+    setEditorContribTo(toInput);
+    if (editorContribWindow === 'month') {
+    }
+  }, [currentMonthYear, editorContribWindow]);
 
   useEffect(() => {
     if (activePersona !== 'builder') return;
@@ -1211,6 +1260,76 @@ export default function EIPsHomePage() {
     };
   }, [currentMonthYear]);
 
+  useEffect(() => {
+    let cancelled = false;
+    if (activePersona !== 'editor') {
+      setEditorContributionRows([]);
+      setEditorRepoDistributionRows([]);
+      return;
+    }
+
+    (async () => {
+      setEditorContribLoading(true);
+      try {
+        let from: string | undefined;
+        let to: string | undefined;
+
+        if (editorContribWindow === 'month') {
+          const range = monthRange(currentMonthYear);
+          from = range.fromQuery;
+          to = range.toQuery;
+        } else if (editorContribWindow === 'custom') {
+          from = dayStartIso(editorContribFrom) ?? undefined;
+          to = dayEndIso(editorContribTo) ?? undefined;
+        }
+
+        const [leaders, repoDistribution] = await Promise.all([
+          client.analytics.getEditorsLeaderboard({
+            limit: 12,
+            from,
+            to,
+          }),
+          client.analytics.getEditorsRepoDistribution({
+            from,
+            to,
+          }),
+        ]);
+
+        if (cancelled) return;
+
+        setEditorContributionRows(
+          leaders.map((row) => ({
+            actor: row.actor,
+            totalActions: row.totalActions,
+            prsTouched: row.prsTouched,
+            reviews: row.reviews,
+            comments: row.comments,
+          })),
+        );
+        setEditorRepoDistributionRows(
+          repoDistribution.map((row) => ({
+            actor: row.actor,
+            repo: row.repo,
+            count: row.count,
+            pct: row.pct,
+          })),
+        );
+      } catch (err) {
+        console.error('Failed to load editor contribution snapshot:', err);
+        if (!cancelled) {
+          setEditorContributionRows([]);
+          setEditorRepoDistributionRows([]);
+        }
+      } finally {
+        if (!cancelled) setEditorContribLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activePersona, currentMonthYear, editorContribWindow, editorContribFrom, editorContribTo]);
+
   const totalCount = useMemo(
     () => distribution.reduce((acc, row) => acc + row.count, 0),
     [distribution]
@@ -1316,6 +1435,108 @@ export default function EIPsHomePage() {
     () => Math.max(1, ...monthlyEditorRows.map((e) => e.totalActions)),
     [monthlyEditorRows]
   );
+  const editorContributionWindowLabel = useMemo(() => {
+    if (editorContribWindow === 'all') return 'All-Time Contributions';
+    if (editorContribWindow === 'custom') {
+      return `${editorContribFrom || 'Start'} → ${editorContribTo || 'Now'}`;
+    }
+    return monthLabel(currentMonthYear);
+  }, [editorContribWindow, editorContribFrom, editorContribTo, currentMonthYear]);
+  const editorRepoBreakdownOption = useMemo(() => {
+    const topActors = editorContributionRows.slice(0, 8).map((row) => row.actor);
+    const repoAliases = (repo: string) => {
+      const short = repo.includes('/') ? repo.split('/').pop() || repo : repo;
+      return short.toLowerCase();
+    };
+    const bucketed = new Map<string, { eips: number; ercs: number; rips: number }>();
+    topActors.forEach((actor) => {
+      bucketed.set(actor, { eips: 0, ercs: 0, rips: 0 });
+    });
+    editorRepoDistributionRows.forEach((row) => {
+      const actor = topActors.find((name) => name.toLowerCase() === row.actor.toLowerCase());
+      if (!actor) return;
+      const bucket = bucketed.get(actor);
+      if (!bucket) return;
+      const repo = repoAliases(row.repo);
+      if (repo === 'eips') bucket.eips += row.count;
+      else if (repo === 'ercs') bucket.ercs += row.count;
+      else if (repo === 'rips') bucket.rips += row.count;
+    });
+    const eipsSeries = topActors.map((actor) => bucketed.get(actor)?.eips ?? 0);
+    const ercsSeries = topActors.map((actor) => bucketed.get(actor)?.ercs ?? 0);
+    const ripsSeries = topActors.map((actor) => bucketed.get(actor)?.rips ?? 0);
+    const totals = topActors.map((actor) => {
+      const b = bucketed.get(actor);
+      return (b?.eips ?? 0) + (b?.ercs ?? 0) + (b?.rips ?? 0);
+    });
+
+    return {
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: { type: 'shadow' },
+        backgroundColor: isDark ? 'rgba(15,23,42,0.94)' : 'rgba(255,255,255,0.98)',
+        borderColor: isDark ? 'rgba(148,163,184,0.25)' : 'rgba(148,163,184,0.35)',
+        textStyle: { color: isDark ? '#e2e8f0' : '#0f172a', fontSize: 12 },
+        formatter: (params: Array<{ seriesName: string; value: number; marker: string; axisValue: string }>) => {
+          if (!params?.length) return '';
+          const actor = params[0]?.axisValue ?? '';
+          const avatar = editorAvatar(actor);
+          const lines = params
+            .filter((entry) => ['EIPs', 'ERCs', 'RIPs'].includes(entry.seriesName))
+            .map((entry) => `${entry.marker} ${entry.seriesName}: ${Number(entry.value ?? 0).toLocaleString()}`);
+          const total = params
+            .filter((entry) => ['EIPs', 'ERCs', 'RIPs'].includes(entry.seriesName))
+            .reduce((sum, entry) => sum + Number(entry.value ?? 0), 0);
+          const header = `
+            <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px;">
+              <img src="${avatar}" alt="${actor}" width="22" height="22" style="width:22px;height:22px;border-radius:999px;border:1px solid rgba(148,163,184,0.35);" />
+              <strong>${actor}</strong>
+            </div>
+          `;
+          return [header, ...lines, `<strong>Total: ${total.toLocaleString()}</strong>`].join('<br/>');
+        },
+      },
+      legend: {
+        top: 0,
+        textStyle: { color: isDark ? '#cbd5e1' : '#475569', fontSize: 11 },
+      },
+      grid: { left: 70, right: 10, top: 28, bottom: 12, containLabel: true },
+      xAxis: {
+        type: 'value',
+        splitLine: { lineStyle: { color: isDark ? 'rgba(148,163,184,0.14)' : 'rgba(148,163,184,0.24)' } },
+        axisLabel: { color: isDark ? '#94a3b8' : '#64748b', fontSize: 11 },
+      },
+      yAxis: {
+        type: 'category',
+        data: topActors,
+        inverse: true,
+        axisLabel: { color: isDark ? '#cbd5e1' : '#334155', fontSize: 11 },
+        axisTick: { show: false },
+      },
+      series: [
+        { name: 'EIPs', type: 'bar', stack: 'repo', data: eipsSeries, itemStyle: { color: '#10b981' }, barMaxWidth: 12 },
+        { name: 'ERCs', type: 'bar', stack: 'repo', data: ercsSeries, itemStyle: { color: '#60a5fa' }, barMaxWidth: 12 },
+        { name: 'RIPs', type: 'bar', stack: 'repo', data: ripsSeries, itemStyle: { color: '#a78bfa' }, barMaxWidth: 12 },
+        {
+          type: 'scatter',
+          symbolSize: 1,
+          silent: true,
+          data: topActors.map((actor, index) => [totals[index], actor]),
+          tooltip: { show: false },
+          label: {
+            show: true,
+            position: 'right',
+            offset: [4, 0],
+            color: isDark ? '#e2e8f0' : '#0f172a',
+            fontSize: 11,
+            formatter: (params: { value: [number, string] }) => Number(params.value?.[0] ?? 0).toLocaleString(),
+          },
+          itemStyle: { color: 'transparent' },
+          emphasis: { disabled: true },
+        },
+      ],
+    };
+  }, [editorContributionRows, editorRepoDistributionRows, isDark]);
   const showDistributionSkeleton = distributionLoading && distribution.length === 0;
   const showTableSkeleton = tableLoading && !tableData;
   const showInsightSkeleton = widgetsLoading && febDelta.length === 0;
@@ -1453,19 +1674,38 @@ export default function EIPsHomePage() {
   const downloadLeaderboardDetailedCSV = async () => {
     try {
       setDownloadingLeaderboard(true);
-      const res = await client.analytics.exportMonthlyEditorLeaderboardDetailedCSV({
-        monthYear: currentMonthYear,
-        limit: 10,
-      });
-      const blob = new Blob([res.csv], { type: 'text/csv;charset=utf-8;' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = res.filename;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      if (activePersona === 'editor' && editorContribWindow !== 'month') {
+        const from = editorContribWindow === 'custom' ? dayStartIso(editorContribFrom) ?? undefined : undefined;
+        const to = editorContribWindow === 'custom' ? dayEndIso(editorContribTo) ?? undefined : undefined;
+        const res = await client.analytics.getEditorsLeaderboardExport({
+          from,
+          to,
+          detailsOnly: true,
+        });
+        const blob = new Blob([res.csv], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = res.filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      } else {
+        const res = await client.analytics.exportMonthlyEditorLeaderboardDetailedCSV({
+          monthYear: currentMonthYear,
+          limit: 10,
+        });
+        const blob = new Blob([res.csv], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = res.filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
     } catch (err) {
       console.error('Failed to export editor leaderboard CSV:', err);
     } finally {
@@ -1742,26 +1982,26 @@ export default function EIPsHomePage() {
 
       {visibleSections.quickAccess && (
         <section className="mb-5" id="persona-home-workspace">
-          <div className="rounded-xl border border-border bg-card/60 p-2.5 sm:p-3">
+          <div className="rounded-xl border border-border/80 bg-gradient-to-b from-card/90 to-card/60 p-3 shadow-sm sm:p-3.5">
             <div className="flex flex-wrap items-center justify-between gap-2">
               <div>
-                <p className="text-[10px] font-semibold uppercase tracking-wider text-primary">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-primary">
                   {PERSONA_LABELS[activePersona]} Quick Access
                 </p>
-                <p className="text-xs text-muted-foreground">{personaPlan.goal}</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">{personaPlan.goal}</p>
               </div>
               <div className="inline-flex items-center gap-1.5">
                 <button
                   type="button"
                   onClick={togglePersonaWorkspace}
-                  className="inline-flex items-center gap-1 rounded-md border border-border bg-muted/50 px-2 py-1 text-[11px] font-medium text-muted-foreground hover:border-primary/30 hover:text-foreground"
+                  className="inline-flex items-center gap-1 rounded-md border border-border bg-background/80 px-2 py-1 text-[11px] font-medium text-muted-foreground hover:border-primary/30 hover:text-foreground"
                 >
                   {showPersonaWorkspace ? 'Close' : 'Show'}
                   <ChevronDown className={cn('h-3 w-3 transition-transform', showPersonaWorkspace && 'rotate-180')} />
                 </button>
                 <Link
                   href="/p"
-                  className="inline-flex items-center gap-1 rounded-md border border-border bg-muted/50 px-2 py-1 text-[11px] font-medium text-muted-foreground hover:border-primary/30 hover:text-foreground"
+                  className="inline-flex items-center gap-1 rounded-md border border-border bg-background/80 px-2 py-1 text-[11px] font-medium text-muted-foreground hover:border-primary/30 hover:text-foreground"
                 >
                   Persona
                   <ArrowRight className="h-3 w-3" />
@@ -1769,14 +2009,14 @@ export default function EIPsHomePage() {
               </div>
             </div>
             {showPersonaWorkspace && (
-                <div className="mt-2 grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+                <div className="mt-2.5 grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
                   {personaPlan.tools.map((tool) => {
                     const Icon = tool.icon;
                     return (
                       <Link
                         key={tool.key}
                         href={tool.href}
-                        className="group rounded-lg border border-border bg-background/70 px-2.5 py-2.5 transition hover:border-primary/35 hover:bg-primary/[0.04]"
+                        className="group rounded-lg border border-border/90 bg-background/75 px-2.5 py-2.5 transition hover:border-primary/35 hover:bg-primary/[0.04]"
                       >
                         <div className="mb-1.5 inline-flex h-7 w-7 items-center justify-center rounded-md bg-primary/10 text-primary">
                           <Icon className="h-3.5 w-3.5" />
@@ -1796,6 +2036,94 @@ export default function EIPsHomePage() {
         </section>
       )}
       <PersonaDashboardComponent>
+      {activePersona === 'editor' && (
+        <section className="mb-6 border-t border-border/70 pt-6" id="editor-contributions-overview">
+          <div className="mb-3 flex flex-col items-start gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <div className="inline-flex items-center gap-2">
+                <h2 className={sectionTitleClass}>Editors - {editorContributionWindowLabel}</h2>
+                <CopyLinkButton sectionId="editor-contributions-overview" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
+              </div>
+              <p className={sectionSubtitleClass}>
+                Contribution ranking with action coverage and repository breakdown.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <select
+                value={editorContribWindow}
+                onChange={(e) => setEditorContribWindow(e.target.value as EditorContributionWindow)}
+                className="h-8 rounded-md border border-border bg-muted/40 px-2.5 text-xs text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+              >
+                <option value="month">This Month</option>
+                <option value="all">All-Time</option>
+                <option value="custom">Custom Range</option>
+              </select>
+              {editorContribWindow === 'month' && (
+                <select
+                  value={currentMonthYear}
+                  onChange={(e) => setCurrentMonthYear(e.target.value)}
+                  className="h-8 rounded-md border border-border bg-muted/40 px-2.5 text-xs text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                >
+                  {monthYearOptions.map((opt) => (
+                    <option key={`editor-contrib-month-${opt.value}`} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              )}
+              <button
+                onClick={downloadLeaderboardDetailedCSV}
+                disabled={downloadingLeaderboard}
+                aria-label="Download editor leaderboard CSV"
+                title="Download editor leaderboard CSV"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-primary/40 bg-primary/10 text-primary hover:bg-primary/15 disabled:opacity-60"
+              >
+                <Download className="h-3.5 w-3.5" />
+              </button>
+              <Link
+                href="/analytics/editors"
+                className="inline-flex h-8 items-center justify-center gap-1 whitespace-nowrap rounded-md border border-primary/30 bg-primary/10 px-2.5 text-xs font-medium text-primary transition-colors hover:bg-primary/15"
+              >
+                Explore Editor Analytics
+                <ArrowRight className="h-3 w-3" />
+              </Link>
+            </div>
+          </div>
+
+          {editorContribWindow === 'custom' && (
+            <div className="mb-3 flex flex-wrap items-center gap-2">
+              <input
+                type="date"
+                value={editorContribFrom}
+                onChange={(e) => setEditorContribFrom(e.target.value)}
+                className="h-8 rounded-md border border-border bg-muted/40 px-2.5 text-xs text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+              />
+              <span className="text-xs text-muted-foreground">to</span>
+              <input
+                type="date"
+                value={editorContribTo}
+                onChange={(e) => setEditorContribTo(e.target.value)}
+                className="h-8 rounded-md border border-border bg-muted/40 px-2.5 text-xs text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+              />
+            </div>
+          )}
+
+          <div className="rounded-xl border border-border/70 bg-gradient-to-b from-background/70 to-card/50 p-3 shadow-sm">
+            {editorContribLoading ? (
+              <div className="h-[300px] animate-pulse rounded-lg bg-muted/50" />
+            ) : editorContributionRows.length === 0 ? (
+              <div className="flex h-[300px] items-center justify-center rounded-lg border border-border/60 bg-background/40 text-sm text-muted-foreground">
+                No editor contribution data for this range.
+              </div>
+            ) : (
+              <div className="h-[300px]">
+                <ReactECharts option={editorRepoBreakdownOption} style={{ height: '100%', width: '100%' }} opts={{ renderer: 'svg' }} />
+              </div>
+            )}
+          </div>
+
+        </section>
+      )}
       {activePersona === 'developer' && visibleSections.upgradeWatch && (
         <DeveloperUpgradeWatchSection
           sectionTitleClass={sectionTitleClass}
@@ -1822,10 +2150,12 @@ export default function EIPsHomePage() {
         >
           <div className="mb-3 flex items-start justify-between gap-3">
             <div>
-              <h2 className={sectionTitleClass}>Learning Resources</h2>
+              <div className="inline-flex items-center gap-2">
+                <h2 className={sectionTitleClass}>Learning Resources</h2>
+                <CopyLinkButton sectionId="newcomer-learning-resources" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
+              </div>
               <p className={sectionSubtitleClass}>Start here to understand Ethereum standards without the noise.</p>
             </div>
-            <CopyLinkButton sectionId="newcomer-learning-resources" className="h-8 w-8 rounded-md" />
           </div>
           <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
             {[
@@ -1869,6 +2199,7 @@ export default function EIPsHomePage() {
           <div className="mb-2 flex items-start justify-end">
             <CopyLinkButton
               sectionId={activePersona === 'builder' ? 'builder-trending-proposals' : 'developer-trending-proposals'}
+              tooltipLabel="Copy link"
               className="h-8 w-8 rounded-md"
             />
           </div>
@@ -1892,10 +2223,12 @@ export default function EIPsHomePage() {
         >
           <div className="mb-3 flex items-start justify-between gap-3">
             <div>
-              <h2 className={sectionTitleClass}>Trending Proposals</h2>
+              <div className="inline-flex items-center gap-2">
+                <h2 className={sectionTitleClass}>Trending Proposals</h2>
+                <CopyLinkButton sectionId="newcomer-trending-proposals" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
+              </div>
               <p className={sectionSubtitleClass}>A simple snapshot of proposals with active discussions.</p>
             </div>
-            <CopyLinkButton sectionId="newcomer-trending-proposals" className="h-8 w-8 rounded-md" />
           </div>
           <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
             {newcomerTrendingLoading ? (
@@ -1946,10 +2279,12 @@ export default function EIPsHomePage() {
         >
           <div className="mb-3 flex items-start justify-between gap-3">
             <div>
-              <h2 className={sectionTitleClass}>Upgrade Watch</h2>
+              <div className="inline-flex items-center gap-2">
+                <h2 className={sectionTitleClass}>Upgrade Watch</h2>
+                <CopyLinkButton sectionId="newcomer-upgrade-watch" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
+              </div>
               <p className={sectionSubtitleClass}>Simplified snapshot of where proposal discussions stand for upgrades.</p>
             </div>
-            <CopyLinkButton sectionId="newcomer-upgrade-watch" className="h-8 w-8 rounded-md" />
           </div>
           <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-5">
             {[
@@ -1988,7 +2323,7 @@ export default function EIPsHomePage() {
           id="developer-governance-over-time"
         >
           <div className="mb-2 flex items-start justify-end">
-            <CopyLinkButton sectionId="developer-governance-over-time" className="h-8 w-8 rounded-md" />
+            <CopyLinkButton sectionId="developer-governance-over-time" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
           </div>
           <GovernanceOverTime />
           <div className="mt-2 flex justify-center">
@@ -2010,10 +2345,12 @@ export default function EIPsHomePage() {
         >
           <div className="mb-3 flex items-start justify-between gap-3">
             <div>
-              <h2 className={sectionTitleClass}>EIP Builder</h2>
+              <div className="inline-flex items-center gap-2">
+                <h2 className={sectionTitleClass}>EIP Builder</h2>
+                <CopyLinkButton sectionId="builder-eip-builder-focus" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
+              </div>
               <p className={sectionSubtitleClass}>Primary workspace to draft, validate, and structure standards.</p>
             </div>
-            <CopyLinkButton sectionId="builder-eip-builder-focus" className="h-8 w-8 rounded-md" />
           </div>
           <div className="rounded-xl border border-primary/30 bg-primary/10 p-4">
             <div className="mb-2 inline-flex h-8 w-8 items-center justify-center rounded-md bg-primary/15 text-primary">
@@ -2043,7 +2380,10 @@ export default function EIPsHomePage() {
         >
           <div className="mb-3 flex items-start justify-between gap-3">
             <div>
-              <h2 className={sectionTitleClass}>Board</h2>
+              <div className="inline-flex items-center gap-2">
+                <h2 className={sectionTitleClass}>Board</h2>
+                <CopyLinkButton sectionId="developer-board-snapshot" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
+              </div>
               <p className={sectionSubtitleClass}>Compact open PR snapshot from the Editing Board.</p>
             </div>
             <div className="flex items-center gap-2">
@@ -2058,7 +2398,6 @@ export default function EIPsHomePage() {
                 <option value="ercs">ERCs</option>
                 <option value="rips">RIPs</option>
               </select>
-              <CopyLinkButton sectionId="developer-board-snapshot" className="h-8 w-8 rounded-md" />
             </div>
           </div>
           <div className="overflow-hidden rounded-xl border border-border bg-card/60">
@@ -2205,10 +2544,12 @@ export default function EIPsHomePage() {
         >
           <div className="mb-3 flex items-start justify-between gap-3">
             <div>
-              <h2 className={sectionTitleClass}>Tool Shortcuts</h2>
+              <div className="inline-flex items-center gap-2">
+                <h2 className={sectionTitleClass}>Tool Shortcuts</h2>
+                <CopyLinkButton sectionId="builder-tool-shortcuts" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
+              </div>
               <p className={sectionSubtitleClass}>Jump directly into core contribution tools.</p>
             </div>
-            <CopyLinkButton sectionId="builder-tool-shortcuts" className="h-8 w-8 rounded-md" />
           </div>
           <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
             {[
@@ -2252,10 +2593,12 @@ export default function EIPsHomePage() {
         >
           <div className="mb-3 flex items-start justify-between gap-3">
             <div>
-              <h2 className={sectionTitleClass}>Beginner-Friendly Tool Shortcuts</h2>
+              <div className="inline-flex items-center gap-2">
+                <h2 className={sectionTitleClass}>Beginner-Friendly Tool Shortcuts</h2>
+                <CopyLinkButton sectionId="newcomer-tools-shortcuts" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
+              </div>
               <p className={sectionSubtitleClass}>Start with the essential tools for exploration and contribution.</p>
             </div>
-            <CopyLinkButton sectionId="newcomer-tools-shortcuts" className="h-8 w-8 rounded-md" />
           </div>
           <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
             {[
@@ -2339,9 +2682,18 @@ export default function EIPsHomePage() {
         <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex min-w-0 items-start">
             <div>
-              <h2 className={sectionTitleClass}>
-                Browse by Status, Category, Repository & Stages
-              </h2>
+              <div className="inline-flex items-center gap-2">
+                <h2 className={sectionTitleClass}>
+                  Browse by Status, Category, Repository & Stages
+                </h2>
+                {(activePersona === 'editor' || activePersona === 'builder') && (
+                  <CopyLinkButton
+                    sectionId={activePersona === 'builder' ? 'builder-browse-snapshot' : 'editor-browse-snapshot'}
+                    tooltipLabel="Copy link"
+                    className="h-8 w-8 rounded-md"
+                  />
+                )}
+              </div>
               <p className={sectionSubtitleClass}>
                 {activePersona === 'builder'
                   ? 'ERC-focused browse view with quick status/category/repository checks.'
@@ -2380,12 +2732,6 @@ export default function EIPsHomePage() {
                 </span>
               );
             })()}
-            {(activePersona === 'editor' || activePersona === 'builder') && (
-              <CopyLinkButton
-                sectionId={activePersona === 'builder' ? 'builder-browse-snapshot' : 'editor-browse-snapshot'}
-                className="h-8 w-8 rounded-md"
-              />
-            )}
           </div>
         </div>
       </div>
@@ -2992,10 +3338,12 @@ export default function EIPsHomePage() {
           {activePersona === 'editor' && (
             <div className="mb-3 flex items-start justify-between gap-2">
               <div>
-                <h2 className={sectionTitleClass}>Reference</h2>
+                <div className="inline-flex items-center gap-2">
+                  <h2 className={sectionTitleClass}>Reference</h2>
+                  <CopyLinkButton sectionId="home-reference" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
+                </div>
                 <p className={sectionSubtitleClass}>Key FAQs and guidance for standards workflow.</p>
               </div>
-              <CopyLinkButton sectionId="home-reference" className="h-8 w-8 rounded-md" />
             </div>
           )}
           <HomeFAQs categoryBreakdown={faqCategoryBreakdown} statusDist={faqStatusDist} />
@@ -3023,7 +3371,10 @@ export default function EIPsHomePage() {
       {activePersona === 'editor' && (
         <div className="mb-3 flex items-start justify-between gap-2">
           <div>
-            <h2 className={sectionTitleClass}>Monthly Insight & Editor Leaderboard</h2>
+            <div className="inline-flex items-center gap-2">
+              <h2 className={sectionTitleClass}>Monthly Insight & Editor Leaderboard</h2>
+              <CopyLinkButton sectionId="editor-monthly-insight" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
+            </div>
             <p className={sectionSubtitleClass}>Monthly status distribution and editor activity snapshot.</p>
           </div>
           <div className="flex items-center gap-2">
@@ -3042,7 +3393,6 @@ export default function EIPsHomePage() {
                 </option>
               ))}
             </select>
-            <CopyLinkButton sectionId="editor-monthly-insight" className="h-8 w-8 rounded-md" />
           </div>
         </div>
       )}
@@ -3158,115 +3508,117 @@ export default function EIPsHomePage() {
             activePersona === 'editor' ? 'h-[460px] sm:h-[500px]' : 'h-[560px] sm:h-[620px]',
           )}
         >
-          <div className="mb-3 flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <div className="inline-flex items-center gap-2">
-                <Trophy className="h-4 w-4 text-primary" />
-                <h3 className={panelTitleClass}>Editor Leaderboard ({monthLabel(currentMonthYear)})</h3>
-              </div>
-              <p className="mt-0.5 text-xs text-muted-foreground">
-                Ranked by editor actions this month (open + closed PRs).
-              </p>
-            </div>
-            <div className="inline-flex items-center gap-2">
-              <Link
-                href="/analytics/editors"
-                className="inline-flex items-center gap-1 text-[11px] font-medium text-muted-foreground hover:text-foreground hover:underline"
-              >
-                Explore Editor Leaderboard
-                <ArrowRight className="h-3 w-3" />
-              </Link>
-              <button
-                onClick={downloadLeaderboardDetailedCSV}
-                disabled={downloadingLeaderboard}
-                aria-label="Download editor leaderboard CSV"
-                title="Download editor leaderboard CSV"
-                className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-primary/40 bg-primary/10 text-primary hover:bg-primary/15 disabled:opacity-60"
-              >
-                <Download className="h-3.5 w-3.5" />
-              </button>
-            </div>
-          </div>
-
-          <div className="min-h-0 flex-1 space-y-2 overflow-y-auto p-1 pr-2">
-            {showEditorSkeleton
-              ? Array.from({ length: 6 }).map((_, i) => (
-                  <div key={`editor-skeleton-${i}`} className="rounded-lg border border-border p-2.5">
-                    <div className="mb-2 flex items-center gap-2">
-                      <div className="h-8 w-8 animate-pulse rounded-full bg-muted" />
-                      <div className="flex-1">
-                        <div className="mb-1 h-3 w-24 animate-pulse rounded bg-muted" />
-                        <div className="h-3 w-36 animate-pulse rounded bg-muted" />
-                      </div>
-                    </div>
-                    <div className="h-1.5 animate-pulse rounded-full bg-muted" />
+          <>
+              <div className="mb-3 flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <div className="inline-flex items-center gap-2">
+                    <Trophy className="h-4 w-4 text-primary" />
+                    <h3 className={panelTitleClass}>Editor Leaderboard ({monthLabel(currentMonthYear)})</h3>
                   </div>
-                ))
-              : monthlyEditorRows.length === 0 ? (
-                <div className="flex flex-col items-center justify-center gap-3 py-10 text-center">
-                  <Trophy className="h-10 w-10 text-muted-foreground/40" />
-                  <div>
-                    <p className="text-sm font-medium text-muted-foreground">No editor activity yet</p>
-                    <p className="mt-1 text-xs text-muted-foreground/70">
-                      Editor actions for {monthLabel(currentMonthYear)} will appear here as PRs are reviewed.
-                    </p>
-                  </div>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    Ranked by editor actions this month (open + closed PRs).
+                  </p>
                 </div>
-              )
-              : monthlyEditorRows.map((row, idx) => (
-                  <div
-                    key={`editor-${row.actor}`}
-                    className={`rounded-lg px-2.5 py-2.5 border ${idx === 0 ? 'bg-primary/10 border-primary/30' : 'bg-muted/40 border-border'}`}
+                <div className="inline-flex items-center gap-2">
+                  <Link
+                    href="/analytics/editors"
+                    className="inline-flex items-center gap-1 text-[11px] font-medium text-muted-foreground hover:text-foreground hover:underline"
                   >
-                    <div className="mb-2 flex items-center justify-between gap-2">
-                      <div className="flex min-w-0 items-center gap-2">
-                        <div className="h-8 w-8 shrink-0 rounded-full bg-background/80 p-[1.5px] ring-1 ring-border">
-                          <div className="h-full w-full overflow-hidden rounded-full">
-                            <Image
-                              src={editorAvatar(row.actor)}
-                              alt={row.actor}
-                              width={32}
-                              height={32}
-                              className="h-full w-full object-cover object-center"
-                            />
+                    Explore Editor Leaderboard
+                    <ArrowRight className="h-3 w-3" />
+                  </Link>
+                  <button
+                    onClick={downloadLeaderboardDetailedCSV}
+                    disabled={downloadingLeaderboard}
+                    aria-label="Download editor leaderboard CSV"
+                    title="Download editor leaderboard CSV"
+                    className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-primary/40 bg-primary/10 text-primary hover:bg-primary/15 disabled:opacity-60"
+                  >
+                    <Download className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              </div>
+
+              <div className="min-h-0 flex-1 space-y-2 overflow-y-auto p-1 pr-2">
+                {showEditorSkeleton
+                  ? Array.from({ length: 6 }).map((_, i) => (
+                      <div key={`editor-skeleton-${i}`} className="rounded-lg border border-border p-2.5">
+                        <div className="mb-2 flex items-center gap-2">
+                          <div className="h-8 w-8 animate-pulse rounded-full bg-muted" />
+                          <div className="flex-1">
+                            <div className="mb-1 h-3 w-24 animate-pulse rounded bg-muted" />
+                            <div className="h-3 w-36 animate-pulse rounded bg-muted" />
                           </div>
                         </div>
-                        <div className="min-w-0">
-                          <p className="truncate text-sm font-medium text-foreground">#{idx + 1} {row.actor}</p>
-                          <p className="text-xs text-muted-foreground">{row.totalActions} actions across {row.prsTouched} PRs</p>
+                        <div className="h-1.5 animate-pulse rounded-full bg-muted" />
+                      </div>
+                    ))
+                  : monthlyEditorRows.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center gap-3 py-10 text-center">
+                      <Trophy className="h-10 w-10 text-muted-foreground/40" />
+                      <div>
+                        <p className="text-sm font-medium text-muted-foreground">No editor activity yet</p>
+                        <p className="mt-1 text-xs text-muted-foreground/70">
+                          Editor actions for {monthLabel(currentMonthYear)} will appear here as PRs are reviewed.
+                        </p>
+                      </div>
+                    </div>
+                  )
+                  : monthlyEditorRows.map((row, idx) => (
+                      <div
+                        key={`editor-${row.actor}`}
+                        className={`rounded-lg px-2.5 py-2.5 border ${idx === 0 ? 'bg-primary/10 border-primary/30' : 'bg-muted/40 border-border'}`}
+                      >
+                        <div className="mb-2 flex items-center justify-between gap-2">
+                          <div className="flex min-w-0 items-center gap-2">
+                            <div className="h-8 w-8 shrink-0 rounded-full bg-background/80 p-[1.5px] ring-1 ring-border">
+                              <div className="h-full w-full overflow-hidden rounded-full">
+                                <Image
+                                  src={editorAvatar(row.actor)}
+                                  alt={row.actor}
+                                  width={32}
+                                  height={32}
+                                  className="h-full w-full object-cover object-center"
+                                />
+                              </div>
+                            </div>
+                            <div className="min-w-0">
+                              <p className="truncate text-sm font-medium text-foreground">#{idx + 1} {row.actor}</p>
+                              <p className="text-xs text-muted-foreground">{row.totalActions} actions across {row.prsTouched} PRs</p>
+                            </div>
+                          </div>
+                          <span className="ml-2 min-w-[2.5ch] shrink-0 text-right text-sm leading-tight font-semibold tabular-nums text-primary">
+                            {row.totalActions}
+                          </span>
+                        </div>
+                        <div className="h-1.5 overflow-hidden rounded-full bg-muted/80">
+                          <div
+                            className="h-full bg-primary transition-all duration-300"
+                            style={{ width: `${row.totalActions > 0 ? Math.max(8, (row.totalActions / maxEditor) * 100) : 0}%` }}
+                          />
                         </div>
                       </div>
-                      <span className="ml-2 min-w-[2.5ch] shrink-0 text-right text-sm leading-tight font-semibold tabular-nums text-primary">
-                        {row.totalActions}
-                      </span>
-                    </div>
-                    <div className="h-1.5 overflow-hidden rounded-full bg-muted/80">
-                      <div
-                        className="h-full bg-primary transition-all duration-300"
-                        style={{ width: `${row.totalActions > 0 ? Math.max(8, (row.totalActions / maxEditor) * 100) : 0}%` }}
-                      />
-                    </div>
-                  </div>
-                ))}
-          </div>
+                    ))}
+              </div>
 
-          <div className="mt-3 flex items-center justify-between gap-2 border-t border-border/70 pt-3">
-            {monthlyLeaderboardUpdatedAt ? (
-              <LastUpdated
-                timestamp={monthlyLeaderboardUpdatedAt}
-                prefix="Updated"
-                showAbsolute
-                className="bg-muted/40 text-xs"
-              />
-            ) : (
-              <span className="rounded-md bg-muted/40 px-2.5 py-1 text-xs text-muted-foreground">
-                No editor activity recorded for this period
-              </span>
-            )}
-            <span className="text-xs text-muted-foreground">
-              Monthly editor activity snapshot
-            </span>
-          </div>
+              <div className="mt-3 flex items-center justify-between gap-2 border-t border-border/70 pt-3">
+                {monthlyLeaderboardUpdatedAt ? (
+                  <LastUpdated
+                    timestamp={monthlyLeaderboardUpdatedAt}
+                    prefix="Updated"
+                    showAbsolute
+                    className="bg-muted/40 text-xs"
+                  />
+                ) : (
+                  <span className="rounded-md bg-muted/40 px-2.5 py-1 text-xs text-muted-foreground">
+                    No editor activity recorded for this period
+                  </span>
+                )}
+                <span className="text-xs text-muted-foreground">
+                  Monthly editor activity snapshot
+                </span>
+              </div>
+          </>
         </div>
       </div>
 
@@ -3301,9 +3653,12 @@ export default function EIPsHomePage() {
       <section className="mb-6 w-full" id="recent-governance-activity">
         <div className="mb-4 flex flex-col items-start gap-2 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <h2 className={sectionTitleClass}>
-              {(activePersona === 'developer' || activePersona === 'builder') ? 'Recent Activity' : 'Recent Governance Activity'}
-            </h2>
+            <div className="inline-flex items-center gap-2">
+              <h2 className={sectionTitleClass}>
+                {(activePersona === 'developer' || activePersona === 'builder') ? 'Recent Activity' : 'Recent Governance Activity'}
+              </h2>
+              <CopyLinkButton sectionId="recent-governance-activity" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
+            </div>
             <p className={sectionSubtitleClass}>
               {(activePersona === 'developer' || activePersona === 'builder')
                 ? 'Latest governance and PR movement with actor context and proposal links.'
@@ -3311,7 +3666,13 @@ export default function EIPsHomePage() {
             </p>
           </div>
           <div className="flex items-center gap-2">
-            <CopyLinkButton sectionId="recent-governance-activity" className="h-8 w-8 rounded-md" />
+            <Link
+              href="/analytics/prs"
+              className="inline-flex h-8 items-center justify-center gap-1 whitespace-nowrap rounded-md border border-primary/30 bg-primary/10 px-2.5 text-xs font-medium text-primary transition-colors hover:bg-primary/15"
+            >
+              Explore PR Analytics
+              <ArrowRight className="h-3 w-3" />
+            </Link>
           </div>
         </div>
         <div className="grid gap-4 lg:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)]">
@@ -3438,15 +3799,6 @@ export default function EIPsHomePage() {
             </div>
           </aside>
         </div>
-        <div className="mt-3 flex justify-center">
-          <Link
-            href="/analytics/prs"
-            className="inline-flex h-8 items-center justify-center gap-1 whitespace-nowrap rounded-md border border-primary/30 bg-primary/10 px-2.5 text-xs font-medium text-primary transition-colors hover:bg-primary/15"
-          >
-            Explore PR Analytics
-            <ArrowRight className="h-3 w-3" />
-          </Link>
-        </div>
       </section>
 
       </div>
@@ -3456,7 +3808,11 @@ export default function EIPsHomePage() {
         style={activePersona === 'editor' ? undefined : { order: sectionOrder.social }}
         className={cn(activePersona === 'editor' && 'border-t border-border/70 pt-6')}
       >
-        <SocialCommunityUpdates showCommunityResources={activePersona !== 'editor'} />
+        <SocialCommunityUpdates
+          showCommunityResources={activePersona !== 'editor'}
+          sectionTitleClass={sectionTitleClass}
+          sectionSubtitleClass={sectionSubtitleClass}
+        />
       </section>
       )}
       {visibleSections.social && activePersona === 'builder' && (
@@ -3467,10 +3823,12 @@ export default function EIPsHomePage() {
         >
           <div className="mb-3 flex items-start justify-between gap-3">
             <div>
-              <h2 className={sectionTitleClass}>Practical Resources</h2>
+              <div className="inline-flex items-center gap-2">
+                <h2 className={sectionTitleClass}>Practical Resources</h2>
+                <CopyLinkButton sectionId="builder-practical-resources" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
+              </div>
               <p className={sectionSubtitleClass}>Documentation and references to contribute effectively.</p>
             </div>
-            <CopyLinkButton sectionId="builder-practical-resources" className="h-8 w-8 rounded-md" />
           </div>
           <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
             {[

--- a/src/app/analytics/editors/page.tsx
+++ b/src/app/analytics/editors/page.tsx
@@ -1005,17 +1005,15 @@ export default function EditorsAnalyticsPage() {
         </div>
       )}
 
-      <section
-        id="editor-leaderboard-hero"
-        className="rounded-xl border border-border bg-card/60 p-4 backdrop-blur-sm sm:p-5"
-      >
-        <div className="mb-4 flex items-center justify-between gap-3">
-          <div>
+      <section id="editor-leaderboard-hero" className="space-y-3 border-b border-border/70 pb-6">
+        <div>
+          <div className="inline-flex items-center gap-2">
             <h2 className="dec-title text-xl font-semibold tracking-tight text-foreground sm:text-2xl">Editors - {leaderboardLabel}</h2>
-            <p className="mt-0.5 text-xs text-muted-foreground">Ranked by actions with PR coverage context.</p>
+            <CopyLinkButton sectionId="editor-leaderboard-hero" className="h-8 w-8 rounded-md border border-border bg-muted/60 hover:border-primary/40 hover:bg-primary/10" />
           </div>
-          <CopyLinkButton sectionId="editor-leaderboard-hero" className="h-8 w-8 rounded-md border border-border bg-muted/60 hover:border-primary/40 hover:bg-primary/10" />
+          <p className="mt-0.5 text-xs text-muted-foreground">Ranked by actions with PR coverage context.</p>
         </div>
+        <div className="rounded-xl border border-border bg-card/60 p-4 backdrop-blur-sm sm:p-5">
         <div className="mb-3 flex flex-wrap items-center gap-2">
           <div className="inline-flex items-center gap-1 rounded-md border border-border bg-muted/60 p-0.5 text-xs">
             <button
@@ -1084,8 +1082,17 @@ export default function EditorsAnalyticsPage() {
           <span>EIPsInsight.com</span>
           <LastUpdated timestamp={dataUpdatedAt} className="text-xs" />
         </div>
+        </div>
       </section>
 
+      <section id="editor-snapshot" className="space-y-3 border-b border-border/70 pb-6">
+        <div>
+          <div className="inline-flex items-center gap-2">
+            <h2 className="dec-title text-xl font-semibold tracking-tight text-foreground sm:text-2xl">Editor Snapshot</h2>
+            <CopyLinkButton sectionId="editor-snapshot" className="h-8 w-8 rounded-md border border-border bg-muted/60 hover:border-primary/40 hover:bg-primary/10" />
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">Coverage, participation, and response metrics in this scope.</p>
+        </div>
       <div className="rounded-xl border border-border/70 bg-card/60 p-4 backdrop-blur-sm sm:p-5">
         <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
           <div className="rounded-lg border border-border/60 bg-background/35 p-4">
@@ -1141,12 +1148,20 @@ export default function EditorsAnalyticsPage() {
           Inactive editors: {inactiveEditorList.length}
         </div>
       </div>
+      </section>
 
+      <section id="editor-trends" className="space-y-3 border-b border-border/70 pb-6">
+        <div>
+          <div className="inline-flex items-center gap-2">
+            <h2 className="dec-title text-xl font-semibold tracking-tight text-foreground sm:text-2xl">Editorial Trends</h2>
+            <CopyLinkButton sectionId="editor-trends" className="h-8 w-8 rounded-md border border-border bg-muted/60 hover:border-primary/40 hover:bg-primary/10" />
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">{trendMetricMeta(trendPrimaryMetric).subtitle}</p>
+        </div>
       <div className="rounded-xl border border-border/70 bg-card/60 p-5 backdrop-blur-sm">
         <div className="mb-3 flex items-center justify-between gap-3">
           <div>
-            <h2 className="text-lg font-semibold text-foreground">{trendMetricMeta(trendPrimaryMetric).title}</h2>
-            <p className="mt-0.5 text-xs text-muted-foreground">{trendMetricMeta(trendPrimaryMetric).subtitle}</p>
+            <h3 className="text-lg font-semibold text-foreground">{trendMetricMeta(trendPrimaryMetric).title}</h3>
           </div>
           <div className="flex items-center gap-2">
             <div className="inline-flex rounded-md border border-border bg-muted/30 p-0.5">
@@ -1182,11 +1197,17 @@ export default function EditorsAnalyticsPage() {
           <LastUpdated timestamp={dataUpdatedAt} className="text-xs" />
         </div>
       </div>
+      </section>
 
-      <div className="rounded-xl border border-border/70 bg-card/60 p-5 backdrop-blur-sm">
-        <div className="mb-4">
-          <h2 className="dec-title text-xl font-semibold tracking-tight text-foreground sm:text-2xl">Top Active Editors</h2>
+      <section id="top-active-editors" className="space-y-3 border-b border-border/70 pb-6">
+        <div>
+          <div className="inline-flex items-center gap-2">
+            <h2 className="dec-title text-xl font-semibold tracking-tight text-foreground sm:text-2xl">Top Active Editors</h2>
+            <CopyLinkButton sectionId="top-active-editors" className="h-8 w-8 rounded-md border border-border bg-muted/60 hover:border-primary/40 hover:bg-primary/10" />
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">Most active official editors for the selected scope.</p>
         </div>
+      <div className="rounded-xl border border-border/70 bg-card/60 p-5 backdrop-blur-sm">
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
           {topEditorCards.map((editor) => {
             const categories = (categoriesByActor[editor.actor] || []).slice(0, 2);
@@ -1255,12 +1276,20 @@ export default function EditorsAnalyticsPage() {
           )}
         </div>
       </div>
+      </section>
 
+      <section id="editor-category-coverage" className="space-y-3 border-b border-border/70 pb-6">
+        <div>
+          <div className="inline-flex items-center gap-2">
+            <h2 className="dec-title text-xl font-semibold tracking-tight text-foreground sm:text-2xl">Category Coverage</h2>
+            <CopyLinkButton sectionId="editor-category-coverage" className="h-8 w-8 rounded-md border border-border bg-muted/60 hover:border-primary/40 hover:bg-primary/10" />
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">Who covers what and where concentration risk appears.</p>
+        </div>
       <div className="rounded-xl border border-border/70 bg-card/60 p-5 backdrop-blur-sm">
         <div className="mb-3 flex items-center justify-between gap-3">
           <div>
-            <h2 className="text-lg font-semibold text-foreground">Category Coverage</h2>
-            <p className="mt-0.5 text-xs text-muted-foreground">Who covers what and where concentration risk appears.</p>
+            <h3 className="text-lg font-semibold text-foreground">Coverage Matrix</h3>
           </div>
           <button onClick={downloadCoverageReport} className="inline-flex items-center gap-1 rounded-md border border-border bg-muted/40 px-2.5 py-1 text-xs text-foreground/85 hover:bg-muted/60">
             <Download className="h-3.5 w-3.5" />
@@ -1303,16 +1332,24 @@ export default function EditorsAnalyticsPage() {
           <LastUpdated timestamp={dataUpdatedAt} className="text-xs" />
         </div>
       </div>
+      </section>
 
       {/* Editor Directory */}
+      <section id="editor-activity-directory" className="space-y-3 border-b border-border/70 pb-6">
+        <div>
+          <div className="inline-flex items-center gap-2">
+            <h2 className="dec-title text-xl font-semibold tracking-tight text-foreground sm:text-2xl">Editor Activity Directory</h2>
+            <CopyLinkButton sectionId="editor-activity-directory" className="h-8 w-8 rounded-md border border-border bg-muted/60 hover:border-primary/40 hover:bg-primary/10" />
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">Who is doing the work in this scope.</p>
+        </div>
       <div className="rounded-xl border border-border/70 bg-card/60 p-5 backdrop-blur-sm">
         <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
           <div className="flex flex-col gap-1">
-            <h2 className="text-xl font-semibold text-foreground">
-              Editor Activity Directory
+            <h3 className="text-xl font-semibold text-foreground">
+              Directory Table
               <span className="ml-2 text-sm font-normal text-muted-foreground">— {leaderboardLabel}</span>
-            </h2>
-            <p className="text-xs text-muted-foreground">Who is doing the work in this scope.</p>
+            </h3>
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <select
@@ -1458,13 +1495,22 @@ export default function EditorsAnalyticsPage() {
           </table>
         </div>
       </div>
+      </section>
 
       {/* Daily + Repo */}
+      <section id="editor-operations" className="space-y-3 border-b border-border/70 pb-6">
+        <div>
+          <div className="inline-flex items-center gap-2">
+            <h2 className="dec-title text-xl font-semibold tracking-tight text-foreground sm:text-2xl">Operational Breakdown</h2>
+            <CopyLinkButton sectionId="editor-operations" className="h-8 w-8 rounded-md border border-border bg-muted/60 hover:border-primary/40 hover:bg-primary/10" />
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">Daily throughput and repository concentration.</p>
+        </div>
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-        <div className="lg:col-span-2 rounded-lg border border-border/70 bg-card/60 p-4 backdrop-blur-sm">
-          <div className="mb-3 flex items-center justify-between gap-3">
+        <div className="space-y-2 lg:col-span-2">
+          <div className="flex items-center justify-between gap-3">
             <div>
-              <h2 className="text-lg font-semibold text-foreground">Daily Editorial Activity</h2>
+              <h3 className="text-lg font-semibold text-foreground">Daily Editorial Activity</h3>
               <p className="mt-0.5 text-xs text-muted-foreground">Which editors drove activity day by day.</p>
             </div>
             <button onClick={downloadDailyActivityReport} className="inline-flex items-center gap-1 rounded-md border border-border bg-muted/40 px-2.5 py-1 text-xs text-foreground/85 hover:bg-muted/60">
@@ -1472,6 +1518,7 @@ export default function EditorsAnalyticsPage() {
               Download Reports
             </button>
           </div>
+        <div className="rounded-lg border border-border/70 bg-card/60 p-4 backdrop-blur-sm">
           <div className="relative h-64 w-full">
             <ReactECharts option={dailyActivityOption} style={{ height: "100%", width: "100%" }} opts={{ renderer: "svg" }} notMerge />
             <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
@@ -1485,11 +1532,12 @@ export default function EditorsAnalyticsPage() {
             <LastUpdated timestamp={dataUpdatedAt} className="text-xs" />
           </div>
         </div>
+        </div>
 
-        <div className="rounded-lg border border-border/70 bg-card/60 p-4 backdrop-blur-sm">
-          <div className="mb-4 flex items-center justify-between gap-3">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-3">
             <div>
-              <h2 className="text-lg font-semibold text-foreground">Repo Distribution</h2>
+              <h3 className="text-lg font-semibold text-foreground">Repo Distribution</h3>
               <p className="mt-0.5 text-xs text-muted-foreground">Where editor work is concentrated.</p>
             </div>
             <button onClick={downloadRepoDistributionReport} className="inline-flex items-center gap-1 rounded-md border border-border bg-muted/40 px-2.5 py-1 text-xs text-foreground/85 hover:bg-muted/60">
@@ -1497,6 +1545,7 @@ export default function EditorsAnalyticsPage() {
               Download Reports
             </button>
           </div>
+        <div className="rounded-lg border border-border/70 bg-card/60 p-4 backdrop-blur-sm">
           <div className="relative h-64 w-full">
             <ReactECharts option={repoOption} style={{ height: "100%", width: "100%" }} opts={{ renderer: "svg" }} notMerge />
             <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
@@ -1507,13 +1556,19 @@ export default function EditorsAnalyticsPage() {
             <LastUpdated timestamp={dataUpdatedAt} className="text-xs" />
           </div>
         </div>
-      </div>
-
-      <div className="rounded-xl border border-border/70 bg-card/60 backdrop-blur-sm">
-        <div className="border-b border-border/70 px-5 py-4">
-          <h2 className="text-sm font-semibold uppercase tracking-wider text-foreground">Recent Activities</h2>
-          <p className="mt-1 text-sm text-muted-foreground">Live feed</p>
         </div>
+      </div>
+      </section>
+
+      <section id="editor-recent-activity" className="space-y-3 border-b border-border/70 pb-6">
+        <div>
+          <div className="inline-flex items-center gap-2">
+            <h2 className="dec-title text-xl font-semibold tracking-tight text-foreground sm:text-2xl">Recent Activities</h2>
+            <CopyLinkButton sectionId="editor-recent-activity" className="h-8 w-8 rounded-md border border-border bg-muted/60 hover:border-primary/40 hover:bg-primary/10" />
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">Live feed with repository/editor/action filters.</p>
+        </div>
+      <div className="rounded-xl border border-border/70 bg-card/60 backdrop-blur-sm">
         <div className="border-b border-border/70 px-5 py-3">
           <div className="grid grid-cols-1 gap-2 md:grid-cols-3">
             <select
@@ -1640,6 +1695,7 @@ export default function EditorsAnalyticsPage() {
           </div>
         )}
       </div>
+      </section>
 
       <div className="rounded-xl border border-border/60 bg-muted/30 p-3.5 backdrop-blur-sm">
         <div className="flex flex-wrap items-center gap-2">

--- a/src/app/tools/board/page.tsx
+++ b/src/app/tools/board/page.tsx
@@ -140,6 +140,8 @@ export default function BoardPage() {
   const [showInfo, setShowInfo] = useState(false);
   const [data, setData] = useState<BoardData | null>(null);
   const [stats, setStats] = useState<StatsData | null>(null);
+  const [csvExporting, setCsvExporting] = useState(false);
+  const [mdExporting, setMdExporting] = useState(false);
 
   const typedRepo = repo || undefined;
 
@@ -219,11 +221,47 @@ export default function BoardPage() {
 
   const csvEscape = (value: string | number | null | undefined) => `"${String(value ?? "").replaceAll(`"`, `""`)}` + `"`;
 
-  const downloadCSV = () => {
-    if (!rows.length) return;
+  const getAllFilteredRows = async (): Promise<PRRow[]> => {
+    const exportPageSize = 500;
+    const firstPage = await client.tools.getOpenPRBoard({
+      repo: typedRepo,
+      govState: selectedGovStates.length ? selectedGovStates : undefined,
+      processType: selectedProcessTypes.length ? selectedProcessTypes : undefined,
+      search: search || undefined,
+      page: 1,
+      pageSize: exportPageSize,
+    });
+
+    let exportRows = firstPage.rows ?? [];
+    if ((firstPage.totalPages ?? 1) > 1) {
+      const remainingPages = await Promise.all(
+        Array.from({ length: firstPage.totalPages - 1 }, (_, idx) =>
+          client.tools.getOpenPRBoard({
+            repo: typedRepo,
+            govState: selectedGovStates.length ? selectedGovStates : undefined,
+            processType: selectedProcessTypes.length ? selectedProcessTypes : undefined,
+            search: search || undefined,
+            page: idx + 2,
+            pageSize: exportPageSize,
+          }),
+        ),
+      );
+      exportRows = exportRows.concat(remainingPages.flatMap((pageData) => pageData.rows ?? []));
+    }
+
+    return exportRows;
+  };
+
+  const downloadCSV = async () => {
+    if (csvExporting) return;
+    setCsvExporting(true);
+    try {
+      const exportRows = await getAllFilteredRows();
+      if (!exportRows.length) return;
+
     const headers = ["Month", "Repo", "Process", "Participants", "PRNumber", "PRLink", "Title", "Author", "CreatedAt", "Labels"];
     const lines = [headers.join(",")];
-    rows.forEach((row) => {
+    exportRows.forEach((row) => {
       const repoName = row.repo.split("/")[1] ?? row.repo;
       const prLink = `https://github.com/${row.repo}/pull/${row.prNumber}`;
       const values = [
@@ -250,38 +288,51 @@ export default function BoardPage() {
     a.remove();
     URL.revokeObjectURL(url);
     toast.success("CSV downloaded", {
-      description: `${rows.length} PR rows exported.`,
+      description: `${exportRows.length} PR rows exported.`,
     });
+    } catch (err) {
+      console.error("CSV export failed:", err);
+      toast.error("Failed to export CSV");
+    } finally {
+      setCsvExporting(false);
+    }
   };
 
   const copyAsMarkdown = async () => {
-    if (!rows.length) return;
-    const grouped = new Map<string, PRRow[]>();
-    rows.forEach((row) => {
-      const process = row.processType || "Other";
-      if (!grouped.has(process)) grouped.set(process, []);
-      grouped.get(process)!.push(row);
-    });
-    const order = PROCESS_ORDER.concat([...grouped.keys()].filter((p) => !PROCESS_ORDER.includes(p)));
-    let markdown = `## Open PR Board — ${monthLabel}\n\n`;
-    for (const process of order) {
-      const sectionRows = grouped.get(process);
-      if (!sectionRows?.length) continue;
-      markdown += `### ${process}\n`;
-      sectionRows.forEach((row) => {
-        const title = (row.title ?? "Untitled").replace(/\]/g, "\\]");
-        const url = `https://github.com/${row.repo}/pull/${row.prNumber}`;
-        markdown += `- [${title} #${row.prNumber}](${url}) — ${row.govState}\n`;
-      });
-      markdown += "\n";
-    }
+    if (mdExporting) return;
+    setMdExporting(true);
     try {
+      const exportRows = await getAllFilteredRows();
+      if (!exportRows.length) return;
+      const grouped = new Map<string, PRRow[]>();
+      exportRows.forEach((row) => {
+        const process = row.processType || "Other";
+        if (!grouped.has(process)) grouped.set(process, []);
+        grouped.get(process)!.push(row);
+      });
+
+      const order = PROCESS_ORDER.concat([...grouped.keys()].filter((p) => !PROCESS_ORDER.includes(p)));
+      let markdown = `## Open PR Board — ${monthLabel}\n\n`;
+      for (const process of order) {
+        const sectionRows = grouped.get(process);
+        if (!sectionRows?.length) continue;
+        markdown += `### ${process}\n`;
+        sectionRows.forEach((row) => {
+          const title = (row.title ?? "Untitled").replace(/\]/g, "\\]");
+          const url = `https://github.com/${row.repo}/pull/${row.prNumber}`;
+          markdown += `- [${title} #${row.prNumber}](${url}) — ${row.govState}\n`;
+        });
+        markdown += "\n";
+      }
+
       await navigator.clipboard.writeText(markdown.trim());
       toast.success("Copied as markdown", {
-        description: `${rows.length} PRs copied to clipboard.`,
+        description: `${exportRows.length} PRs copied to clipboard.`,
       });
     } catch {
       toast.error("Failed to copy markdown");
+    } finally {
+      setMdExporting(false);
     }
   };
 
@@ -475,8 +526,8 @@ export default function BoardPage() {
               Showing <span className="text-foreground">{startIdx}–{endIdx}</span> of <span className="text-foreground">{totalMatching.toLocaleString()}</span> PRs
             </p>
             <div className="flex flex-wrap items-center gap-2">
-              <button onClick={downloadCSV} disabled={!rows.length || loading} className="inline-flex h-8 items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-2.5 text-xs text-primary transition-colors hover:bg-primary/15 disabled:cursor-not-allowed disabled:opacity-50">Download CSV</button>
-              <button onClick={copyAsMarkdown} disabled={!rows.length || loading} className="inline-flex h-8 items-center gap-1 rounded-md border border-border bg-muted/60 px-2.5 text-xs text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50">Copy as MD</button>
+              <button onClick={downloadCSV} disabled={!rows.length || loading || csvExporting} className="inline-flex h-8 items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-2.5 text-xs text-primary transition-colors hover:bg-primary/15 disabled:cursor-not-allowed disabled:opacity-50">{csvExporting ? "Exporting..." : "Download CSV"}</button>
+              <button onClick={copyAsMarkdown} disabled={!rows.length || loading || mdExporting} className="inline-flex h-8 items-center gap-1 rounded-md border border-border bg-muted/60 px-2.5 text-xs text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50">{mdExporting ? "Copying..." : "Copy as MD"}</button>
               <button onClick={copyFilterLink} className="inline-flex h-8 items-center gap-1 rounded-md border border-border bg-muted/60 px-2.5 text-xs text-foreground transition-colors hover:bg-muted">Copy link</button>
             </div>
           </div>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -5,7 +5,15 @@ import { Copy, Check, Activity, Sparkles, TrendingUp, BarChart3 } from 'lucide-r
 import { useState } from 'react';
 import { motion } from 'motion/react';
 
-export function CopyLinkButton({ sectionId, className }: { sectionId: string; className?: string }) {
+export function CopyLinkButton({
+  sectionId,
+  className,
+  tooltipLabel = 'Copy section link',
+}: {
+  sectionId: string;
+  className?: string;
+  tooltipLabel?: string;
+}) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
@@ -27,8 +35,8 @@ export function CopyLinkButton({ sectionId, className }: { sectionId: string; cl
         'transition-colors hover:border-primary/40 hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
         className
       )}
-      title="Copy section link"
-      aria-label="Copy section link"
+      title={tooltipLabel}
+      aria-label={tooltipLabel}
       type="button"
     >
       {copied ? (

--- a/src/server/orpc/procedures/analytics.ts
+++ b/src/server/orpc/procedures/analytics.ts
@@ -4557,6 +4557,7 @@ export const analyticsProcedures = {
       from: z.string().optional(),
       to: z.string().optional(),
       actor: z.string().optional(),
+      detailsOnly: z.boolean().optional(),
     }))
     .handler(async ({ context, input }) => {
       await requireTier(context, 'pro');
@@ -4629,13 +4630,31 @@ export const analyticsProcedures = {
 
       const detailRows = [
         '',
-        'Editor,PR Number,Repository,Occurred At,Action Type',
+        'Editor,PR Number,Repository,Occurred At,Action Type,PR Link',
         ...details.map((r) =>
-          [r.actor, r.pr_number, r.repo_name ?? '', r.occurred_at, r.action_type].map(escape).join(',')
+          [
+            r.actor,
+            r.pr_number,
+            r.repo_name ?? '',
+            r.occurred_at,
+            r.action_type,
+            r.repo_name ? `https://github.com/${r.repo_name}/pull/${r.pr_number}` : '',
+          ].map(escape).join(',')
         ),
       ];
 
-      const csv = [...summaryRows, ...detailRows].join('\n');
+      const csv = input.detailsOnly
+        ? ['Editor,PR Number,Repository,Occurred At,Action Type,PR Link', ...details.map((r) =>
+            [
+              r.actor,
+              r.pr_number,
+              r.repo_name ?? '',
+              r.occurred_at,
+              r.action_type,
+              r.repo_name ? `https://github.com/${r.repo_name}/pull/${r.pr_number}` : '',
+            ].map(escape).join(',')
+          )].join('\n')
+        : [...summaryRows, ...detailRows].join('\n');
       const monthLabel = input.from
         ? `${input.from.slice(0, 7)}`
         : new Date().toISOString().slice(0, 7);


### PR DESCRIPTION
This pull request focuses on improving the UI/UX and structure of the editor analytics and homepage persona sections. The main changes include enhanced section headers with copy-link functionality for easier navigation, improved visual grouping and layout consistency, new export/reporting features, and updated or reorganized content blocks for clarity and polish.

**UI/UX Improvements and Section Structure:**

* All major sections on the editor analytics page (`/analytics/editors`) and homepage persona panels now use consistent, prominent headers with inline copy-link buttons for better navigation and sharing. New section containers and spacing improve readability and visual hierarchy. [[1]](diffhunk://#diff-9bb64009dceca141115a78c960c8fb407dbc757e5640c2ce893c84fa9560c857L1008-R1016) [[2]](diffhunk://#diff-9bb64009dceca141115a78c960c8fb407dbc757e5640c2ce893c84fa9560c857R1085-R1095) [[3]](diffhunk://#diff-9bb64009dceca141115a78c960c8fb407dbc757e5640c2ce893c84fa9560c857R1151-R1164) [[4]](diffhunk://#diff-9bb64009dceca141115a78c960c8fb407dbc757e5640c2ce893c84fa9560c857R1200-R1210) [[5]](diffhunk://#diff-9bb64009dceca141115a78c960c8fb407dbc757e5640c2ce893c84fa9560c857R1279-R1292) [[6]](diffhunk://#diff-9bb64009dceca141115a78c960c8fb407dbc757e5640c2ce893c84fa9560c857R1335-R1352) [[7]](diffhunk://#diff-f672a730f0286b42a8181c9fbb5c5fd0e9d98438d10ba1fe99ee4da81c658c44R58-R61) [[8]](diffhunk://#diff-d8be64873b22c84e94257239bf57191180f40577ce2d681cb703ef9ab73eeb8cR187-R206) [[9]](diffhunk://#diff-d8be64873b22c84e94257239bf57191180f40577ce2d681cb703ef9ab73eeb8cL193-L200)
* Section headers and action buttons (such as "Explore Board" and "Explore PR Analytics") are now grouped inline with the section titles, improving discoverability and reducing visual clutter. [[1]](diffhunk://#diff-f672a730f0286b42a8181c9fbb5c5fd0e9d98438d10ba1fe99ee4da81c658c44L74-R83) [[2]](diffhunk://#diff-c79cae646d8da699c595b18431c0be226913eea7f4eeee308cafdf5dd22d83a2R66-R160)

**Export and Reporting Features:**

* Added a "Download board report CSV" button to the Editor Review Queue section, allowing users to export open PRs data as a CSV, with proper handling for pagination and loading state.

**Content and Data Updates:**

* The Social & Community Updates section now sorts discussions to prioritize "hot" topics and those with more replies, and includes several new community discussions for increased relevance. [[1]](diffhunk://#diff-d8be64873b22c84e94257239bf57191180f40577ce2d681cb703ef9ab73eeb8cR75-R107) [[2]](diffhunk://#diff-d8be64873b22c84e94257239bf57191180f40577ce2d681cb703ef9ab73eeb8cL231-R278)
* The homepage Editor Persona section introduces a new "Editors – Contributions" block after Quick Access, mirroring the leaderboard hero pattern and embedding a stacked repository breakdown.

**Changelog and Documentation:**

* Updated the UI changelog (`docs/ui-changelog.md`) to reflect these homepage and editor analytics improvements, ensuring documentation is current with the latest changes.

**Code Cleanup and Refactoring:**

* Removed redundant or relocated action buttons and improved prop usage for section title/subtitle class names, increasing maintainability and consistency. [[1]](diffhunk://#diff-f672a730f0286b42a8181c9fbb5c5fd0e9d98438d10ba1fe99ee4da81c658c44L155-L163) [[2]](diffhunk://#diff-c79cae646d8da699c595b18431c0be226913eea7f4eeee308cafdf5dd22d83a2L224-L232) [[3]](diffhunk://#diff-d8be64873b22c84e94257239bf57191180f40577ce2d681cb703ef9ab73eeb8cR187-R206)

Let me know if you have questions about any of these changes or want to dive deeper into a particular section!