### PR TITLE
Fix board view queries to exclude specific typo PRs

### DIFF
--- a/src/server/orpc/procedures/tools.ts
+++ b/src/server/orpc/procedures/tools.ts
@@ -410,6 +410,11 @@ const { repo, govState, processType, search, page, pageSize } = input;
             ON p.pr_number = gs.pr_number AND p.repository_id = gs.repository_id
           WHERE p.state = 'open'
             AND ($1::text IS NULL OR LOWER(SPLIT_PART(r.name, '/', 2)) = LOWER($1))
+            -- TEMPORARY: hide specific typo PRs from board view. REVERT: remove the AND NOT block below.
+            AND NOT (
+              (LOWER(SPLIT_PART(r.name, '/', 2)) = 'ercs' AND p.pr_number IN (1123, 1191, 1232, 1257, 1254))
+              OR (LOWER(SPLIT_PART(r.name, '/', 2)) = 'eips' AND p.pr_number IN (10171, 11159, 11286))
+            )
         ),
         filtered AS (
           SELECT * FROM base
@@ -483,6 +488,11 @@ const { repo, govState, search } = input;
             ON p.pr_number = gs.pr_number AND p.repository_id = gs.repository_id
           WHERE p.state = 'open'
             AND ($1::text IS NULL OR LOWER(SPLIT_PART(r.name, '/', 2)) = LOWER($1))
+            -- TEMPORARY: hide specific typo PRs. REVERT: remove the AND NOT block below.
+            AND NOT (
+              (LOWER(SPLIT_PART(r.name, '/', 2)) = 'ercs' AND p.pr_number IN (1123, 1191, 1232, 1257, 1254))
+              OR (LOWER(SPLIT_PART(r.name, '/', 2)) = 'eips' AND p.pr_number IN (10171, 11159, 11286))
+            )
         )
         SELECT process_type, COUNT(*)::bigint AS count
         FROM base
@@ -526,6 +536,11 @@ const { repo, govState, search } = input;
           ON p.pr_number = gs.pr_number AND p.repository_id = gs.repository_id
         WHERE p.state = 'open'
           AND ($1::text IS NULL OR LOWER(SPLIT_PART(r.name, '/', 2)) = LOWER($1))
+          -- TEMPORARY: hide specific typo PRs. REVERT: remove the AND NOT block below.
+          AND NOT (
+            (LOWER(SPLIT_PART(r.name, '/', 2)) = 'ercs' AND p.pr_number IN (1123, 1191, 1232, 1257, 1254))
+            OR (LOWER(SPLIT_PART(r.name, '/', 2)) = 'eips' AND p.pr_number IN (10171, 11159, 11286))
+          )
           AND ($2::text IS NULL OR (
             p.pr_number::text LIKE '%' || $2 || '%'
             OR LOWER(COALESCE(p.title, '')) LIKE '%' || LOWER($2) || '%'


### PR DESCRIPTION
This pull request introduces a temporary filter to exclude specific typo-related pull requests from various board and count queries in the `tools.ts` server procedure. The filter is applied to PRs in the `ercs` and `eips` repositories with certain PR numbers, and is clearly marked as a temporary change to be reverted later.

Filtering of typo PRs in board and count queries:

* Added a temporary SQL condition to exclude specific PR numbers from the `ercs` (1123, 1191, 1232, 1257, 1254) and `eips` (10171, 11159, 11286) repositories in the main board view query.
* Applied the same exclusion filter to the PR count aggregation queries to ensure consistency across different endpoints. [[1]](diffhunk://#diff-fc05cff2abe8e6e1321f6b8b9ea2cb104c35afa365cf403014f14de3c9784e6cR491-R495) [[2]](diffhunk://#diff-fc05cff2abe8e6e1321f6b8b9ea2cb104c35afa365cf403014f14de3c9784e6cR539-R543)