### PR TITLE
Refine state filtering and update trend spike normalization

### DIFF
--- a/src/app/analytics/editors/page.tsx
+++ b/src/app/analytics/editors/page.tsx
@@ -152,19 +152,15 @@ function getMonthWindow(year: number, month: number): { from: string; to: string
   };
 }
 
-// TEMPORARY: normalize spike months to prevent visual distortion in the trend charts.
-// Months "2022-08" and "2026-02" had anomalously high counts; capped at 65 per actor.
-// REVERT: remove this function and its call sites in setMonthlyTrend / setMonthlyReviewedTrend.
-const TEMP_NORMALIZE_MONTHS: Record<string, number> = { "2022-08": 65, "2026-02": 65 };
+// TEMPORARY: cap 2022-08 spike at 65 per actor. REVERT: remove this function + call sites.
 function normalizeTrendSpikes(data: MonthlyTrendPoint[]): MonthlyTrendPoint[] {
   return data.map((point) => {
-    const cap = TEMP_NORMALIZE_MONTHS[point.month];
-    if (!cap) return point;
+    if (point.month !== "2022-08") return point;
     const normalized: MonthlyTrendPoint = { month: point.month };
     for (const key of Object.keys(point)) {
       if (key === "month") continue;
       const val = Number(point[key] || 0);
-      normalized[key] = val > cap ? cap : val;
+      normalized[key] = val > 65 ? 65 : val;
     }
     return normalized;
   });
@@ -393,11 +389,14 @@ export default function EditorsAnalyticsPage() {
         ]);
 
         setLeaderboard(leaderboardData.rows);
-        setMonthlyTrend(normalizeTrendSpikes(trendData)); // TEMPORARY: see normalizeTrendSpikes
-        setMonthlyReviewedTrend(normalizeTrendSpikes(reviewedTrendData)); // TEMPORARY: see normalizeTrendSpikes
+        setMonthlyTrend(normalizeTrendSpikes(trendData)); // TEMPORARY
+        setMonthlyReviewedTrend(normalizeTrendSpikes(reviewedTrendData)); // TEMPORARY
         setCategoryCoverage(categoryData);
         setRepoDistribution(repoData);
-        setDailyActivityStacked(dailyStackedData);
+        // TEMPORARY: cap 2022-08-18 spike at 15 per actor. REVERT: revert this line.
+        setDailyActivityStacked(dailyStackedData.map((row) =>
+          row.date === "2022-08-18" ? { ...row, count: Math.min(row.count, 15) } : row
+        ));
         setEditorActionDetails(actionDetails);
         if (leaderboardData.updatedAt) {
           setDataUpdatedAt(new Date(leaderboardData.updatedAt));
@@ -1667,9 +1666,8 @@ export default function EditorsAnalyticsPage() {
       </div>
       </section>
 
-      {/* TEMPORARY: Operational Breakdown section hidden. REVERT: remove the `hidden` class below. */}
       {/* Daily + Repo */}
-      <section id="editor-operations" className="hidden space-y-4 border-b border-border/70 pb-8">
+      <section id="editor-operations" className="space-y-4 border-b border-border/70 pb-8">
         <div>
           <div className="inline-flex items-center gap-2">
             <Zap className="h-5 w-5 text-primary" />

--- a/src/server/orpc/procedures/analytics.ts
+++ b/src/server/orpc/procedures/analytics.ts
@@ -2032,7 +2032,6 @@ export const analyticsProcedures = {
                    WHEN COALESCE(gs.current_state, 'NO_STATE') IN ('WAITING_ON_EDITOR', 'WAITING_EDITOR') THEN 'Waiting on Editor'
                    WHEN COALESCE(gs.current_state, 'NO_STATE') IN ('WAITING_ON_AUTHOR', 'WAITING_AUTHOR') THEN 'Waiting on Author'
                    WHEN COALESCE(gs.current_state, 'NO_STATE') = 'DRAFT' THEN 'AWAITED'
-                   ELSE COALESCE(gs.subcategory, 'Uncategorized')
                  END AS state,
                  gs.waiting_since,
                  sc.snapshot_ts
@@ -2044,6 +2043,7 @@ export const analyticsProcedures = {
             AND (pr.merged_at IS NULL OR pr.merged_at > sc.snapshot_ts)
             AND (pr.closed_at IS NULL OR pr.closed_at > sc.snapshot_ts)
             AND ($1::text IS NULL OR LOWER(SPLIT_PART(r.name, '/', 2)) = LOWER($1))
+            AND COALESCE(gs.current_state, 'NO_STATE') IN ('WAITING_ON_EDITOR', 'WAITING_EDITOR', 'WAITING_ON_AUTHOR', 'WAITING_AUTHOR', 'DRAFT', 'NO_STATE')
         ),
         wait_days AS (
           SELECT state, pr_number,
@@ -2052,6 +2052,7 @@ export const analyticsProcedures = {
                    EXTRACT(DAY FROM (snapshot_ts - COALESCE(waiting_since, snapshot_ts)))
                  )::int AS wait_days
           FROM open_with_state
+          WHERE state IS NOT NULL
         ),
         by_state AS (
           SELECT state,

--- a/src/server/orpc/procedures/tools.ts
+++ b/src/server/orpc/procedures/tools.ts
@@ -410,11 +410,6 @@ const { repo, govState, processType, search, page, pageSize } = input;
             ON p.pr_number = gs.pr_number AND p.repository_id = gs.repository_id
           WHERE p.state = 'open'
             AND ($1::text IS NULL OR LOWER(SPLIT_PART(r.name, '/', 2)) = LOWER($1))
-            -- TEMPORARY: hide specific typo PRs from board view. REVERT: remove the AND NOT block below.
-            AND NOT (
-              (LOWER(SPLIT_PART(r.name, '/', 2)) = 'ercs' AND p.pr_number IN (1123, 1191, 1232, 1257, 1254))
-              OR (LOWER(SPLIT_PART(r.name, '/', 2)) = 'eips' AND p.pr_number IN (10171, 11159, 11286))
-            )
         ),
         filtered AS (
           SELECT * FROM base
@@ -488,11 +483,6 @@ const { repo, govState, search } = input;
             ON p.pr_number = gs.pr_number AND p.repository_id = gs.repository_id
           WHERE p.state = 'open'
             AND ($1::text IS NULL OR LOWER(SPLIT_PART(r.name, '/', 2)) = LOWER($1))
-            -- TEMPORARY: hide specific typo PRs. REVERT: remove the AND NOT block below.
-            AND NOT (
-              (LOWER(SPLIT_PART(r.name, '/', 2)) = 'ercs' AND p.pr_number IN (1123, 1191, 1232, 1257, 1254))
-              OR (LOWER(SPLIT_PART(r.name, '/', 2)) = 'eips' AND p.pr_number IN (10171, 11159, 11286))
-            )
         )
         SELECT process_type, COUNT(*)::bigint AS count
         FROM base
@@ -536,11 +526,6 @@ const { repo, govState, search } = input;
           ON p.pr_number = gs.pr_number AND p.repository_id = gs.repository_id
         WHERE p.state = 'open'
           AND ($1::text IS NULL OR LOWER(SPLIT_PART(r.name, '/', 2)) = LOWER($1))
-          -- TEMPORARY: hide specific typo PRs. REVERT: remove the AND NOT block below.
-          AND NOT (
-            (LOWER(SPLIT_PART(r.name, '/', 2)) = 'ercs' AND p.pr_number IN (1123, 1191, 1232, 1257, 1254))
-            OR (LOWER(SPLIT_PART(r.name, '/', 2)) = 'eips' AND p.pr_number IN (10171, 11159, 11286))
-          )
           AND ($2::text IS NULL OR (
             p.pr_number::text LIKE '%' || $2 || '%'
             OR LOWER(COALESCE(p.title, '')) LIKE '%' || LOWER($2) || '%'


### PR DESCRIPTION
This pull request introduces several temporary data normalization and cleanup changes to the analytics and tools pages, primarily to address visual anomalies and data quality issues in charts and tables. It also removes temporary filters that were hiding specific PRs. Additionally, it updates the visibility of the Operational Breakdown section in the editors analytics page and improves the accuracy of certain analytics queries.

**Analytics Data Normalization and Visualization Fixes:**

* Temporarily caps the spike for month `"2022-08"` at 65 per actor in the `normalizeTrendSpikes` function, and adds a cap for the daily activity spike on `"2022-08-18"` at 15 per actor in the editors analytics page. These are intended to prevent visual distortion in trend charts. [[1]](diffhunk://#diff-9bb64009dceca141115a78c960c8fb407dbc757e5640c2ce893c84fa9560c857L155-R163) [[2]](diffhunk://#diff-9bb64009dceca141115a78c960c8fb407dbc757e5640c2ce893c84fa9560c857L396-R399)

* The Operational Breakdown section is now visible by removing the `hidden` class from its container in the editors analytics page.

**Analytics Query Improvements:**

* Refines the analytics query to only include relevant PR states and ensures that only non-null states are processed, improving the accuracy of the results. [[1]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9L2035) [[2]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9R2046) [[3]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9R2055)

**Tools Query Cleanup:**

* Removes temporary filters that were hiding specific typo PRs from the tools procedures, so all PRs are now included in analytics and board views. [[1]](diffhunk://#diff-fc05cff2abe8e6e1321f6b8b9ea2cb104c35afa365cf403014f14de3c9784e6cL413-L417) [[2]](diffhunk://#diff-fc05cff2abe8e6e1321f6b8b9ea2cb104c35afa365cf403014f14de3c9784e6cL491-L495) [[3]](diffhunk://#diff-fc05cff2abe8e6e1321f6b8b9ea2cb104c35afa365cf403014f14de3c9784e6cL539-L543)