### PR TITLE
Refine governance state filtering in analytics for relevance and accuracy

### DIFF
--- a/src/app/analytics/prs/page.tsx
+++ b/src/app/analytics/prs/page.tsx
@@ -437,18 +437,22 @@ export default function PRsAnalyticsPage() {
     }
 
     const VALID_GOV_STATES = ["Waiting on Editor", "Waiting on Author", "AWAITED"];
+    
+    // Ultra-aggressive filtering: only allow exactly these 3 states
     const filteredGovWait = govWaitStatesByMonth.map(m => ({
       ...m,
-      rows: m.rows.filter(r => VALID_GOV_STATES.includes(r.state))
+      rows: m.rows
+        .filter(r => VALID_GOV_STATES.includes(r.state))
+        .map(r => ({ ...r, state: r.state as typeof VALID_GOV_STATES[number] }))
     }));
-    const states = VALID_GOV_STATES.filter((s) =>
-      filteredGovWait.some((m) => m.rows.some((r) => r.state === s && r.count > 0))
-    );
-    const validSeries = states.map((state) => {
+    
+    // Build series for only the 3 valid states, no others
+    const validSeries = VALID_GOV_STATES.map((state) => {
+      const hasData = filteredGovWait.some((m) => m.rows.some((r) => r.state === state && r.count > 0));
       const data = months.map((month) => {
         const row = filteredGovWait.find((d) => d.month === month);
         const value = row?.rows.find((r) => r.state === state)?.count ?? 0;
-        return Math.max(0, value);
+        return Math.max(0, Number(value));
       });
       return {
         name: state,
@@ -456,8 +460,10 @@ export default function PRsAnalyticsPage() {
         stack: "open",
         data: data,
         itemStyle: { color: GOVERNANCE_COLORS[state] || "#64748B" },
+        show: hasData,
       };
-    });
+    }).filter(s => s.show);
+    
     return {
       backgroundColor: "transparent",
       tooltip: { trigger: "axis", axisPointer: { type: "shadow" } },
@@ -493,7 +499,7 @@ export default function PRsAnalyticsPage() {
           end: 100,
         },
       ],
-      series: validSeries,
+      series: validSeries.map(({ show, ...s }) => s),
     };
   }, [govWaitStatesByMonth, monthlySeries, openPRDistributionMode, processCategoriesByMonth]);
 

--- a/src/app/analytics/prs/page.tsx
+++ b/src/app/analytics/prs/page.tsx
@@ -436,13 +436,35 @@ export default function PRsAnalyticsPage() {
       };
     }
 
-    const states = Array.from(new Set(govWaitStatesByMonth.flatMap((m) => m.rows.map((r) => r.state))));
+    const VALID_GOV_STATES = ["Waiting on Editor", "Waiting on Author", "AWAITED"];
+    const filteredGovWait = govWaitStatesByMonth.map(m => ({
+      ...m,
+      rows: m.rows.filter(r => VALID_GOV_STATES.includes(r.state))
+    }));
+    const states = VALID_GOV_STATES.filter((s) =>
+      filteredGovWait.some((m) => m.rows.some((r) => r.state === s && r.count > 0))
+    );
+    const validSeries = states.map((state) => {
+      const data = months.map((month) => {
+        const row = filteredGovWait.find((d) => d.month === month);
+        const value = row?.rows.find((r) => r.state === state)?.count ?? 0;
+        return Math.max(0, value);
+      });
+      return {
+        name: state,
+        type: "bar",
+        stack: "open",
+        data: data,
+        itemStyle: { color: GOVERNANCE_COLORS[state] || "#64748B" },
+      };
+    });
     return {
       backgroundColor: "transparent",
       tooltip: { trigger: "axis", axisPointer: { type: "shadow" } },
       legend: {
         top: 0,
         textStyle: { color: "var(--muted-foreground)", fontSize: 11 },
+        data: validSeries.map(s => s.name),
       },
       grid: { top: 38, left: 38, right: 18, bottom: 46 },
       xAxis: {
@@ -471,16 +493,7 @@ export default function PRsAnalyticsPage() {
           end: 100,
         },
       ],
-      series: states.map((state) => ({
-        name: state,
-        type: "bar",
-        stack: "open",
-        data: months.map((month) => {
-          const row = govWaitStatesByMonth.find((d) => d.month === month);
-          return row?.rows.find((r) => r.state === state)?.count ?? 0;
-        }),
-        itemStyle: { color: GOVERNANCE_COLORS[state] || "#64748B" },
-      })),
+      series: validSeries,
     };
   }, [govWaitStatesByMonth, monthlySeries, openPRDistributionMode, processCategoriesByMonth]);
 
@@ -688,7 +701,8 @@ export default function PRsAnalyticsPage() {
     monthlySeries.forEach((m) => {
       combined.push({ type: "Monthly Activity", month: m.month, openAtMonthEnd: m.openAtMonthEnd, created: m.created, merged: m.merged, closed: m.closed });
     });
-    governanceStates.forEach((g) => combined.push({ type: "Governance State", state: g.state, count: g.count }));
+    const validGovernanceStates = governanceStates.filter(g => ["Waiting on Editor", "Waiting on Author", "AWAITED"].includes(g.state));
+    validGovernanceStates.forEach((g) => combined.push({ type: "Governance State", state: g.state, count: g.count }));
     processCategories.forEach((p) => combined.push({ type: "Process", category: p.category, count: p.count }));
     govWaitStates.forEach((g) => combined.push({ type: "Participant State", state: g.state, count: g.count, medianWaitDays: g.medianWaitDays }));
     openPRs.forEach((pr) => combined.push({ type: "Open PR", ...pr }));
@@ -969,8 +983,11 @@ export default function PRsAnalyticsPage() {
             <div>
               <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">Participant status mix</h3>
               <div className="space-y-2">
-                {governanceStates.map((g) => {
-                  const total = governanceStates.reduce((acc, s) => acc + s.count, 0);
+                {governanceStates
+                  .filter(g => ["Waiting on Editor", "Waiting on Author", "AWAITED"].includes(g.state))
+                  .map((g) => {
+                  const filteredStates = governanceStates.filter(s => ["Waiting on Editor", "Waiting on Author", "AWAITED"].includes(s.state));
+                  const total = filteredStates.reduce((acc, s) => acc + s.count, 0);
                   const pct = total > 0 ? (g.count / total) * 100 : 0;
                   const color = GOVERNANCE_COLORS[g.state] ?? "#64748b";
                   return (

--- a/src/server/orpc/procedures/analytics.ts
+++ b/src/server/orpc/procedures/analytics.ts
@@ -685,6 +685,7 @@ const getPRGovernanceStatesCached = unstable_cache(
       SELECT state, COUNT(*)::bigint as count
       FROM mapped_states
       WHERE state IS NOT NULL
+        AND state IN ('Waiting on Editor', 'Waiting on Author', 'AWAITED')
       GROUP BY state
       ORDER BY count DESC
     `, repo || null);
@@ -696,7 +697,7 @@ const getPRGovernanceStatesCached = unstable_cache(
     }));
   },
   ['analytics-getPRGovernanceStates'],
-  { tags: ['analytics-prs-governance'], revalidate: 300 }
+  { tags: ['analytics-prs-governance'], revalidate: 60 }
 );
 
 const getContributorActivityByTypeCached = unstable_cache(

--- a/src/server/orpc/procedures/analytics.ts
+++ b/src/server/orpc/procedures/analytics.ts
@@ -666,47 +666,32 @@ const getPRGovernanceStatesCached = unstable_cache(
   async (repo: string | null) => {
     const results = await prisma.$queryRawUnsafe<Array<{
       state: string;
-      label: string;
       count: bigint;
     }>>(`
-      WITH pr_metadata AS (
+      WITH mapped_states AS (
         SELECT 
-          pr.pr_number,
-          r.name as repo,
-          pr.title,
-          pr.author,
-          CASE 
-            WHEN pr.merged_at IS NOT NULL THEN 'merged'
-            WHEN pr.state = 'open' THEN 'open'
-            ELSE 'closed'
-          END as state,
-          COALESCE(gs.current_state, 'NO_STATE') as governance_state
+          CASE
+            WHEN COALESCE(gs.current_state, 'NO_STATE') IN ('WAITING_ON_EDITOR', 'WAITING_EDITOR') THEN 'Waiting on Editor'
+            WHEN COALESCE(gs.current_state, 'NO_STATE') IN ('WAITING_ON_AUTHOR', 'WAITING_AUTHOR') THEN 'Waiting on Author'
+            WHEN COALESCE(gs.current_state, 'NO_STATE') = 'DRAFT' THEN 'AWAITED'
+            ELSE NULL
+          END as state
         FROM pull_requests pr
         JOIN repositories r ON pr.repository_id = r.id
         LEFT JOIN pr_governance_state gs ON pr.pr_number = gs.pr_number AND pr.repository_id = gs.repository_id
         WHERE pr.state = 'open'
           AND ($1::text IS NULL OR LOWER(SPLIT_PART(r.name, '/', 2)) = LOWER($1))
-      ),
-      governance_mapping AS (
-        SELECT 'WAITING_ON_EDITOR' as state, 'waiting for editors review' as label UNION ALL
-        SELECT 'WAITING_ON_AUTHOR', 'author review' UNION ALL
-        SELECT 'STALLED', 'stalled' UNION ALL
-        SELECT 'DRAFT', 'draft' UNION ALL
-        SELECT 'NO_STATE', 'uncategorized'
       )
-      SELECT 
-        pm.governance_state as state,
-        COALESCE(gm.label, pm.governance_state) as label,
-        COUNT(*)::bigint as count
-      FROM pr_metadata pm
-      LEFT JOIN governance_mapping gm ON pm.governance_state = gm.state
-      GROUP BY pm.governance_state, gm.label
+      SELECT state, COUNT(*)::bigint as count
+      FROM mapped_states
+      WHERE state IS NOT NULL
+      GROUP BY state
       ORDER BY count DESC
     `, repo || null);
 
     return results.map(r => ({
       state: r.state,
-      label: r.label,
+      label: r.state,
       count: Number(r.count),
     }));
   },
@@ -2171,6 +2156,7 @@ export const analyticsProcedures = {
         SELECT month, state, COUNT(*)::bigint AS count
         FROM open_with_state
         WHERE state IS NOT NULL
+          AND state IN ('Waiting on Editor', 'Waiting on Author', 'AWAITED')
         GROUP BY month, state
         ORDER BY month, count DESC
       `, input.repo || null, input.from ?? null, input.to ?? null);


### PR DESCRIPTION
This pull request makes the analytics for PR governance states much stricter and more focused by filtering to only three specific states: "Waiting on Editor", "Waiting on Author", and "AWAITED". This filtering is consistently applied across the backend SQL queries, the frontend data processing, and the UI display logic. The changes ensure that only these three states are counted, visualized, and shown in analytics, removing any ambiguity or noise from other possible states.

Key changes grouped by theme:

**Backend data filtering:**
* The SQL queries for PR governance state analytics now only count pull requests in the "Waiting on Editor", "Waiting on Author", or "AWAITED" states, mapping internal state codes to these three labels and excluding all others. [[1]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9L669-R700) [[2]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9R2160)

**Frontend data processing:**
* All frontend aggregations and series construction for governance states now filter and process only the three valid states, ensuring that charts and tables are based solely on this subset. [[1]](diffhunk://#diff-9538e727ae560d5e5bb01d471e18d2c133b644d15c3af662e8ad6bb3be9b1cc7L439-R473) [[2]](diffhunk://#diff-9538e727ae560d5e5bb01d471e18d2c133b644d15c3af662e8ad6bb3be9b1cc7L474-R502) [[3]](diffhunk://#diff-9538e727ae560d5e5bb01d471e18d2c133b644d15c3af662e8ad6bb3be9b1cc7L691-R711)
* The participant status mix UI component now only displays the three valid governance states, with percentages calculated relative to their combined total.

These changes make the governance state analytics more precise, consistent, and easier to interpret.