### PR TITLE
Add Giveth banner component and enhance upgrade timeline functionality

### DIFF
--- a/src/app/(public)/_components/persona-home/DeveloperUpgradeWatchSection.tsx
+++ b/src/app/(public)/_components/persona-home/DeveloperUpgradeWatchSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import Link from 'next/link';
 import ReactECharts from 'echarts-for-react';
 import { ArrowRight, Download, Package } from 'lucide-react';
@@ -27,6 +27,14 @@ type DeveloperUpgradeWatchSectionProps = {
   setUpgradeWatchSlug: (value: string) => void;
   upgradeOptions: UpgradeOption[];
   upgradeTimelineLoading: boolean;
+  upgradeTimelineRows: Array<{
+    date: string;
+    included: string[];
+    scheduled: string[];
+    considered: string[];
+    proposed: string[];
+    declined: string[];
+  }>;
   upgradeWatchChartOption: unknown;
   latestCounts: Counts;
   onDownloadMetadata: () => void;
@@ -40,11 +48,27 @@ export default function DeveloperUpgradeWatchSection({
   setUpgradeWatchSlug,
   upgradeOptions,
   upgradeTimelineLoading,
+  upgradeTimelineRows,
   upgradeWatchChartOption,
   latestCounts,
   onDownloadMetadata,
   downloadMetadataLoading,
 }: DeveloperUpgradeWatchSectionProps) {
+  const [showTable, setShowTable] = useState(false);
+
+  const renderEipList = (values: string[]) => {
+    if (!values.length) return <span className="text-muted-foreground">-</span>;
+    return (
+      <div className="flex flex-wrap gap-1">
+        {values.map((value) => (
+          <span key={value} className="rounded border border-border/70 bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium text-foreground">
+            EIP-{value}
+          </span>
+        ))}
+      </div>
+    );
+  };
+
   return (
     <section className="mb-6 border-t border-border/70 pt-6" id="developer-upgrade-watch">
       <div className="mb-3 flex items-start justify-between gap-3">
@@ -75,6 +99,14 @@ export default function DeveloperUpgradeWatchSection({
             Explore Upgrades
             <ArrowRight className="h-3 w-3" />
           </Link>
+          <button
+            type="button"
+            onClick={() => setShowTable((prev) => !prev)}
+            disabled={upgradeTimelineLoading || !upgradeTimelineRows.length}
+            className="inline-flex h-8 items-center justify-center whitespace-nowrap rounded-md border border-border bg-muted/40 px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-muted/60 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {showTable ? 'Hide Table' : 'Show Table'}
+          </button>
           <button
             type="button"
             onClick={onDownloadMetadata}
@@ -110,6 +142,34 @@ export default function DeveloperUpgradeWatchSection({
             </span>
           ))}
         </div>
+        {showTable && (
+          <div className="mt-3 overflow-x-auto rounded-lg border border-border/70">
+            <table className="min-w-full text-xs">
+              <thead>
+                <tr className="border-b border-border/70 bg-muted/40 text-left text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  <th className="px-2.5 py-2">Date</th>
+                  <th className="px-2.5 py-2">Included</th>
+                  <th className="px-2.5 py-2">SFI</th>
+                  <th className="px-2.5 py-2">CFI</th>
+                  <th className="px-2.5 py-2">PFI</th>
+                  <th className="px-2.5 py-2">DFI</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[...upgradeTimelineRows].reverse().map((row) => (
+                  <tr key={`upgrade-watch-row-${row.date}`} className="border-b border-border/60 align-top">
+                    <td className="whitespace-nowrap px-2.5 py-2 font-medium text-foreground">{row.date}</td>
+                    <td className="px-2.5 py-2">{renderEipList(row.included)}</td>
+                    <td className="px-2.5 py-2">{renderEipList(row.scheduled)}</td>
+                    <td className="px-2.5 py-2">{renderEipList(row.considered)}</td>
+                    <td className="px-2.5 py-2">{renderEipList(row.proposed)}</td>
+                    <td className="px-2.5 py-2">{renderEipList(row.declined)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/src/app/(public)/_components/persona-home/EditorReviewQueueSection.tsx
+++ b/src/app/(public)/_components/persona-home/EditorReviewQueueSection.tsx
@@ -138,7 +138,13 @@ export default function EditorReviewQueueSection({
             <h2 className={sectionTitleClass}>Editor Review Queue</h2>
             <CopyLinkButton sectionId="editor-review-queue" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
           </div>
-          <p className={sectionSubtitleClass}>Open PRs currently waiting on editor action.</p>
+          <p className={sectionSubtitleClass}>
+            Open PRs currently waiting on editor action in the{' '}
+            <Link href="/tools/board" className="text-primary underline-offset-2 hover:underline">
+              Editing Board
+            </Link>
+            .
+          </p>
         </div>
         <div className="flex items-center gap-2">
           <button

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -60,6 +60,7 @@ import { useSession } from '@/hooks/useSession';
 import { useTheme } from 'next-themes';
 import { cn } from '@/lib/utils';
 import { ASSOCIATE_EIP_EDITORS, CANONICAL_EIP_EDITORS } from '@/data/eip-contributor-roles';
+import { getUpgradeTimelineData } from '@/data/upgrade-timelines';
 import { useEffectivePersona, useIsHydrated } from '@/stores/personaStore';
 
 type Dimension = 'status' | 'category' | 'repo' | 'stages';
@@ -130,6 +131,25 @@ type UpgradeTimelineRow = {
   considered: string[];
   proposed: string[];
 };
+
+function normalizeUpgradeEipIds(values: string[]): string[] {
+  return values
+    .map((value) => String(value).replace(/^EIP-/i, '').trim())
+    .filter((value) => value.length > 0);
+}
+
+function normalizeUpgradeTimelineRows(rows: UpgradeTimelineRow[]): UpgradeTimelineRow[] {
+  return [...rows]
+    .map((row) => ({
+      date: row.date,
+      included: normalizeUpgradeEipIds(row.included),
+      scheduled: normalizeUpgradeEipIds(row.scheduled),
+      declined: normalizeUpgradeEipIds(row.declined),
+      considered: normalizeUpgradeEipIds(row.considered),
+      proposed: normalizeUpgradeEipIds(row.proposed),
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
 
 type NewcomerTrendingProposal = {
   proposalNumber: number;
@@ -1912,7 +1932,7 @@ export default function EIPsHomePage() {
   const upgradeWatchChartOption = useMemo(() => {
     if (!upgradeTimelineRows.length) return null;
 
-    const compactDates = upgradeTimelineRows.map((row) => row.date.slice(5));
+    const timelineDates = upgradeTimelineRows.map((row) => row.date);
     const seriesConfig = [
       { key: 'included', label: 'Included', color: '#10b981' },
       { key: 'scheduled', label: 'SFI', color: '#06b6d4' },
@@ -1922,7 +1942,7 @@ export default function EIPsHomePage() {
     ] as const;
 
     return {
-      grid: { left: 36, right: 10, top: 24, bottom: 26 },
+      grid: { left: 36, right: 10, top: 24, bottom: 56 },
       tooltip: {
         trigger: 'axis',
         backgroundColor: isDark ? 'rgba(15,23,42,0.95)' : 'rgba(255,255,255,0.98)',
@@ -1937,9 +1957,16 @@ export default function EIPsHomePage() {
       },
       xAxis: {
         type: 'category',
-        data: compactDates,
+        data: timelineDates,
         boundaryGap: false,
-        axisLabel: { color: isDark ? '#94a3b8' : '#64748b', fontSize: 10, hideOverlap: true },
+        axisLabel: {
+          color: isDark ? '#94a3b8' : '#64748b',
+          fontSize: 10,
+          hideOverlap: true,
+          rotate: 0,
+          interval: (index: number) => index % 2 === 0,
+          formatter: (value: string) => value,
+        },
       },
       yAxis: {
         type: 'value',
@@ -1947,6 +1974,32 @@ export default function EIPsHomePage() {
         axisLabel: { color: isDark ? '#94a3b8' : '#64748b', fontSize: 10 },
         splitLine: { lineStyle: { color: isDark ? 'rgba(148,163,184,0.14)' : 'rgba(148,163,184,0.2)', type: 'dashed' } },
       },
+      dataZoom: [
+        {
+          type: 'inside',
+          xAxisIndex: 0,
+          filterMode: 'none',
+          zoomOnMouseWheel: true,
+          moveOnMouseMove: true,
+          moveOnMouseWheel: true,
+          preventDefaultMouseMove: false,
+        },
+        {
+          type: 'slider',
+          xAxisIndex: 0,
+          filterMode: 'none',
+          height: 16,
+          bottom: 8,
+          borderColor: isDark ? 'rgba(148,163,184,0.2)' : 'rgba(148,163,184,0.35)',
+          backgroundColor: isDark ? 'rgba(15,23,42,0.5)' : 'rgba(241,245,249,0.7)',
+          fillerColor: isDark ? 'rgba(59,130,246,0.28)' : 'rgba(59,130,246,0.2)',
+          handleStyle: {
+            color: isDark ? '#334155' : '#cbd5e1',
+            borderColor: isDark ? '#64748b' : '#94a3b8',
+          },
+          textStyle: { color: isDark ? '#94a3b8' : '#64748b', fontSize: 10 },
+        },
+      ],
       series: seriesConfig.map((series) => ({
         name: series.label,
         type: 'bar',
@@ -1985,9 +2038,28 @@ export default function EIPsHomePage() {
     (async () => {
       setUpgradeTimelineLoading(true);
       try {
+        const canonicalTimeline = getUpgradeTimelineData(upgradeWatchSlug);
+        if (canonicalTimeline && canonicalTimeline.length > 0) {
+          if (!cancelled) {
+            setUpgradeTimelineRows(
+              normalizeUpgradeTimelineRows(
+                canonicalTimeline.map((item) => ({
+                  date: item.date,
+                  included: item.included,
+                  scheduled: item.scheduled,
+                  declined: item.declined,
+                  considered: item.considered,
+                  proposed: item.proposed,
+                }))
+              )
+            );
+          }
+          return;
+        }
+
         const timeline = await client.upgrades.getUpgradeTimeline({ slug: upgradeWatchSlug });
         if (!cancelled) {
-          setUpgradeTimelineRows(timeline as UpgradeTimelineRow[]);
+          setUpgradeTimelineRows(normalizeUpgradeTimelineRows(timeline as UpgradeTimelineRow[]));
         }
       } catch (err) {
         console.error('Failed to load developer upgrade watch timeline:', err);
@@ -2219,6 +2291,7 @@ export default function EIPsHomePage() {
           setUpgradeWatchSlug={setUpgradeWatchSlug}
           upgradeOptions={upgradeOptions}
           upgradeTimelineLoading={upgradeTimelineLoading}
+          upgradeTimelineRows={upgradeTimelineRows}
           upgradeWatchChartOption={upgradeWatchChartOption}
           latestCounts={{
             included: latestUpgradeSnapshot?.included.length ?? 0,
@@ -2482,7 +2555,13 @@ export default function EIPsHomePage() {
                 <h2 className={sectionTitleClass}>Board</h2>
                 <CopyLinkButton sectionId="developer-board-snapshot" tooltipLabel="Copy link" />
               </div>
-              <p className={sectionSubtitleClass}>Compact open PR snapshot from the Editing Board.</p>
+              <p className={sectionSubtitleClass}>
+                Compact open PR snapshot from the{' '}
+                <Link href="/tools/board" className="text-primary underline-offset-2 hover:underline">
+                  Editing Board
+                </Link>
+                .
+              </p>
             </div>
             <div className="flex items-center gap-2">
               <select

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { WhatsNewV4Dialog } from "@/components/whats-new-v4-dialog";
 import { Providers } from "@/providers/Providers";
 import { buildMetadata } from "@/lib/seo";
+import { GivethBanner } from "@/components/giveth-banner";
 
 const Libre_Baskerville = LibreBaskervilleFont({
   variable: "--font-libre-baskerville",
@@ -78,6 +79,7 @@ export default function RootLayout({
           <SidebarProvider>
             <AppSidebar />
             <SidebarInset className="flex h-screen flex-col overflow-hidden">
+              <GivethBanner />
               <div className="shrink-0">
                 <Navbar />
               </div>

--- a/src/components/giveth-banner.tsx
+++ b/src/components/giveth-banner.tsx
@@ -1,0 +1,23 @@
+"use client";
+import { StickyBanner } from "@/components/ui/sticky-banner";
+
+export function GivethBanner() {
+  return (
+    <StickyBanner className="border-b border-border/40 bg-gradient-to-r from-primary/4 via-primary/2 to-transparent backdrop-blur-sm">
+      <div className="mx-auto flex w-full max-w-7xl items-center justify-center px-4 sm:px-6 lg:px-8">
+        <p className="text-center text-[13px] font-medium text-foreground sm:text-sm">
+          Public goods infrastructure for Ethereum governance. Support us on{" "}
+          <a
+            href="https://giveth.io/project/eipsinsight"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-semibold text-primary underline transition-colors duration-200 hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+          >
+            Giveth QF
+          </a>
+          <span className="text-primary font-semibold"> 💜</span>
+        </p>
+      </div>
+    </StickyBanner>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -451,7 +451,7 @@ export default function Navbar() {
               <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <input
                 type="search"
-                placeholder="Search EIPs, ERCs, authors…"
+                placeholder="Search EIPs, ERCs, RIPs, authors…"
                 className={cn(
                   "h-9 w-full rounded-md border border-border bg-muted/60 px-10 text-sm text-foreground",
                   "placeholder:text-muted-foreground",

--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -312,7 +312,6 @@ export function SearchBar() {
         <div
           ref={dropdownRef}
           className="absolute z-50 mt-2 w-full overflow-hidden rounded-xl border border-border bg-card/95 shadow-2xl backdrop-blur-xl"
-          style={{ maxHeight: '480px' }}
         >
           {loading ? (
             <div className="p-8 text-center">
@@ -330,7 +329,7 @@ export function SearchBar() {
               </p>
             </div>
           ) : (
-            <div className="max-h-[480px] overflow-y-auto">
+            <div className="max-h-[70vh] overflow-y-auto overscroll-contain">
               {/* Proposals Section */}
               {results.proposals.length > 0 && (
                 <div className="border-b border-border/80">

--- a/src/components/ui/sticky-banner.tsx
+++ b/src/components/ui/sticky-banner.tsx
@@ -1,0 +1,109 @@
+"use client";
+import React, { SVGProps, useState } from "react";
+import { motion, useMotionValueEvent, useScroll, AnimatePresence } from "motion/react";
+import { cn } from "@/lib/utils";
+
+export const StickyBanner = ({
+  className,
+  children,
+  hideOnScroll = false,
+}: {
+  className?: string;
+  children: React.ReactNode;
+  hideOnScroll?: boolean;
+}) => {
+  const [open, setOpen] = useState(true);
+  const [dismissedPermanently, setDismissedPermanently] = useState(false);
+  const { scrollY } = useScroll();
+
+  useMotionValueEvent(scrollY, "change", (latest) => {
+    if (hideOnScroll && latest > 40) {
+      setOpen(false);
+    } else {
+      setOpen(true);
+    }
+  });
+
+  const handleClose = () => {
+    setOpen(false);
+    setDismissedPermanently(true);
+  };
+
+  if (dismissedPermanently) return null;
+
+  return (
+    <AnimatePresence mode="wait">
+      {open && (
+        <motion.div
+          className={cn(
+            "sticky inset-x-0 top-0 z-20 flex min-h-10 w-full items-center justify-center bg-transparent px-4 py-1.5",
+            className,
+          )}
+          initial={{
+            y: -100,
+            opacity: 0,
+            height: 0,
+          }}
+          animate={{
+            y: 0,
+            opacity: 1,
+            height: "auto",
+          }}
+          exit={{
+            y: -100,
+            opacity: 0,
+            height: 0,
+          }}
+          transition={{
+            duration: 0.3,
+            ease: "easeInOut",
+          }}
+        >
+          {children}
+
+          <motion.button
+            initial={{
+              scale: 0,
+              opacity: 0,
+            }}
+            animate={{
+              scale: 1,
+              opacity: 1,
+            }}
+            exit={{
+              scale: 0,
+              opacity: 0,
+            }}
+            className="absolute top-1/2 right-3 -translate-y-1/2 flex h-8 w-8 cursor-pointer items-center justify-center rounded-md transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30"
+            onClick={handleClose}
+            aria-label="Close banner"
+            type="button"
+          >
+            <CloseIcon className="h-4 w-4" />
+          </motion.button>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+const CloseIcon = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path d="M18 6l-12 12" />
+      <path d="M6 6l12 12" />
+    </svg>
+  );
+};

--- a/src/server/orpc/procedures/search.ts
+++ b/src/server/orpc/procedures/search.ts
@@ -664,9 +664,18 @@ const searchTerm = `%${input.query}%`;
       const numericQuery = input.query.replace(/[^\d]/g, '');
       const exactNumber = numericQuery ? parseInt(numericQuery, 10) : null;
       const exactTitle = input.query.trim().toLowerCase();
+      const normalizedQuery = input.query.trim().toLowerCase();
+      const hintedRepo =
+        /\brips?\b/.test(normalizedQuery)
+          ? '%rip%'
+          : /\bercs?\b/.test(normalizedQuery)
+            ? '%erc%'
+            : /\beips?\b/.test(normalizedQuery)
+              ? '%eip%'
+              : null;
 
-      // Get all matching proposals first
-      const allResults = await prisma.$queryRawUnsafe<Array<{
+      // Get all matching proposals first (EIP/ERC snapshots + RIP table)
+      const eipLikeResults = await prisma.$queryRawUnsafe<Array<{
         eip_number: number;
         title: string | null;
         author: string | null;
@@ -693,8 +702,39 @@ const searchTerm = `%${input.query}%`;
           OR s.status ILIKE $1
           OR s.type ILIKE $1
           OR s.category ILIKE $1
+          OR ($3::int IS NOT NULL AND e.eip_number = $3)
+          OR ($4::text IS NOT NULL AND LOWER(r.name) LIKE LOWER($4))
         LIMIT $2
-      `, searchTerm, input.limit * 2); // Get more to score and filter
+      `, searchTerm, input.limit * 2, exactNumber, hintedRepo); // Get more to score and filter
+      const ripResults = await prisma.$queryRawUnsafe<Array<{
+        eip_number: number;
+        title: string | null;
+        author: string | null;
+        status: string;
+        type: string | null;
+        category: string | null;
+        repo: string;
+      }>>(`
+        SELECT
+          rp.rip_number AS eip_number,
+          rp.title,
+          rp.author,
+          COALESCE(rp.status, 'Unknown') AS status,
+          'RIP'::text AS type,
+          'RIP'::text AS category,
+          'ethereum/RIPs'::text AS repo
+        FROM rips rp
+        WHERE
+          rp.rip_number::text ILIKE $1
+          OR COALESCE(rp.title, '') ILIKE $1
+          OR COALESCE(rp.author, '') ILIKE $1
+          OR COALESCE(rp.status, '') ILIKE $1
+          OR ($3::int IS NOT NULL AND rp.rip_number = $3)
+          OR ($4::text IS NOT NULL AND LOWER('ethereum/RIPs') LIKE LOWER($4))
+        LIMIT $2
+      `, searchTerm, input.limit * 2, exactNumber, hintedRepo);
+
+      const allResults = [...eipLikeResults, ...ripResults];
 
       // Score and sort results
       const scoredResults = allResults.map(r => {
@@ -737,17 +777,23 @@ const searchTerm = `%${input.query}%`;
         
         return { ...r, score };
       })
-      .filter(r => r.score > 0)
+      .filter(r => r.score > 0);
+
+      const uniqueScoredResults = Array.from(
+        new Map(
+          scoredResults.map((row) => [`${row.repo}:${row.eip_number}`, row] as const)
+        ).values()
+      )
       .sort((a, b) => {
         if (b.score !== a.score) return b.score - a.score;
         return a.eip_number - b.eip_number;
       })
       .slice(0, input.limit);
 
-      return scoredResults.map(r => ({
+      return uniqueScoredResults.map(r => ({
         kind: 'proposal' as const,
         number: r.eip_number,
-        repo: r.repo.includes('EIPs') ? 'eip' : r.repo.includes('ERCs') ? 'erc' : 'rip',
+        repo: r.repo.toLowerCase().includes('/eips') ? 'eip' : r.repo.toLowerCase().includes('/ercs') ? 'erc' : 'rip',
         title: r.title || '',
         status: r.status,
         category: r.category || null,

--- a/src/server/orpc/procedures/upgrades.ts
+++ b/src/server/orpc/procedures/upgrades.ts
@@ -115,6 +115,41 @@ function getCanonicalUpgradeName(upgrade: string, date: string): string {
   return upgrade;
 }
 
+function normalizeUpgradeBucket(bucket: string | null | undefined): 'included' | 'scheduled' | 'considered' | 'proposed' | 'declined' | null {
+  if (!bucket) return null;
+  const normalized = bucket.toLowerCase().replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (normalized === 'included' || normalized.includes('included')) return 'included';
+  if (
+    normalized === 'scheduled' ||
+    normalized === 'sfi' ||
+    normalized.includes('scheduled for inclusion')
+  ) {
+    return 'scheduled';
+  }
+  if (
+    normalized === 'considered' ||
+    normalized === 'cfi' ||
+    normalized.includes('considered for inclusion')
+  ) {
+    return 'considered';
+  }
+  if (
+    normalized === 'proposed' ||
+    normalized === 'pfi' ||
+    normalized.includes('proposed for inclusion')
+  ) {
+    return 'proposed';
+  }
+  if (
+    normalized === 'declined' ||
+    normalized === 'dfi' ||
+    normalized.includes('declined')
+  ) {
+    return 'declined';
+  }
+  return null;
+}
+
 async function computeIndependentIncludedAuthorRows() {
   const eipToUpgrades = new Map<number, Set<string>>();
 
@@ -400,7 +435,7 @@ export const upgradesProcedures = {
         const eip = eips.find(e => e.eip_number === comp.eip_number);
         return {
           eip_number: comp.eip_number,
-          bucket: comp.bucket || null,
+          bucket: normalizeUpgradeBucket(comp.bucket),
           title: eip?.title || '',
           status: eip?.eip_snapshots?.status || null,
           updated_at: comp.updated_at?.toISOString() || null,
@@ -498,7 +533,7 @@ export const upgradesProcedures = {
 
         dateChanges.get(dateStr)!.push({
           eipNumber: event.eip_number,
-          bucket: event.bucket ? event.bucket.toLowerCase() : null,
+          bucket: normalizeUpgradeBucket(event.bucket),
           type: event.event_type || 'added',
         });
       });
@@ -545,8 +580,9 @@ export const upgradesProcedures = {
         if (date === finalSnapshotDate) {
           cumulativeState.clear();
           currentComposition.forEach((comp) => {
-            if (comp.bucket) {
-              cumulativeState.set(comp.eip_number, comp.bucket.toLowerCase());
+            const normalizedBucket = normalizeUpgradeBucket(comp.bucket);
+            if (normalizedBucket) {
+              cumulativeState.set(comp.eip_number, normalizedBucket);
             }
           });
         }


### PR DESCRIPTION
This pull request introduces several user experience improvements, adds a new sticky banner for Giveth QF support, and enhances the Developer Upgrade Watch section with a timeline table and improved chart interactivity. It also includes search enhancements and minor UI adjustments for clarity and accessibility.

**Developer Upgrade Watch Enhancements:**

* Added a toggleable table view to the `DeveloperUpgradeWatchSection` showing the upgrade timeline with categorized EIPs (included, scheduled, considered, proposed, declined) and a utility to normalize EIP IDs for consistent display. [[1]](diffhunk://#diff-25f8cafc27df9e99a67a4c51f161edb4dd33ee03f2c881b36f649bcf599bd1deR30-R37) [[2]](diffhunk://#diff-25f8cafc27df9e99a67a4c51f161edb4dd33ee03f2c881b36f649bcf599bd1deR51-R71) [[3]](diffhunk://#diff-25f8cafc27df9e99a67a4c51f161edb4dd33ee03f2c881b36f649bcf599bd1deR102-R109) [[4]](diffhunk://#diff-25f8cafc27df9e99a67a4c51f161edb4dd33ee03f2c881b36f649bcf599bd1deR145-R172) [[5]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfR135-R153) [[6]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfR2041-R2062) [[7]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfR2294)
* Improved the upgrade timeline chart with a data zoom slider, better axis labeling, and support for longer timelines. [[1]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfL1915-R1935) [[2]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfL1925-R1945) [[3]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfL1940-R2002)

**UI and UX Improvements:**

* Introduced a sticky Giveth QF support banner via the new `GivethBanner` and reusable `StickyBanner` components, displayed at the top of the layout. [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R16) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R82) [[3]](diffhunk://#diff-5ce72bf3fb76ae3529970fbda22cf13800c387202afcbf4f903d4234e2f989d3R1-R23) [[4]](diffhunk://#diff-63c4583c97009481e875103724d73ea57def0506798dcaea1aee3b0e368b24f0R1-R109)
* Improved section subtitles to link directly to the Editing Board for both the Editor Review Queue and Developer Board Snapshot, clarifying navigation for users. [[1]](diffhunk://#diff-c79cae646d8da699c595b18431c0be226913eea7f4eeee308cafdf5dd22d83a2L141-R147) [[2]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfL2485-R2564)

**Search Experience:**

* Updated the search placeholder to include "RIPs" and improved the search dropdown's max height for better usability on large screens. [[1]](diffhunk://#diff-22f07440d147576aefe7a062a84ac12e07bbb1bdc66c02cf368e71261439cc4bL454-R454) [[2]](diffhunk://#diff-6646223bb51829a68545690736a9f7a2b522f8e8afb1eb53f453b65db0d373c0L315) [[3]](diffhunk://#diff-6646223bb51829a68545690736a9f7a2b522f8e8afb1eb53f453b65db0d373c0L333-R332)
* Enhanced backend search logic to recognize "RIP", "ERC", and "EIP" keywords, improving search relevance.

These changes collectively improve discoverability, navigation, and the visual presentation of upgrade data, while also supporting community funding efforts.