### PR TITLE
Enhance upgrade timeline display with EIP counts

### DIFF
--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1742,24 +1742,27 @@ export default function EIPsHomePage() {
     try {
       setUpgradeMetadataDownloading(true);
       const selectedUpgradeLabel = upgradeOptions.find((opt) => opt.slug === upgradeWatchSlug)?.label ?? upgradeWatchSlug;
+      const latestIncluded = latestUpgradeSnapshot?.included.length ?? 0;
+      const latestScheduled = latestUpgradeSnapshot?.scheduled.length ?? 0;
+      const latestConsidered = latestUpgradeSnapshot?.considered.length ?? 0;
+      const latestProposed = latestUpgradeSnapshot?.proposed.length ?? 0;
+      const latestDeclined = latestUpgradeSnapshot?.declined.length ?? 0;
+      const latestTotal = latestIncluded + latestScheduled + latestConsidered + latestProposed + latestDeclined;
       const header = [
         'upgrade_slug',
         'upgrade_label',
         'date',
-        'included_count',
-        'scheduled_count',
-        'considered_count',
-        'proposed_count',
-        'declined_count',
         'total_count',
-        'included_eips',
-        'scheduled_eips',
-        'considered_eips',
-        'proposed_eips',
-        'declined_eips',
-        'all_eips',
+        `included_eips (${latestIncluded})`,
+        `scheduled_eips (${latestScheduled})`,
+        `considered_eips (${latestConsidered})`,
+        `proposed_eips (${latestProposed})`,
+        `declined_eips (${latestDeclined})`,
+        `all_eips (${latestTotal})`,
       ];
-      const rows = upgradeTimelineRows.map((row) => {
+      const rows = [...upgradeTimelineRows]
+        .sort((a, b) => b.date.localeCompare(a.date))
+        .map((row) => {
         const toEipCode = (value: string) => {
           const normalized = String(value ?? '').trim().replace(/^EIP[-\s]*/i, '');
           return normalized ? `EIP-${normalized}` : '';
@@ -1779,22 +1782,18 @@ export default function EIPsHomePage() {
         const all = [...included, ...scheduled, ...considered, ...proposed, ...declined]
           .filter(Boolean)
           .sort((a, b) => Number(a.replace('EIP-', '')) - Number(b.replace('EIP-', '')));
+        const withCount = (values: string[]) => (values.length ? `${values.join(' | ')} (${values.length})` : '(0)');
         return [
           upgradeWatchSlug,
           selectedUpgradeLabel,
           row.date,
-          included.length,
-          scheduled.length,
-          considered.length,
-          proposed.length,
-          declined.length,
           total,
-          included.join(' | '),
-          scheduled.join(' | '),
-          considered.join(' | '),
-          proposed.join(' | '),
-          declined.join(' | '),
-          all.join(' | '),
+          withCount(included),
+          withCount(scheduled),
+          withCount(considered),
+          withCount(proposed),
+          withCount(declined),
+          withCount(all),
         ];
       });
 


### PR DESCRIPTION
This pull request improves the EIPs export functionality on the home page by enhancing the CSV export headers and data rows to include EIP counts directly in the exported file. The changes also ensure that the EIP lists are consistently sorted and display counts for each category, making the exported data more informative and user-friendly.

**Export header and data improvements:**

* The CSV export headers for each EIP status now include the current count of EIPs in that category, e.g., `included_eips (5)`, providing immediate context about the number of EIPs in each group.
* The exported data rows now display the EIP lists for each category along with their respective counts in the format `EIP-1 | EIP-2 (2)`, and show `(0)` for empty categories, making the export clearer and easier to interpret.

**Sorting and consistency enhancements:**

* The export rows are now sorted by date in descending order, ensuring the most recent upgrades appear first in the exported file.
* The combined `all_eips` list in each row is sorted numerically by EIP number for consistency and easier reading.