### PR TITLE
Update social links for YouTube and LinkedIn in footer

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -20,8 +20,8 @@ const supportLinks = [
 ];
 
 const socialLinks = [
-  { name: "YouTube", href: "https://www.youtube.com/@avarch", icon: Youtube },
-  { name: "LinkedIn", href: "https://www.linkedin.com/company/avarch", icon: Linkedin },
+  { name: "YouTube", href: "https://www.youtube.com/@etherworldco", icon: Youtube },
+  { name: "LinkedIn", href: "https://www.linkedin.com/company/eipsinsight/", icon: Linkedin },
   { name: "X", href: "https://x.com/EIPsInsight", icon: Twitter },
   { name: "EtherWorld", href: "https://etherworld.co/", icon: Globe },
 ];


### PR DESCRIPTION
This pull request updates the social media links in the `footer.tsx` component to reflect new YouTube and LinkedIn profiles.

Social media link updates:

* Updated the YouTube link to `https://www.youtube.com/@etherworldco` and the LinkedIn link to `https://www.linkedin.com/company/eipsinsight/` in the `socialLinks` array of `footer.tsx`.