### PR TITLE
Add customizable publication date field to blog editor and backend

### DIFF
--- a/src/app/admin/blogs/[id]/edit/page.tsx
+++ b/src/app/admin/blogs/[id]/edit/page.tsx
@@ -17,6 +17,7 @@ export default function EditBlogPage() {
     content: string;
     coverImage: string | null;
     published: boolean;
+    createdAt: string | Date;
     categoryId?: string | null;
     readingTimeMinutes?: number | null;
     tags?: string[];
@@ -64,6 +65,7 @@ export default function EditBlogPage() {
         readingTimeMinutes: post.readingTimeMinutes ?? null,
         tags: post.tags ?? [],
         featured: post.featured ?? false,
+        publicationDate: new Date(post.createdAt).toISOString(),
       }}
     />
   );

--- a/src/app/admin/blogs/_components/blog-editor.tsx
+++ b/src/app/admin/blogs/_components/blog-editor.tsx
@@ -23,6 +23,7 @@ import {
   User,
   Tag,
   Clock,
+  Calendar,
   Star,
 } from "lucide-react";
 import { client } from "@/lib/orpc";
@@ -42,6 +43,7 @@ interface BlogEditorProps {
     readingTimeMinutes?: number | null;
     tags?: string[];
     featured?: boolean;
+    publicationDate?: string;
   };
 }
 
@@ -135,6 +137,13 @@ function useMarkdownToolbar(textareaRef: React.RefObject<HTMLTextAreaElement | n
 }
 
 export function BlogEditor({ mode, postId, initialData }: BlogEditorProps) {
+  const formatDateInput = (value?: string) => {
+    if (!value) return new Date().toISOString().slice(0, 10);
+    const d = new Date(value);
+    if (Number.isNaN(d.getTime())) return new Date().toISOString().slice(0, 10);
+    return d.toISOString().slice(0, 10);
+  };
+
   const [slug, setSlug] = useState(initialData.slug);
   const [title, setTitle] = useState(initialData.title);
   const [excerpt, setExcerpt] = useState(initialData.excerpt);
@@ -146,6 +155,7 @@ export function BlogEditor({ mode, postId, initialData }: BlogEditorProps) {
   const [tags, setTags] = useState<string[]>(initialData.tags ?? []);
   const [tagInput, setTagInput] = useState("");
   const [featured, setFeatured] = useState(initialData.featured ?? false);
+  const [publicationDate, setPublicationDate] = useState<string>(formatDateInput(initialData.publicationDate));
   const [saving, setSaving] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [generatingMeta, setGeneratingMeta] = useState(false);
@@ -290,6 +300,7 @@ export function BlogEditor({ mode, postId, initialData }: BlogEditorProps) {
           readingTimeMinutes: readingTimeMinutes ?? undefined,
           tags,
           featured,
+          publicationDate,
         });
         window.location.href = "/admin?tab=blogs";
       } else if (postId) {
@@ -305,6 +316,7 @@ export function BlogEditor({ mode, postId, initialData }: BlogEditorProps) {
           readingTimeMinutes,
           tags,
           featured,
+          publicationDate,
         });
         window.location.href = "/admin?tab=blogs";
       }
@@ -444,6 +456,18 @@ export function BlogEditor({ mode, postId, initialData }: BlogEditorProps) {
                 value={readingTimeMinutes ?? ""}
                 onChange={(e) => setReadingTimeMinutes(e.target.value ? parseInt(e.target.value, 10) : null)}
                 placeholder="e.g. 5"
+                className={fieldClass}
+              />
+            </div>
+            <div>
+              <label className={cn(labelClass, "flex items-center gap-1.5")}>
+                <Calendar className="h-4 w-4" />
+                Publication date
+              </label>
+              <input
+                type="date"
+                value={publicationDate}
+                onChange={(e) => setPublicationDate(e.target.value)}
                 className={fieldClass}
               />
             </div>

--- a/src/app/admin/blogs/new/page.tsx
+++ b/src/app/admin/blogs/new/page.tsx
@@ -14,6 +14,7 @@ export default function NewBlogPage() {
         content: "",
         coverImage: null,
         published: false,
+        publicationDate: new Date().toISOString(),
       }}
     />
   );

--- a/src/server/orpc/procedures/blog.ts
+++ b/src/server/orpc/procedures/blog.ts
@@ -46,6 +46,7 @@ const blogSchema = z.object({
   readingTimeMinutes: z.number().min(0).optional().nullable(),
   tags: z.array(z.string()).optional(),
   featured: z.boolean().optional(),
+  publicationDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
 })
 
 const authorProfileSchema = z.object({
@@ -141,6 +142,9 @@ export const blogProcedures = {
         throw new ORPCError('BAD_REQUEST', { message: 'A blog post with this slug already exists' })
       }
       const { categoryId, readingTimeMinutes, tags, featured, ...rest } = input
+      const publicationDate = input.publicationDate
+        ? new Date(`${input.publicationDate}T12:00:00.000Z`)
+        : undefined
       const post = await prisma.blog.create({
         data: {
           ...rest,
@@ -150,6 +154,7 @@ export const blogProcedures = {
           readingTimeMinutes: readingTimeMinutes ?? null,
           tags: tags ?? [],
           featured: featured ?? false,
+          ...(publicationDate ? { createdAt: publicationDate } : {}),
         },
         include: {
           author: { select: { id: true, name: true, image: true, blog_editor_profile: true } },
@@ -174,6 +179,7 @@ export const blogProcedures = {
         readingTimeMinutes: z.number().min(0).optional().nullable(),
         tags: z.array(z.string()).optional(),
         featured: z.boolean().optional(),
+        publicationDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
       }),
     )
     .handler(async ({ input, context }) => {
@@ -185,10 +191,13 @@ export const blogProcedures = {
       if (existing.authorId !== session.user.id && (await prisma.user.findUnique({ where: { id: session.user.id }, select: { role: true } }))?.role !== 'admin') {
         throw new ORPCError('FORBIDDEN', { message: 'You can only edit your own posts' })
       }
-      const { id, ...data } = input
+      const { id, publicationDate, ...data } = input
       const post = await prisma.blog.update({
         where: { id },
-        data: data as Record<string, unknown>,
+        data: {
+          ...(data as Record<string, unknown>),
+          ...(publicationDate ? { createdAt: new Date(`${publicationDate}T12:00:00.000Z`) } : {}),
+        },
         include: {
           author: { select: { id: true, name: true, image: true, blog_editor_profile: true } },
           category: { select: { id: true, slug: true, name: true } },


### PR DESCRIPTION
This pull request adds support for setting a custom publication date for blog posts in the admin UI. It introduces a new `publicationDate` field to the blog editor, ensures the date is properly validated and formatted, and updates the backend to handle the new field when creating or editing blog posts.

**Admin UI changes:**

- Added a "Publication date" field (with a date picker) to the blog editor form, allowing admins to set or edit the publication date of a blog post. The field is initialized with the post's creation date or today's date for new posts. (`src/app/admin/blogs/_components/blog-editor.tsx` [[1]](diffhunk://#diff-cb1d7681c7de72c99d5df045c5f2d933cd4e93563da3301c191a52e9bbee04fbR46) [[2]](diffhunk://#diff-cb1d7681c7de72c99d5df045c5f2d933cd4e93563da3301c191a52e9bbee04fbR140-R146) [[3]](diffhunk://#diff-cb1d7681c7de72c99d5df045c5f2d933cd4e93563da3301c191a52e9bbee04fbR158) [[4]](diffhunk://#diff-cb1d7681c7de72c99d5df045c5f2d933cd4e93563da3301c191a52e9bbee04fbR462-R473) [[5]](diffhunk://#diff-e9e4e8d7df99dd31acc39bb5f3f13aca7ca1cc7ac1ea9b174c6b66f8b5e10446R17) [src/app/admin/blogs/[id]/edit/page.tsxR20](diffhunk://#diff-c15ec4e9d803f603eed1258e9925bf29072530c7b200eb2e20b79fc2e02c0d67R20), [src/app/admin/blogs/[id]/edit/page.tsxR68](diffhunk://#diff-c15ec4e9d803f603eed1258e9925bf29072530c7b200eb2e20b79fc2e02c0d67R68))
- The `publicationDate` value is sent to the backend when creating or updating a blog post. (`src/app/admin/blogs/_components/blog-editor.tsx` [[1]](diffhunk://#diff-cb1d7681c7de72c99d5df045c5f2d933cd4e93563da3301c191a52e9bbee04fbR303) [[2]](diffhunk://#diff-cb1d7681c7de72c99d5df045c5f2d933cd4e93563da3301c191a52e9bbee04fbR319)

**Backend changes:**

- Updated the blog post schema and procedures to accept and validate an optional `publicationDate` in `YYYY-MM-DD` format. (`src/server/orpc/procedures/blog.ts` [[1]](diffhunk://#diff-fde2e60224b3cac8923ee788e6f76b16684998197561094e6518e04e60edff82R49) [[2]](diffhunk://#diff-fde2e60224b3cac8923ee788e6f76b16684998197561094e6518e04e60edff82R182)
- On create and update, if a `publicationDate` is provided, it is used to set the blog post's `createdAt` timestamp; otherwise, the default timestamp is used. (`src/server/orpc/procedures/blog.ts` [[1]](diffhunk://#diff-fde2e60224b3cac8923ee788e6f76b16684998197561094e6518e04e60edff82R145-R147) [[2]](diffhunk://#diff-fde2e60224b3cac8923ee788e6f76b16684998197561094e6518e04e60edff82R157) [[3]](diffhunk://#diff-fde2e60224b3cac8923ee788e6f76b16684998197561094e6518e04e60edff82L188-R200)

**UI improvements:**

- Added the `Calendar` icon to the UI for the new publication date field. (`src/app/admin/blogs/_components/blog-editor.tsx` [src/app/admin/blogs/_components/blog-editor.tsxR26](diffhunk://#diff-cb1d7681c7de72c99d5df045c5f2d933cd4e93563da3301c191a52e9bbee04fbR26))