### PR TITLE
Implement PR list dialog and analytics for reviewed PRs

### DIFF
--- a/src/app/EIPOH100/page.tsx
+++ b/src/app/EIPOH100/page.tsx
@@ -31,6 +31,7 @@ import {
   PartyPopper,
 } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { client } from "@/lib/orpc";
 
 const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
@@ -88,6 +89,21 @@ type ProposalBreakdown = {
   proposalType: string;
   status: string;
   prsChecked: number;
+};
+
+type PRListItem = {
+  prNumber: number;
+  repoName: string;
+  repoType: string;
+  title: string;
+  state: string;
+  mergedAt: string | null;
+  editors: string[];
+  reviews: number;
+  comments: number;
+  merges: number;
+  eipNumbers: number[];
+  githubUrl: string;
 };
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -601,6 +617,10 @@ export default function EIPOH100Page() {
   const [showBlitzAnim, setShowBlitzAnim] = useState(false);
   const [showBlitzComplete, setShowBlitzComplete] = useState(false);
   const [proposalBreakdown, setProposalBreakdown] = useState<ProposalBreakdown[]>([]);
+  const [showPRDialog, setShowPRDialog] = useState(false);
+  const [prList, setPRList] = useState<PRListItem[]>([]);
+  const [prListLoading, setPRListLoading] = useState(false);
+  const [prFilter, setPRFilter] = useState<"all" | "eips" | "ercs" | "rips">("all");
   const prevSprintStatus = React.useRef(sprint.status);
 
   const chartColors = useChartColors();
@@ -628,6 +648,20 @@ export default function EIPOH100Page() {
       setLoading(false);
     }
   }, [displayDate]);
+
+  const openPRDialog = useCallback(async () => {
+    setShowPRDialog(true);
+    if (prList.length > 0) return;
+    setPRListLoading(true);
+    try {
+      const data = await client.analytics.getEventDayPRList({ date: displayDate });
+      setPRList(data as PRListItem[]);
+    } catch (err) {
+      console.error("PR list fetch error:", err);
+    } finally {
+      setPRListLoading(false);
+    }
+  }, [displayDate, prList.length]);
 
   useEffect(() => {
     fetchData();
@@ -919,11 +953,10 @@ export default function EIPOH100Page() {
               </span>
               <button
                 type="button"
-                onClick={() => setShowBlitzComplete(true)}
-                className="inline-flex h-8 items-center gap-1 rounded-md border border-dashed border-emerald-500/50 bg-emerald-500/10 px-2.5 text-xs font-medium text-emerald-700 transition-colors hover:bg-emerald-500/15 dark:text-emerald-400"
-                title="Dev only — simulate blitz complete animation"
+                onClick={openPRDialog}
+                className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-card px-2.5 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary"
               >
-                🎉 Simulate End
+                <GitPullRequest className="h-3.5 w-3.5" />View PRs
               </button>
               <button
                 type="button"
@@ -1305,6 +1338,118 @@ export default function EIPOH100Page() {
 
       </div>
     </div>
+
+    {/* ── PR List Dialog ── */}
+    <Dialog open={showPRDialog} onOpenChange={(open) => { setShowPRDialog(open); if (!open) { setPRList([]); setPRFilter("all"); } }}>
+      <DialogContent className="max-h-[85vh] w-full max-w-3xl flex flex-col p-0">
+        <DialogHeader className="px-6 pt-6 pb-3 border-b border-border">
+          <div className="flex items-center justify-between pr-6">
+            <DialogTitle className="flex items-center gap-2">
+              <GitPullRequest className="h-4 w-4 text-primary" />
+              PRs Reviewed
+              {!prListLoading && (
+                <span className="ml-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                  {prList.filter(p => prFilter === "all" || p.repoType === prFilter).length}
+                </span>
+              )}
+            </DialogTitle>
+            <div className="flex items-center gap-1">
+              {(["all", "eips", "ercs", "rips"] as const).map(f => (
+                <button
+                  key={f}
+                  type="button"
+                  onClick={() => setPRFilter(f)}
+                  className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                    prFilter === f
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                  }`}
+                >
+                  {f === "all" ? "All" : f.toUpperCase()}
+                </button>
+              ))}
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto px-6 py-3 space-y-2">
+          {prListLoading ? (
+            <div className="flex items-center justify-center py-16 text-sm text-muted-foreground">
+              <RefreshCw className="mr-2 h-4 w-4 animate-spin" />
+              Loading PRs…
+            </div>
+          ) : prList.filter(p => prFilter === "all" || p.repoType === prFilter).length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 text-sm text-muted-foreground">
+              <GitPullRequest className="mb-2 h-8 w-8 opacity-30" />
+              No PRs found
+            </div>
+          ) : (
+            prList
+              .filter(p => prFilter === "all" || p.repoType === prFilter)
+              .map(pr => (
+                <div key={`${pr.repoName}-${pr.prNumber}`}
+                  className="rounded-lg border border-border bg-card px-4 py-3 transition-colors hover:border-primary/30 hover:bg-primary/5"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <a
+                          href={pr.githubUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-xs font-mono font-semibold text-primary hover:underline shrink-0"
+                        >
+                          #{pr.prNumber}
+                        </a>
+                        <span className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase ${
+                          pr.repoType === "ercs" ? "bg-violet-500/15 text-violet-700 dark:text-violet-400" :
+                          pr.repoType === "rips" ? "bg-cyan-500/15 text-cyan-700 dark:text-cyan-400" :
+                          "bg-indigo-500/15 text-indigo-700 dark:text-indigo-400"
+                        }`}>
+                          {pr.repoType === "ercs" ? "ERC" : pr.repoType === "rips" ? "RIP" : "EIP"}
+                        </span>
+                        {pr.mergedAt ? (
+                          <span className="shrink-0 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-semibold text-emerald-700 dark:text-emerald-400">Merged</span>
+                        ) : pr.state === "closed" ? (
+                          <span className="shrink-0 rounded-full bg-rose-500/15 px-2 py-0.5 text-[10px] font-semibold text-rose-700 dark:text-rose-400">Closed</span>
+                        ) : (
+                          <span className="shrink-0 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-semibold text-amber-700 dark:text-amber-400">Open</span>
+                        )}
+                        {pr.eipNumbers.length > 0 && pr.eipNumbers.slice(0, 3).map(n => (
+                          <span key={n} className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                            EIP-{n}
+                          </span>
+                        ))}
+                      </div>
+                      <p className="mt-1 text-sm font-medium text-foreground line-clamp-1">{pr.title}</p>
+                      <p className="mt-0.5 text-[11px] text-muted-foreground">{pr.repoName}</p>
+                    </div>
+                    <div className="flex shrink-0 flex-col items-end gap-1.5">
+                      <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                        {pr.reviews > 0 && <span className="flex items-center gap-0.5"><Eye className="h-3 w-3" />{pr.reviews}</span>}
+                        {pr.comments > 0 && <span className="flex items-center gap-0.5"><MessageSquare className="h-3 w-3" />{pr.comments}</span>}
+                        {pr.merges > 0 && <span className="flex items-center gap-0.5 text-emerald-600 dark:text-emerald-400"><GitMerge className="h-3 w-3" />{pr.merges}</span>}
+                      </div>
+                      <div className="flex flex-wrap justify-end gap-1">
+                        {pr.editors.map(e => (
+                          <span key={e} className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
+                            @{e}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ))
+          )}
+        </div>
+
+        <div className="border-t border-border px-6 py-3 text-[11px] text-muted-foreground">
+          Showing today&apos;s blitz window · Editor PRs only
+        </div>
+      </DialogContent>
+    </Dialog>
+
     </TooltipProvider>
   );
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,93 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({ className, children, ...props }: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed left-1/2 top-1/2 z-50 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border bg-background shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+          <XIcon className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div data-slot="dialog-header" className={cn("flex flex-col gap-1.5 p-6 pb-4", className)} {...props} />
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-base font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/server/orpc/procedures/analytics.ts
+++ b/src/server/orpc/procedures/analytics.ts
@@ -6837,14 +6837,16 @@ export const analyticsProcedures = {
           COUNT(*)::bigint AS total_events
         FROM pr_events pe
         JOIN repositories r ON pe.repository_id = r.id
-        WHERE pe.created_at >= $1::date
+        WHERE LOWER(pe.actor) = ANY($3::text[])
+          AND pe.created_at >= $1::date
           AND pe.created_at < $1::date + INTERVAL '1 day'
           AND ($2::text IS NULL OR LOWER(SPLIT_PART(r.name, '/', 2)) = LOWER($2))
         GROUP BY DATE_TRUNC('hour', pe.created_at)
         ORDER BY hour ASC
         `,
         targetDate,
-        input.repo ?? null
+        input.repo ?? null,
+        CANONICAL_EIP_EDITOR_LOWER
       );
       return results.map((r) => ({
         hour: r.hour.toISOString(),
@@ -6860,8 +6862,6 @@ export const analyticsProcedures = {
     }))
     .handler(async ({ input }) => {
       const targetDate = input.date ?? new Date().toISOString().slice(0, 10);
-      // Exclude bots and associate editors that would skew sprint metrics
-      const EXCLUDED = ['abcoathup', 'eip-review-bot'];
       const results = await prisma.$queryRawUnsafe<Array<{
         editor: string;
         prs_reviewed: bigint;
@@ -6880,17 +6880,16 @@ export const analyticsProcedures = {
           COUNT(*) FILTER (WHERE pe.event_type = 'merged')::bigint AS merges
         FROM pr_events pe
         JOIN repositories r ON pe.repository_id = r.id
-        WHERE pe.actor_role = 'EDITOR'
+        WHERE LOWER(pe.actor) = ANY($3::text[])
           AND pe.created_at >= $1::date
           AND pe.created_at < $1::date + INTERVAL '1 day'
-          AND pe.actor != ALL($3::text[])
           AND ($2::text IS NULL OR LOWER(SPLIT_PART(r.name, '/', 2)) = LOWER($2))
         GROUP BY pe.actor
         ORDER BY prs_reviewed DESC, total_events DESC
         `,
         targetDate,
         input.repo ?? null,
-        EXCLUDED
+        CANONICAL_EIP_EDITOR_LOWER
       );
       return results.map((r) => ({
         editor: r.editor,
@@ -6991,12 +6990,14 @@ export const analyticsProcedures = {
           COUNT(DISTINCT pe.pr_number)::bigint AS prs_checked
         FROM pr_events pe
         JOIN repositories r ON pe.repository_id = r.id
-        WHERE pe.created_at >= $1::date
+        WHERE LOWER(pe.actor) = ANY($2::text[])
+          AND pe.created_at >= $1::date
           AND pe.created_at < $1::date + INTERVAL '1 day'
         GROUP BY DATE_TRUNC('hour', pe.created_at), LOWER(SPLIT_PART(r.name, '/', 2))
         ORDER BY hour ASC
         `,
-        targetDate
+        targetDate,
+        CANONICAL_EIP_EDITOR_LOWER
       );
       return results.map((r) => ({
         hour: r.hour.toISOString(),
@@ -7032,20 +7033,84 @@ export const analyticsProcedures = {
         JOIN pull_request_eips pei ON pei.pr_number = pe.pr_number AND pei.repository_id = pe.repository_id
         JOIN eips e ON e.eip_number = pei.eip_number
         LEFT JOIN eip_snapshots s ON s.eip_id = e.id
-        WHERE pe.created_at >= $1::date + ($2 || ' hours')::interval
+        WHERE LOWER(pe.actor) = ANY($4::text[])
+          AND pe.created_at >= $1::date + ($2 || ' hours')::interval
           AND pe.created_at <  $1::date + ($3 || ' hours')::interval
         GROUP BY s.category, proposal_type, s.status
         ORDER BY prs_checked DESC
         `,
         targetDate,
         input.startHour,
-        input.endHour
+        input.endHour,
+        CANONICAL_EIP_EDITOR_LOWER
       );
       return results.map(r => ({
         category: r.category ?? 'Unknown',
         proposalType: r.proposal_type,
         status: r.status ?? 'Unknown',
         prsChecked: Number(r.prs_checked),
+      }));
+    }),
+
+  getEventDayPRList: optionalAuthProcedure
+    .input(z.object({
+      date: z.string().optional(),
+    }))
+    .handler(async ({ input }) => {
+      const targetDate = input.date ?? new Date().toISOString().slice(0, 10);
+      const results = await prisma.$queryRawUnsafe<Array<{
+        pr_number: number;
+        repo_name: string;
+        repo_type: string;
+        title: string | null;
+        state: string | null;
+        merged_at: Date | null;
+        editors: string[];
+        reviews: bigint;
+        comments: bigint;
+        merges: bigint;
+        eip_numbers: number[];
+      }>>(
+        `
+        SELECT
+          pe.pr_number,
+          r.name AS repo_name,
+          LOWER(SPLIT_PART(r.name, '/', 2)) AS repo_type,
+          pr.title,
+          pr.state,
+          pr.merged_at,
+          ARRAY_AGG(DISTINCT pe.actor ORDER BY pe.actor) AS editors,
+          COUNT(*) FILTER (WHERE pe.event_type IN ('reviewed', 'approved', 'changes_requested'))::bigint AS reviews,
+          COUNT(*) FILTER (WHERE pe.event_type IN ('commented', 'issue_comment', 'review_comment'))::bigint AS comments,
+          COUNT(*) FILTER (WHERE pe.event_type = 'merged')::bigint AS merges,
+          COALESCE(ARRAY_AGG(DISTINCT pei.eip_number) FILTER (WHERE pei.eip_number IS NOT NULL), '{}') AS eip_numbers
+        FROM pr_events pe
+        JOIN repositories r ON pe.repository_id = r.id
+        LEFT JOIN pull_requests pr ON pr.pr_number = pe.pr_number AND pr.repository_id = pe.repository_id
+        LEFT JOIN pull_request_eips pei ON pei.pr_number = pe.pr_number AND pei.repository_id = pe.repository_id
+        WHERE LOWER(pe.actor) = ANY($2::text[])
+          AND pe.created_at >= $1::date
+          AND pe.created_at < $1::date + INTERVAL '1 day'
+        GROUP BY pe.pr_number, r.name, repo_type, pr.title, pr.state, pr.merged_at
+        ORDER BY MAX(pe.created_at) DESC
+        LIMIT 200
+        `,
+        targetDate,
+        CANONICAL_EIP_EDITOR_LOWER
+      );
+      return results.map(r => ({
+        prNumber: r.pr_number,
+        repoName: r.repo_name,
+        repoType: r.repo_type,
+        title: r.title ?? `PR #${r.pr_number}`,
+        state: r.state ?? 'open',
+        mergedAt: r.merged_at?.toISOString() ?? null,
+        editors: r.editors,
+        reviews: Number(r.reviews),
+        comments: Number(r.comments),
+        merges: Number(r.merges),
+        eipNumbers: r.eip_numbers.map(Number),
+        githubUrl: `https://github.com/${r.repo_name}/pull/${r.pr_number}`,
       }));
     }),
 }


### PR DESCRIPTION
This pull request adds a new feature to display a list of pull requests (PRs) reviewed by editors during the event day, accessible via a dialog in the EIPOH100 page. It introduces a reusable dialog component, updates the frontend to fetch and show PR data, and adds a backend procedure to provide this data. Additionally, it refines analytics queries to consistently filter by canonical EIP editors.

**Frontend: PR List Dialog and UI Enhancements**
* Adds a new dialog UI component (`Dialog`, `DialogContent`, etc.) in `src/components/ui/dialog.tsx` for consistent modal dialogs across the app.
* Updates `src/app/EIPOH100/page.tsx` to:
  - Add a "View PRs" button that opens a dialog listing PRs reviewed by editors for the selected day.
  - Fetches PR data from the backend on demand, supports filtering by repo type (EIPs, ERCs, RIPS), and displays PR metadata and editor info in a user-friendly format. [[1]](diffhunk://#diff-ac0e8f71f63ce172796dbe49579d2b7f191b277e4a02eafe2d2d1684e11770beR34) [[2]](diffhunk://#diff-ac0e8f71f63ce172796dbe49579d2b7f191b277e4a02eafe2d2d1684e11770beR94-R108) [[3]](diffhunk://#diff-ac0e8f71f63ce172796dbe49579d2b7f191b277e4a02eafe2d2d1684e11770beR620-R623) [[4]](diffhunk://#diff-ac0e8f71f63ce172796dbe49579d2b7f191b277e4a02eafe2d2d1684e11770beR652-R665) [[5]](diffhunk://#diff-ac0e8f71f63ce172796dbe49579d2b7f191b277e4a02eafe2d2d1684e11770beL922-R959) [[6]](diffhunk://#diff-ac0e8f71f63ce172796dbe49579d2b7f191b277e4a02eafe2d2d1684e11770beR1341-R1452)

**Backend: Analytics Data Consistency and New Endpoint**
* Refactors analytics queries in `src/server/orpc/procedures/analytics.ts` to consistently filter by the canonical list of EIP editors (`CANONICAL_EIP_EDITOR_LOWER`), ensuring all metrics and lists only include relevant editor activity. [[1]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9L6840-R6849) [[2]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9L6863-L6864) [[3]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9L6883-R6892) [[4]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9L6994-R7000) [[5]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9L7035-R7045)
* Adds a new `getEventDayPRList` procedure to return detailed PR information for all PRs reviewed by editors on a given day, supporting the new frontend dialog.