### PR TITLE
Fix sprint progress calculation start hour for accuracy

### DIFF
--- a/src/app/EIPOH100/page.tsx
+++ b/src/app/EIPOH100/page.tsx
@@ -183,7 +183,7 @@ function repoTagStyle(eipType: string): { label: string; cls: string } {
 function sprintProgress() {
   const now = new Date();
   const startUTC = new Date(now);
-  startUTC.setUTCHours(15, 30, 0, 0);
+  startUTC.setUTCHours(16, 0, 0, 0);
   const endUTC = new Date(now);
   endUTC.setUTCHours(BLITZ_END_HOUR_UTC, 0, 0, 0);
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the `sprintProgress` function by updating the sprint start time from 15:30 UTC to 16:00 UTC.

- Changed the start time in the `sprintProgress` function to 16:00 UTC to reflect the new sprint schedule.