### PR TITLE
Improve analytics queries for EIP counting and data accuracy

### DIFF
--- a/src/app/EIPOH100/page.tsx
+++ b/src/app/EIPOH100/page.tsx
@@ -633,7 +633,7 @@ export default function EIPOH100Page() {
         client.analytics.getEventDayHourlyByType({ date: displayDate }),
         client.analytics.getEventDayStatusChanges({ date: displayDate }),
         client.analytics.getAllRecentActivity({ limit: 10 }),
-        client.analytics.getEventDayProposalBreakdown({ date: displayDate, startHour: 15.5, endHour: BLITZ_END_HOUR_UTC }),
+        client.analytics.getEventDayProposalBreakdown({ date: displayDate }),
       ]);
       setLeaderboard(editors as EditorEntry[]);
       setHourlyActivity(hourly);
@@ -867,10 +867,10 @@ export default function EIPOH100Page() {
     proposalBreakdown.forEach(r => byStatus.set(r.status, (byStatus.get(r.status) ?? 0) + r.prsChecked));
     const statusEntries = [...byStatus.entries()].sort((a, b) => b[1] - a[1]);
 
-    // Group by category for the right chart
+    // Group by category for the right chart (eip_snapshots.category: Core, ERC, Interface, Meta, etc.)
     const byCategory = new Map<string, number>();
     proposalBreakdown.forEach(r => {
-      const cat = r.category === "ERC" ? "ERC" : r.category || r.proposalType;
+      const cat = r.category && r.category !== 'Unknown' ? r.category : r.proposalType;
       byCategory.set(cat, (byCategory.get(cat) ?? 0) + r.prsChecked);
     });
     const catEntries = [...byCategory.entries()].sort((a, b) => b[1] - a[1]);

--- a/src/app/EIPOH100/page.tsx
+++ b/src/app/EIPOH100/page.tsx
@@ -108,7 +108,7 @@ type PRListItem = {
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const EVENT_DATE = "2025-06-02";
+const EVENT_DATE = "2026-06-02";
 const BLITZ_START_HOUR_UTC = 15;   // hourly bucket filter (catches 15:30+ data)
 const BLITZ_END_HOUR_UTC   = 18;
 const EXCLUDED_ACTORS = new Set(["abcoathup", "eip-review-bot"]);
@@ -600,8 +600,7 @@ function BlitzCompleteAnimation({ label, summary, onDismiss }: {
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function EIPOH100Page() {
-  const today = new Date().toISOString().slice(0, 10);
-  const displayDate = today === EVENT_DATE ? EVENT_DATE : today;
+  const displayDate = EVENT_DATE;
   const blitzLabel = `EIP/ERC Blitz · ${new Date(displayDate + "T12:00:00Z").toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}`;
 
   const [leaderboard, setLeaderboard] = useState<EditorEntry[]>([]);

--- a/src/server/orpc/procedures/analytics.ts
+++ b/src/server/orpc/procedures/analytics.ts
@@ -6958,7 +6958,7 @@ export const analyticsProcedures = {
         LEFT JOIN repositories r ON se.repository_id = r.id
         WHERE se.changed_at >= $1::date
           AND se.changed_at < $1::date + INTERVAL '1 day'
-          AND (se.pr_number IS NULL OR se.pr_number != 1689)
+          AND se.eip_id != 8136
         GROUP BY se.from_status, se.to_status, proposal_type
         ORDER BY count DESC
         `,
@@ -7033,7 +7033,7 @@ export const analyticsProcedures = {
         LEFT JOIN repositories r ON se.repository_id = r.id
         WHERE se.changed_at >= $1::date
           AND se.changed_at < $1::date + INTERVAL '18 hours'
-          AND (se.pr_number IS NULL OR se.pr_number != 1689)
+          AND se.eip_id != 8136
         GROUP BY proposal_type, s.category, se.to_status
         ORDER BY prs_checked DESC
         `,

--- a/src/server/orpc/procedures/analytics.ts
+++ b/src/server/orpc/procedures/analytics.ts
@@ -7019,7 +7019,7 @@ export const analyticsProcedures = {
           CASE WHEN r.name ILIKE '%ERCs%' THEN 'ERC'
                WHEN r.name ILIKE '%RIPs%' THEN 'RIP'
                ELSE 'EIP' END AS proposal_type,
-          COALESCE(s.category, s.type, 'Unknown') AS category,
+          COALESCE(NULLIF(s.category, ''), NULLIF(s.type, ''), 'Unknown') AS category,
           se.to_status AS status,
           COUNT(DISTINCT se.eip_id)::bigint AS prs_checked
         FROM eip_status_events se
@@ -7029,7 +7029,7 @@ export const analyticsProcedures = {
         WHERE se.changed_at >= $1::date
           AND se.changed_at < $1::date + INTERVAL '18 hours'
           AND se.eip_id != 8136
-        GROUP BY proposal_type, s.category, s.type, se.to_status
+        GROUP BY proposal_type, COALESCE(NULLIF(s.category, ''), NULLIF(s.type, ''), 'Unknown'), se.to_status
         ORDER BY prs_checked DESC
         `,
         targetDate

--- a/src/server/orpc/procedures/analytics.ts
+++ b/src/server/orpc/procedures/analytics.ts
@@ -6951,13 +6951,14 @@ export const analyticsProcedures = {
           se.from_status,
           se.to_status,
           CASE WHEN s.category = 'ERC' THEN 'ERC' WHEN r.name LIKE '%RIPs%' THEN 'RIP' ELSE 'EIP' END AS proposal_type,
-          COUNT(*)::bigint AS count
+          COUNT(DISTINCT se.eip_id)::bigint AS count
         FROM eip_status_events se
         JOIN eips e ON se.eip_id = e.id
         LEFT JOIN eip_snapshots s ON s.eip_id = e.id
         LEFT JOIN repositories r ON se.repository_id = r.id
         WHERE se.changed_at >= $1::date
           AND se.changed_at < $1::date + INTERVAL '1 day'
+          AND (se.pr_number IS NULL OR se.pr_number != 1689)
         GROUP BY se.from_status, se.to_status, proposal_type
         ORDER BY count DESC
         `,
@@ -7009,45 +7010,38 @@ export const analyticsProcedures = {
   getEventDayProposalBreakdown: optionalAuthProcedure
     .input(z.object({
       date: z.string().optional(),
-      startHour: z.number().min(0).max(23).optional().default(0),
-      endHour: z.number().min(1).max(24).optional().default(24),
     }))
     .handler(async ({ input }) => {
       const targetDate = input.date ?? new Date().toISOString().slice(0, 10);
       const results = await prisma.$queryRawUnsafe<Array<{
-        category: string | null;
         proposal_type: string;
-        status: string | null;
+        category: string | null;
+        status: string;
         prs_checked: bigint;
       }>>(
         `
         SELECT
-          COALESCE(s.category, 'Unknown') AS category,
-          CASE WHEN s.category = 'ERC' THEN 'ERC'
-               WHEN r.name LIKE '%RIPs%' THEN 'RIP'
+          CASE WHEN r.name ILIKE '%ERCs%' THEN 'ERC'
+               WHEN r.name ILIKE '%RIPs%' THEN 'RIP'
                ELSE 'EIP' END AS proposal_type,
-          COALESCE(s.status, 'Unknown') AS status,
-          COUNT(DISTINCT e.eip_number)::bigint AS prs_checked
-        FROM pr_events pe
-        JOIN repositories r ON pe.repository_id = r.id
-        JOIN pull_request_eips pei ON pei.pr_number = pe.pr_number AND pei.repository_id = pe.repository_id
-        JOIN eips e ON e.eip_number = pei.eip_number
-        LEFT JOIN eip_snapshots s ON s.eip_id = e.id AND s.repository_id = pe.repository_id
-        WHERE LOWER(pe.actor) = ANY($4::text[])
-          AND pe.created_at >= $1::date + ($2 || ' hours')::interval
-          AND pe.created_at <  $1::date + ($3 || ' hours')::interval
-          AND s.eip_id IS NOT NULL
-        GROUP BY s.category, proposal_type, s.status
+          COALESCE(s.category, 'Unknown') AS category,
+          se.to_status AS status,
+          COUNT(DISTINCT se.eip_id)::bigint AS prs_checked
+        FROM eip_status_events se
+        JOIN eips e ON se.eip_id = e.id
+        LEFT JOIN eip_snapshots s ON s.eip_id = e.id
+        LEFT JOIN repositories r ON se.repository_id = r.id
+        WHERE se.changed_at >= $1::date
+          AND se.changed_at < $1::date + INTERVAL '18 hours'
+          AND (se.pr_number IS NULL OR se.pr_number != 1689)
+        GROUP BY proposal_type, s.category, se.to_status
         ORDER BY prs_checked DESC
         `,
-        targetDate,
-        input.startHour,
-        input.endHour,
-        CANONICAL_EIP_EDITOR_LOWER
+        targetDate
       );
       return results.map(r => ({
         category: r.category ?? 'Unknown',
-        proposalType: r.proposal_type,
+        proposalType: r.proposal_type ?? 'Unknown',
         status: r.status ?? 'Unknown',
         prsChecked: Number(r.prs_checked),
       }));

--- a/src/server/orpc/procedures/analytics.ts
+++ b/src/server/orpc/procedures/analytics.ts
@@ -6943,23 +6943,18 @@ export const analyticsProcedures = {
       const results = await prisma.$queryRawUnsafe<Array<{
         from_status: string | null;
         to_status: string;
-        proposal_type: string;
         count: bigint;
       }>>(
         `
         SELECT
           se.from_status,
           se.to_status,
-          CASE WHEN s.category = 'ERC' THEN 'ERC' WHEN r.name LIKE '%RIPs%' THEN 'RIP' ELSE 'EIP' END AS proposal_type,
           COUNT(DISTINCT se.eip_id)::bigint AS count
         FROM eip_status_events se
-        JOIN eips e ON se.eip_id = e.id
-        LEFT JOIN eip_snapshots s ON s.eip_id = e.id
-        LEFT JOIN repositories r ON se.repository_id = r.id
         WHERE se.changed_at >= $1::date
           AND se.changed_at < $1::date + INTERVAL '1 day'
           AND se.eip_id != 8136
-        GROUP BY se.from_status, se.to_status, proposal_type
+        GROUP BY se.from_status, se.to_status
         ORDER BY count DESC
         `,
         targetDate
@@ -6967,7 +6962,7 @@ export const analyticsProcedures = {
       return results.map((r) => ({
         fromStatus: r.from_status ?? '—',
         toStatus: r.to_status,
-        proposalType: r.proposal_type,
+        proposalType: '',
         count: Number(r.count),
         label: `${r.from_status ?? 'New'} → ${r.to_status}`,
       }));
@@ -7024,7 +7019,7 @@ export const analyticsProcedures = {
           CASE WHEN r.name ILIKE '%ERCs%' THEN 'ERC'
                WHEN r.name ILIKE '%RIPs%' THEN 'RIP'
                ELSE 'EIP' END AS proposal_type,
-          COALESCE(s.category, 'Unknown') AS category,
+          COALESCE(s.category, s.type, 'Unknown') AS category,
           se.to_status AS status,
           COUNT(DISTINCT se.eip_id)::bigint AS prs_checked
         FROM eip_status_events se
@@ -7034,7 +7029,7 @@ export const analyticsProcedures = {
         WHERE se.changed_at >= $1::date
           AND se.changed_at < $1::date + INTERVAL '18 hours'
           AND se.eip_id != 8136
-        GROUP BY proposal_type, s.category, se.to_status
+        GROUP BY proposal_type, s.category, s.type, se.to_status
         ORDER BY prs_checked DESC
         `,
         targetDate


### PR DESCRIPTION
This pull request updates the EIP/ERC Blitz event page and related analytics queries to improve data accuracy and simplify the code. The main changes include updating the event date, refactoring how proposal breakdowns are calculated and displayed, and cleaning up the handling of proposal categories and statuses.

**Event date update:**

* Changed the `EVENT_DATE` constant in `page.tsx` from 2025-06-02 to 2026-06-02.
* Updated the page to always use `EVENT_DATE` for display, instead of sometimes using today's date.

**Proposal breakdown and analytics improvements:**

* The `getEventDayProposalBreakdown` query now:
  - Removes the use of `startHour` and `endHour` parameters, simplifying the API and always querying for the first 18 hours of the day. [[1]](diffhunk://#diff-ac0e8f71f63ce172796dbe49579d2b7f191b277e4a02eafe2d2d1684e11770beL636-R635) [[2]](diffhunk://#diff-53d1402f2ae35af79cd2745590ab5d6e234c2a4975ff53ea9cf681fd4580c4a9L7012-R7039)
  - Refactors the SQL to use `eip_status_events` as the source of truth, ensuring more accurate proposal status and category breakdowns, and excludes a specific EIP (`eip_id != 8136`).
  - Improves category determination by preferring non-empty `category`, then `type`, then 'Unknown'.
  - Cleans up proposal type logic and ensures status is always a string.
* The client code now calls the updated `getEventDayProposalBreakdown` without hour parameters.

**Status and category grouping logic:**

* In the page logic, category grouping now checks for a valid, non-'Unknown' category before falling back to `proposalType`, improving chart accuracy.

**Other analytics query cleanup:**

* The `getEventDayStatusChanges` query removes the `proposal_type` field and simplifies grouping, improving the accuracy of status change counts.