### PR TITLE
Add total PRs calculation for event day analytics

### DIFF
--- a/src/app/EIPOH100/page.tsx
+++ b/src/app/EIPOH100/page.tsx
@@ -608,6 +608,7 @@ export default function EIPOH100Page() {
   const [hourlyByType, setHourlyByType] = useState<HourlyByType[]>([]);
   const [statusChanges, setStatusChanges] = useState<StatusChange[]>([]);
   const [recentActivity, setRecentActivity] = useState<RecentActivity[]>([]);
+  const [totalPRsDistinct, setTotalPRsDistinct] = useState<number>(0);
   const [loading, setLoading] = useState(true);
   const [lastRefreshed, setLastRefreshed] = useState<Date | null>(null);
   const [sprint, setSprint] = useState(sprintProgress());
@@ -626,13 +627,14 @@ export default function EIPOH100Page() {
 
   const fetchData = useCallback(async () => {
     try {
-      const [editors, hourly, byType, changes, activity, breakdown] = await Promise.all([
+      const [editors, hourly, byType, changes, activity, breakdown, totalPRs] = await Promise.all([
         client.analytics.getEventDayEditorLeaderboard({ date: displayDate }),
         client.analytics.getEventDayActivity({ date: displayDate }),
         client.analytics.getEventDayHourlyByType({ date: displayDate }),
         client.analytics.getEventDayStatusChanges({ date: displayDate }),
         client.analytics.getAllRecentActivity({ limit: 10 }),
         client.analytics.getEventDayProposalBreakdown({ date: displayDate }),
+        client.analytics.getEventDayTotalPRs({ date: displayDate }),
       ]);
       setLeaderboard(editors as EditorEntry[]);
       setHourlyActivity(hourly);
@@ -640,6 +642,7 @@ export default function EIPOH100Page() {
       setStatusChanges(changes);
       setRecentActivity(activity as typeof recentActivity);
       setProposalBreakdown(breakdown);
+      setTotalPRsDistinct(totalPRs.totalPRs);
       setLastRefreshed(new Date());
     } catch (err) {
       console.error("EIPOH100 fetch error:", err);
@@ -700,7 +703,6 @@ export default function EIPOH100Page() {
     () => hourlyActivity.filter(h => afterBlitzStart(h.hour)),
     [hourlyActivity, afterBlitzStart]
   );
-  const totalPRs = useMemo(() => blitzHourly.reduce((s, h) => s + h.prsChecked, 0), [blitzHourly]);
   const actionBreakdown = useMemo(() => ({
     reviews:  leaderboard.reduce((s, e) => s + e.reviews, 0),
     comments: leaderboard.reduce((s, e) => s + e.comments, 0),
@@ -715,7 +717,7 @@ export default function EIPOH100Page() {
       .forEach(r => typeMap.set(r.repoType, (typeMap.get(r.repoType) ?? 0) + r.prsChecked));
     const topRepoEntry = [...typeMap.entries()].sort((a, b) => b[1] - a[1])[0];
     return {
-      totalPRs,
+      totalPRs: totalPRsDistinct,
       totalActions: actionBreakdown.total,
       reviews: actionBreakdown.reviews,
       comments: actionBreakdown.comments,
@@ -725,7 +727,7 @@ export default function EIPOH100Page() {
       statusChanges: statusChanges.reduce((s, c) => s + c.count, 0),
       topRepo: topRepoEntry?.[0] ?? "",
     };
-  }, [totalPRs, actionBreakdown, leaderboard, statusChanges, hourlyByType, afterBlitzStart]);
+  }, [totalPRsDistinct, actionBreakdown, leaderboard, statusChanges, hourlyByType, afterBlitzStart]);
 
   // ─── Filtered recent activity (exclude bots / associate editors) ─────────
   const filteredActivity = useMemo(
@@ -1008,7 +1010,7 @@ export default function EIPOH100Page() {
               <Tip text="Distinct PRs touched by editors during the 16:00–18:00 UTC blitz window." />
             </div>
             {loading ? <div className="h-8 w-14 animate-pulse rounded-md bg-muted" /> :
-              <p className="text-2xl font-bold tabular-nums text-foreground">{totalPRs}</p>}
+              <p className="text-2xl font-bold tabular-nums text-foreground">{totalPRsDistinct}</p>}
           </motion.div>
 
           <motion.div initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.3, delay: 0.17 }}

--- a/src/server/orpc/procedures/analytics.ts
+++ b/src/server/orpc/procedures/analytics.ts
@@ -6855,6 +6855,26 @@ export const analyticsProcedures = {
       }));
     }),
 
+  getEventDayTotalPRs: optionalAuthProcedure
+    .input(z.object({
+      date: z.string().optional(),
+    }))
+    .handler(async ({ input }) => {
+      const targetDate = input.date ?? new Date().toISOString().slice(0, 10);
+      const [row] = await prisma.$queryRawUnsafe<Array<{ total_prs: bigint }>>(
+        `
+        SELECT COUNT(DISTINCT pe.pr_number)::bigint AS total_prs
+        FROM pr_events pe
+        WHERE LOWER(pe.actor) = ANY($2::text[])
+          AND pe.created_at >= $1::date + INTERVAL '15 hours 30 minutes'
+          AND pe.created_at < $1::date + INTERVAL '18 hours'
+        `,
+        targetDate,
+        CANONICAL_EIP_EDITOR_LOWER
+      );
+      return { totalPRs: Number(row?.total_prs ?? 0) };
+    }),
+
   getEventDayEditorLeaderboard: optionalAuthProcedure
     .input(z.object({
       date: z.string().optional(),


### PR DESCRIPTION
This pull request updates the EIPOH100 dashboard to more accurately report the number of distinct pull requests (PRs) touched by editors during the blitz window. It introduces a new backend procedure to calculate this value directly from the database, updates the frontend to use this new value, and removes the previous estimation logic.

**Backend enhancements:**

* Added a new analytics procedure `getEventDayTotalPRs` in `analytics.ts` to efficiently compute the count of distinct PRs touched by editors during the 16:00–18:00 UTC blitz window using a SQL query.

**Frontend updates:**

* Added a new state variable `totalPRsDistinct` in `EIPOH100/page.tsx` and updated the data fetching logic to call the new backend procedure and set this value. [[1]](diffhunk://#diff-ac0e8f71f63ce172796dbe49579d2b7f191b277e4a02eafe2d2d1684e11770beR611) [[2]](diffhunk://#diff-ac0e8f71f63ce172796dbe49579d2b7f191b277e4a02eafe2d2d1684e11770beL629-R645)
* Replaced all usage of the old `totalPRs` calculation (which summed PRs from hourly activity) with the new `totalPRsDistinct` value in summary statistics and UI display. [[1]](diffhunk://#diff-ac0e8f71f63ce172796dbe49579d2b7f191b277e4a02eafe2d2d1684e11770beL703) [[2]](diffhunk://#diff-ac0e8f71f63ce172796dbe49579d2b7f191b277e4a02eafe2d2d1684e11770beL718-R720) [[3]](diffhunk://#diff-ac0e8f71f63ce172796dbe49579d2b7f191b277e4a02eafe2d2d1684e11770beL728-R730) [[4]](diffhunk://#diff-ac0e8f71f63ce172796dbe49579d2b7f191b277e4a02eafe2d2d1684e11770beL1011-R1013)

These changes ensure the dashboard displays an accurate, de-duplicated count of PRs for the blitz window, improving the reliability of the event’s metrics.