### PR TITLE
feat: Implement Year in Review Insights & User Watchlist Dashboard

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -63,5 +63,3 @@
 | News & Videos page implementations | ✅ Implemented |
 | Analytics export (CSV/JSON) | ✅ Implemented |
 | Author page navigation | ✅ Implemented |
-| Year in Review Infographic Page (`/insights/review/[year]`) | ✅ Implemented |
-| User Watchlist Dashboard (`/dashboard/watchlist`) | ✅ Implemented |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -63,3 +63,5 @@
 | News & Videos page implementations | ✅ Implemented |
 | Analytics export (CSV/JSON) | ✅ Implemented |
 | Author page navigation | ✅ Implemented |
+| Year in Review Infographic Page (`/insights/review/[year]`) | ✅ Implemented |
+| User Watchlist Dashboard (`/dashboard/watchlist`) | ✅ Implemented |

--- a/prisma/migrations/20260706000000_add_author_subscription/migration.sql
+++ b/prisma/migrations/20260706000000_add_author_subscription/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable
+CREATE TABLE "author_subscription" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "author_name" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "author_subscription_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "idx_author_subscription_user" ON "author_subscription"("user_id");
+
+-- CreateIndex
+CREATE INDEX "idx_author_subscription_author" ON "author_subscription"("author_name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "author_subscription_unique" ON "author_subscription"("user_id", "author_name");
+
+-- AddForeignKey
+ALTER TABLE "author_subscription" ADD CONSTRAINT "author_subscription_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AlterTable
+ALTER TABLE "NotificationOutbox" ADD COLUMN "author_subscription_id" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "NotificationOutbox" ADD CONSTRAINT "NotificationOutbox_author_subscription_id_fkey" FOREIGN KEY ("author_subscription_id") REFERENCES "author_subscription"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model User {
   repository_subscriptions RepositorySubscription[]
   sessions               Session[]
   upgrade_subscriptions  UpgradeSubscription[]
+  author_subscriptions   AuthorSubscription[]
   preferences            user_preferences?
 
   @@map("user")
@@ -476,12 +477,28 @@ model UpgradeSubscription {
   @@map("upgrade_subscription")
 }
 
+model AuthorSubscription {
+  id                   String                @id @default(cuid())
+  user_id              String
+  author_name          String
+  created_at           DateTime              @default(now())
+  updated_at           DateTime              @updatedAt
+  notification_outbox  NotificationOutbox[]
+  user                 User                  @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@unique([user_id, author_name], map: "author_subscription_unique")
+  @@index([user_id], map: "idx_author_subscription_user")
+  @@index([author_name], map: "idx_author_subscription_author")
+  @@map("author_subscription")
+}
+
 model NotificationOutbox {
   id                  String                @id @default(cuid())
   user_id             String
   proposal_subscription_id String?
   repository_subscription_id String?
   upgrade_subscription_id String?
+  author_subscription_id String?
   dedupe_key          String                @unique
   channel             String                @default("email")
   template            String
@@ -498,6 +515,7 @@ model NotificationOutbox {
   proposal_subscription ProposalSubscription? @relation(fields: [proposal_subscription_id], references: [id], onDelete: SetNull)
   repository_subscription RepositorySubscription? @relation(fields: [repository_subscription_id], references: [id], onDelete: SetNull)
   upgrade_subscription UpgradeSubscription? @relation(fields: [upgrade_subscription_id], references: [id], onDelete: SetNull)
+  author_subscription AuthorSubscription? @relation(fields: [author_subscription_id], references: [id], onDelete: SetNull)
   user                User                  @relation(fields: [user_id], references: [id], onDelete: Cascade)
 
   @@index([status, created_at], map: "idx_notification_outbox_status_created")

--- a/src/app/dashboard/watchlist/page.tsx
+++ b/src/app/dashboard/watchlist/page.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { motion, AnimatePresence } from "framer-motion";
+import { BookOpen, FolderGit2, Loader2, Package, Users, Bell } from "lucide-react";
+import { client } from "@/lib/orpc";
+import { WatchToggle } from "@/components/watch-toggle";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+type WatchlistState = Awaited<ReturnType<typeof client.watchlist.getWatchlist>>;
+
+export default function WatchlistPage() {
+  const [data, setData] = useState<WatchlistState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState<"proposals" | "repositories" | "upgrades" | "authors">("proposals");
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const result = await client.watchlist.getWatchlist({});
+        setData(result);
+      } catch (error) {
+        console.error("Failed to load watchlist", error);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex h-[400px] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  const tabs = [
+    { id: "proposals", label: "Proposals", icon: BookOpen, count: data?.proposals.length || 0 },
+    { id: "repositories", label: "Repositories", icon: FolderGit2, count: data?.repositories.length || 0 },
+    { id: "upgrades", label: "Upgrades", icon: Package, count: data?.upgrades.length || 0 },
+    { id: "authors", label: "Authors", icon: Users, count: data?.authors.length || 0 },
+  ] as const;
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-8 p-6 md:p-8">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Watchlist</h1>
+        <p className="text-muted-foreground mt-2">
+          Manage your pinned EIPs, repositories, network upgrades, and authors.
+        </p>
+      </div>
+
+      <div className="flex space-x-1 rounded-xl bg-muted/50 p-1">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id as any)}
+            className={`flex flex-1 items-center justify-center gap-2 rounded-lg px-3 py-2.5 text-sm font-medium transition-all ${
+              activeTab === tab.id
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:bg-background/50 hover:text-foreground"
+            }`}
+          >
+            <tab.icon className="h-4 w-4" />
+            <span className="hidden sm:inline">{tab.label}</span>
+            <Badge variant="secondary" className="ml-1 px-1.5 min-w-[20px] justify-center">
+              {tab.count}
+            </Badge>
+          </button>
+        ))}
+      </div>
+
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={activeTab}
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -10 }}
+          transition={{ duration: 0.2 }}
+        >
+          {activeTab === "proposals" && (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {data?.proposals.length === 0 ? (
+                <EmptyState type="proposals" />
+              ) : (
+                data?.proposals.map((item) => (
+                  <Card key={item.id} className="flex flex-col">
+                    <CardHeader className="flex-row items-start justify-between space-y-0 pb-2">
+                      <div className="space-y-1">
+                        <Link href={item.path} className="font-semibold hover:underline">
+                          {item.repo.toUpperCase()}-{item.number}
+                        </Link>
+                        {item.status && (
+                          <Badge variant="outline" className="ml-2">
+                            {item.status}
+                          </Badge>
+                        )}
+                      </div>
+                      <WatchToggle itemType="proposal" itemId={`${item.repo}-${item.number}`} initialWatched />
+                    </CardHeader>
+                    <CardContent className="flex-1">
+                      <p className="text-sm text-muted-foreground line-clamp-2">{item.title}</p>
+                    </CardContent>
+                  </Card>
+                ))
+              )}
+            </div>
+          )}
+
+          {activeTab === "repositories" && (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {data?.repositories.length === 0 ? (
+                <EmptyState type="repositories" />
+              ) : (
+                data?.repositories.map((item) => (
+                  <Card key={item.id} className="flex flex-col">
+                    <CardHeader className="flex-row items-center justify-between space-y-0">
+                      <Link href={item.path} className="font-semibold hover:underline">
+                        {item.label}
+                      </Link>
+                      <WatchToggle itemType="repository" itemId={item.repo} initialWatched />
+                    </CardHeader>
+                  </Card>
+                ))
+              )}
+            </div>
+          )}
+
+          {activeTab === "upgrades" && (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {data?.upgrades.length === 0 ? (
+                <EmptyState type="upgrades" />
+              ) : (
+                data?.upgrades.map((item) => (
+                  <Card key={item.id} className="flex flex-col">
+                    <CardHeader className="flex-row items-center justify-between space-y-0">
+                      <Link href={item.path} className="font-semibold hover:underline">
+                        {item.name}
+                      </Link>
+                      <WatchToggle itemType="upgrade" itemId={item.slug} initialWatched />
+                    </CardHeader>
+                  </Card>
+                ))
+              )}
+            </div>
+          )}
+
+          {activeTab === "authors" && (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {data?.authors.length === 0 ? (
+                <EmptyState type="authors" />
+              ) : (
+                data?.authors.map((item) => (
+                  <Card key={item.id} className="flex flex-col">
+                    <CardHeader className="flex-row items-center justify-between space-y-0">
+                      <Link href={item.path} className="font-semibold hover:underline">
+                        {item.name}
+                      </Link>
+                      <WatchToggle itemType="author" itemId={item.name} initialWatched />
+                    </CardHeader>
+                  </Card>
+                ))
+              )}
+            </div>
+          )}
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}
+
+function EmptyState({ type }: { type: string }) {
+  return (
+    <div className="col-span-full flex flex-col items-center justify-center rounded-xl border border-dashed py-12 text-center">
+      <div className="mb-4 rounded-full bg-muted p-4">
+        <Bell className="h-6 w-6 text-muted-foreground" />
+      </div>
+      <h3 className="text-lg font-semibold">No watched {type}</h3>
+      <p className="mt-2 max-w-sm text-sm text-muted-foreground">
+        You aren't watching any {type} yet. When you see something interesting, click the Watch button to keep track of it here.
+      </p>
+    </div>
+  );
+}

--- a/src/app/insights/review/[year]/client-page.tsx
+++ b/src/app/insights/review/[year]/client-page.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import { Loader2, TrendingUp, Users, CheckCircle2, FileText, User } from "lucide-react";
+import { 
+  Bar, BarChart, CartesianGrid, XAxis, YAxis, Tooltip, ResponsiveContainer,
+  PieChart, Pie, Cell, Legend
+} from "recharts";
+import { client } from "@/lib/orpc";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+type YearInReviewData = Awaited<ReturnType<typeof client.insights.getYearInReview>>;
+
+const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899'];
+
+export default function YearInReviewClient({ year }: { year: number }) {
+  const [data, setData] = useState<YearInReviewData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchYear() {
+      try {
+        const result = await client.insights.getYearInReview({ year });
+        setData(result);
+      } catch (err) {
+        console.error("Failed to load year in review", err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchYear();
+  }, [year]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <Loader2 className="h-10 w-10 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (!data || (data.proposedCount === 0 && data.finalizedCount === 0)) {
+    return (
+      <div className="flex min-h-[50vh] flex-col items-center justify-center text-center p-8">
+        <FolderEmptyIcon className="mb-6 h-16 w-16 text-muted-foreground opacity-50" />
+        <h1 className="text-3xl font-bold">No Data for {year}</h1>
+        <p className="mt-4 max-w-md text-muted-foreground">
+          We couldn't find any significant Ethereum standards activity for this year. Try selecting a different year.
+        </p>
+      </div>
+    );
+  }
+
+  const containerVariants = {
+    hidden: { opacity: 0 },
+    show: { opacity: 1, transition: { staggerChildren: 0.1 } }
+  };
+
+  const itemVariants = {
+    hidden: { opacity: 0, y: 20 },
+    show: { opacity: 1, y: 0, transition: { type: "spring", stiffness: 300, damping: 24 } }
+  };
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-8 p-6 md:p-8">
+      <motion.div initial="hidden" animate="show" variants={containerVariants} className="space-y-8">
+        
+        {/* Header */}
+        <motion.div variants={itemVariants} className="text-center">
+          <h1 className="text-4xl font-extrabold tracking-tight md:text-6xl text-primary mb-2">
+            {year} in Review
+          </h1>
+          <p className="text-lg text-muted-foreground">
+            A look back at Ethereum governance and standards.
+          </p>
+        </motion.div>
+
+        {/* Hero Stats */}
+        <motion.div variants={itemVariants} className="grid gap-4 md:grid-cols-2">
+          <Card className="bg-primary/5 border-primary/20 overflow-hidden relative">
+            <div className="absolute -right-10 -top-10 opacity-10">
+              <FileText className="h-40 w-40" />
+            </div>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+                Proposals Created
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-5xl font-bold text-primary">
+                {data.proposedCount}
+              </div>
+            </CardContent>
+          </Card>
+          
+          <Card className="bg-emerald-500/5 border-emerald-500/20 overflow-hidden relative">
+            <div className="absolute -right-10 -top-10 opacity-10">
+              <CheckCircle2 className="h-40 w-40 text-emerald-500" />
+            </div>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+                Proposals Finalized
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-5xl font-bold text-emerald-600 dark:text-emerald-400">
+                {data.finalizedCount}
+              </div>
+            </CardContent>
+          </Card>
+        </motion.div>
+
+        {/* Charts Section */}
+        <div className="grid gap-8 md:grid-cols-3">
+          {/* Monthly Trend */}
+          <motion.div variants={itemVariants} className="md:col-span-2">
+            <Card className="h-full">
+              <CardHeader>
+                <div className="flex items-center gap-2">
+                  <TrendingUp className="h-5 w-5 text-primary" />
+                  <CardTitle>Activity Trend</CardTitle>
+                </div>
+                <CardDescription>New proposals created per month in {year}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="h-[300px] w-full mt-4">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={data.monthlyActivity} margin={{ top: 0, right: 0, left: -20, bottom: 0 }}>
+                      <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
+                      <XAxis 
+                        dataKey="month" 
+                        axisLine={false}
+                        tickLine={false}
+                        tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 12 }}
+                        dy={10}
+                      />
+                      <YAxis 
+                        axisLine={false}
+                        tickLine={false}
+                        tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 12 }}
+                      />
+                      <Tooltip 
+                        cursor={{ fill: 'hsl(var(--muted)/0.5)' }}
+                        contentStyle={{ borderRadius: '8px', border: '1px solid hsl(var(--border))', backgroundColor: 'hsl(var(--background))' }}
+                      />
+                      <Bar 
+                        dataKey="count" 
+                        name="Proposals" 
+                        fill="hsl(var(--primary))" 
+                        radius={[4, 4, 0, 0]}
+                        animationDuration={1500}
+                      />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              </CardContent>
+            </Card>
+          </motion.div>
+
+          {/* Category Breakdown */}
+          <motion.div variants={itemVariants} className="md:col-span-1">
+            <Card className="h-full">
+              <CardHeader>
+                <CardTitle>Category Breakdown</CardTitle>
+                <CardDescription>Types of proposals in {year}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="h-[250px] w-full">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <PieChart>
+                      <Pie
+                        data={data.categoryBreakdown}
+                        cx="50%"
+                        cy="50%"
+                        innerRadius={60}
+                        outerRadius={80}
+                        paddingAngle={5}
+                        dataKey="count"
+                        nameKey="category"
+                        animationDuration={1500}
+                      >
+                        {data.categoryBreakdown.map((entry, index) => (
+                          <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                        ))}
+                      </Pie>
+                      <Tooltip 
+                        contentStyle={{ borderRadius: '8px', border: '1px solid hsl(var(--border))', backgroundColor: 'hsl(var(--background))' }}
+                      />
+                      <Legend verticalAlign="bottom" height={36} iconType="circle" />
+                    </PieChart>
+                  </ResponsiveContainer>
+                </div>
+              </CardContent>
+            </Card>
+          </motion.div>
+        </div>
+
+        {/* Top Authors */}
+        <motion.div variants={itemVariants}>
+          <Card>
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <Users className="h-5 w-5 text-primary" />
+                <CardTitle>Top Contributors</CardTitle>
+              </div>
+              <CardDescription>Most active authors and editors of {year}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5">
+                {data.topAuthors.length === 0 ? (
+                  <div className="col-span-full py-8 text-center text-muted-foreground">
+                    No contributor activity recorded for this year.
+                  </div>
+                ) : (
+                  data.topAuthors.map((author, idx) => (
+                    <motion.div 
+                      key={author.actor}
+                      whileHover={{ y: -5 }}
+                      className="flex flex-col items-center justify-center rounded-xl border bg-card p-4 text-center shadow-sm transition-all hover:shadow-md"
+                    >
+                      <div className="relative mb-3 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-primary">
+                        <User className="h-8 w-8" />
+                        <div className="absolute -right-2 -top-2 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-xs font-bold text-primary-foreground">
+                          #{idx + 1}
+                        </div>
+                      </div>
+                      <h3 className="font-semibold text-foreground line-clamp-1">{author.actor}</h3>
+                      <Badge variant="secondary" className="mt-2">
+                        {author.activity} interactions
+                      </Badge>
+                    </motion.div>
+                  ))
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </motion.div>
+
+      </motion.div>
+    </div>
+  );
+}
+
+function FolderEmptyIcon(props: any) {
+  return (
+    <svg
+      {...props}
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z" />
+    </svg>
+  );
+}

--- a/src/app/insights/review/[year]/client-page.tsx
+++ b/src/app/insights/review/[year]/client-page.tsx
@@ -60,7 +60,7 @@ export default function YearInReviewClient({ year }: { year: number }) {
 
   const itemVariants = {
     hidden: { opacity: 0, y: 20 },
-    show: { opacity: 1, y: 0, transition: { type: "spring", stiffness: 300, damping: 24 } }
+    show: { opacity: 1, y: 0, transition: { type: "spring" as const, stiffness: 300, damping: 24 } }
   };
 
   return (

--- a/src/app/insights/review/[year]/page.tsx
+++ b/src/app/insights/review/[year]/page.tsx
@@ -1,0 +1,30 @@
+import { Metadata } from "next";
+import YearInReviewClient from "./client-page";
+
+type Props = {
+  params: Promise<{ year: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { year } = await params;
+  return {
+    title: `${year} Year in Review | EIPsInsight`,
+    description: `A look back at Ethereum governance and standards in ${year}.`,
+  };
+}
+
+export default async function YearInReviewPage({ params }: Props) {
+  const { year } = await params;
+  const yearNum = parseInt(year, 10);
+  
+  if (isNaN(yearNum) || yearNum < 2015 || yearNum > new Date().getFullYear()) {
+    return (
+      <div className="flex min-h-[50vh] flex-col items-center justify-center text-center p-8">
+        <h1 className="text-4xl font-bold text-foreground">Invalid Year</h1>
+        <p className="mt-4 text-muted-foreground">Please select a valid year between 2015 and {new Date().getFullYear()}.</p>
+      </div>
+    );
+  }
+  
+  return <YearInReviewClient year={yearNum} />;
+}

--- a/src/components/watch-toggle.tsx
+++ b/src/components/watch-toggle.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { Bell, BellRing, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { client } from "@/lib/orpc";
+import { Button } from "@/components/ui/button";
+
+interface WatchToggleProps {
+  itemType: "proposal" | "repository" | "upgrade" | "author";
+  itemId: string; // for proposal: "repo-number", for repository: "repo", for upgrade: "slug", for author: "name"
+  initialWatched?: boolean;
+  className?: string;
+  variant?: "default" | "outline" | "ghost" | "secondary";
+  size?: "default" | "sm" | "lg" | "icon";
+}
+
+export function WatchToggle({
+  itemType,
+  itemId,
+  initialWatched = false,
+  className,
+  variant = "outline",
+  size = "sm",
+}: WatchToggleProps) {
+  const [isWatched, setIsWatched] = useState(initialWatched);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleToggle = async () => {
+    setIsLoading(true);
+    // Optimistic update
+    const prevWatched = isWatched;
+    setIsWatched(!isWatched);
+
+    try {
+      const result = await client.watchlist.toggleWatch({ itemType, itemId });
+      setIsWatched(result.watched);
+      if (result.watched) {
+        toast.success("Added to watchlist");
+      } else {
+        toast.success("Removed from watchlist");
+      }
+    } catch (error) {
+      // Revert on error
+      setIsWatched(prevWatched);
+      toast.error("Failed to update watchlist");
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant={isWatched ? "secondary" : variant}
+      size={size}
+      className={className}
+      onClick={handleToggle}
+      disabled={isLoading}
+      title={isWatched ? "Remove from watchlist" : "Add to watchlist"}
+    >
+      {isLoading ? (
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+      ) : isWatched ? (
+        <BellRing className="mr-2 h-4 w-4" />
+      ) : (
+        <Bell className="mr-2 h-4 w-4" />
+      )}
+      {isWatched ? "Watching" : "Watch"}
+    </Button>
+  );
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -13,7 +13,7 @@ async function stripeClient() {
   }
   const Stripe = (await import("stripe")).default;
   _stripe = new Stripe(env.STRIPE_SECRET_KEY as string, {
-    apiVersion: "2026-01-28.clover",
+    apiVersion: "2026-02-25.clover",
     typescript: true,
   });
   return _stripe;

--- a/src/server/orpc/procedures/insights.ts
+++ b/src/server/orpc/procedures/insights.ts
@@ -24,6 +24,80 @@ async function getRepoIds(repo?: string): Promise<number[] | null> {
 }
 
 export const insightsProcedures = {
+  getYearInReview: optionalAuthProcedure
+    .input(z.object({ year: z.number().int().min(2015).max(new Date().getFullYear()) }))
+    .handler(async ({ input }) => {
+      const startDate = new Date(Date.UTC(input.year, 0, 1));
+      const endDate = new Date(Date.UTC(input.year + 1, 0, 1));
+
+      // 1. Total EIPs proposed
+      const proposedCount = await prisma.eips.count({
+        where: { created_at: { gte: startDate, lt: endDate } },
+      });
+
+      // 2. Total finalized/accepted
+      const finalizedRows = await prisma.$queryRawUnsafe<Array<{ count: bigint }>>(`
+        SELECT COUNT(DISTINCT eip_id) as count
+        FROM eip_status_events
+        WHERE to_status = 'Final'
+          AND changed_at >= $1::date
+          AND changed_at < $2::date
+      `, startDate, endDate);
+      const finalizedCount = Number(finalizedRows[0]?.count || 0);
+
+      // 3. Month-by-month activity (proposals created)
+      const activityRows = await prisma.$queryRawUnsafe<Array<{ month: number, count: bigint }>>(`
+        SELECT EXTRACT(MONTH FROM created_at) as month, COUNT(*) as count
+        FROM eips
+        WHERE created_at >= $1::date AND created_at < $2::date
+        GROUP BY 1
+      `, startDate, endDate);
+      
+      const activityMap = new Map(activityRows.map(r => [Number(r.month), Number(r.count)]));
+      const monthlyActivity = Array.from({ length: 12 }, (_, i) => ({
+        month: new Date(Date.UTC(2000, i, 1)).toLocaleString('default', { month: 'short' }),
+        count: activityMap.get(i + 1) || 0,
+      }));
+
+      // 4. Category breakdown
+      const categoryRows = await prisma.$queryRawUnsafe<Array<{ category: string, count: bigint }>>(`
+        SELECT COALESCE(NULLIF(s.category, ''), NULLIF(s.type, ''), 'Other') as category, COUNT(*) as count
+        FROM eips e
+        JOIN eip_snapshots s ON s.eip_id = e.id
+        WHERE e.created_at >= $1::date AND e.created_at < $2::date
+        GROUP BY 1
+      `, startDate, endDate);
+      
+      const categoryBreakdown = categoryRows.map(r => ({
+        category: r.category,
+        count: Number(r.count),
+      }));
+
+      // 5. Top 5 most active authors (by activity in that year)
+      const topAuthorsRows = await prisma.$queryRawUnsafe<Array<{ actor: string, count: bigint }>>(`
+        SELECT actor, COUNT(*) as count
+        FROM contributor_activity
+        WHERE occurred_at >= $1::date AND occurred_at < $2::date
+          AND action_type IN ('pr_created', 'pr_merged', 'review_submitted', 'issue_opened')
+        GROUP BY actor
+        ORDER BY count DESC
+        LIMIT 5
+      `, startDate, endDate);
+      
+      const topAuthors = topAuthorsRows.map(r => ({
+        actor: r.actor,
+        activity: Number(r.count),
+      }));
+
+      return {
+        proposedCount,
+        finalizedCount,
+        monthlyActivity,
+        categoryBreakdown,
+        topAuthors,
+      };
+    }),
+
   getDraftVsFinalHistory: optionalAuthProcedure
     .input(z.object({
       repo: z.enum(['eips', 'ercs', 'rips']).optional(),

--- a/src/server/orpc/procedures/insights.ts
+++ b/src/server/orpc/procedures/insights.ts
@@ -36,22 +36,22 @@ export const insightsProcedures = {
       });
 
       // 2. Total finalized/accepted
-      const finalizedRows = await prisma.$queryRawUnsafe<Array<{ count: bigint }>>(`
+      const finalizedRows = await prisma.$queryRaw<Array<{ count: bigint }>>`
         SELECT COUNT(DISTINCT eip_id) as count
         FROM eip_status_events
         WHERE to_status = 'Final'
-          AND changed_at >= $1::date
-          AND changed_at < $2::date
-      `, startDate, endDate);
+          AND changed_at >= ${startDate}::date
+          AND changed_at < ${endDate}::date
+      `;
       const finalizedCount = Number(finalizedRows[0]?.count || 0);
 
       // 3. Month-by-month activity (proposals created)
-      const activityRows = await prisma.$queryRawUnsafe<Array<{ month: number, count: bigint }>>(`
+      const activityRows = await prisma.$queryRaw<Array<{ month: number, count: bigint }>>`
         SELECT EXTRACT(MONTH FROM created_at) as month, COUNT(*) as count
         FROM eips
-        WHERE created_at >= $1::date AND created_at < $2::date
+        WHERE created_at >= ${startDate}::date AND created_at < ${endDate}::date
         GROUP BY 1
-      `, startDate, endDate);
+      `;
       
       const activityMap = new Map(activityRows.map(r => [Number(r.month), Number(r.count)]));
       const monthlyActivity = Array.from({ length: 12 }, (_, i) => ({
@@ -60,13 +60,13 @@ export const insightsProcedures = {
       }));
 
       // 4. Category breakdown
-      const categoryRows = await prisma.$queryRawUnsafe<Array<{ category: string, count: bigint }>>(`
+      const categoryRows = await prisma.$queryRaw<Array<{ category: string, count: bigint }>>`
         SELECT COALESCE(NULLIF(s.category, ''), NULLIF(s.type, ''), 'Other') as category, COUNT(*) as count
         FROM eips e
         JOIN eip_snapshots s ON s.eip_id = e.id
-        WHERE e.created_at >= $1::date AND e.created_at < $2::date
+        WHERE e.created_at >= ${startDate}::date AND e.created_at < ${endDate}::date
         GROUP BY 1
-      `, startDate, endDate);
+      `;
       
       const categoryBreakdown = categoryRows.map(r => ({
         category: r.category,
@@ -74,15 +74,15 @@ export const insightsProcedures = {
       }));
 
       // 5. Top 5 most active authors (by activity in that year)
-      const topAuthorsRows = await prisma.$queryRawUnsafe<Array<{ actor: string, count: bigint }>>(`
+      const topAuthorsRows = await prisma.$queryRaw<Array<{ actor: string, count: bigint }>>`
         SELECT actor, COUNT(*) as count
         FROM contributor_activity
-        WHERE occurred_at >= $1::date AND occurred_at < $2::date
+        WHERE occurred_at >= ${startDate}::date AND occurred_at < ${endDate}::date
           AND action_type IN ('pr_created', 'pr_merged', 'review_submitted', 'issue_opened')
         GROUP BY actor
         ORDER BY count DESC
         LIMIT 5
-      `, startDate, endDate);
+      `;
       
       const topAuthors = topAuthorsRows.map(r => ({
         actor: r.actor,

--- a/src/server/orpc/procedures/watchlist.ts
+++ b/src/server/orpc/procedures/watchlist.ts
@@ -1,0 +1,194 @@
+import * as z from "zod";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { protectedProcedure, ORPCError } from "./types";
+import { resolveProposal, resolveRepository, resolveUpgrade, getProposalPath, getRepositoryPath } from "@/lib/subscriptions";
+
+async function requireSessionUser(headers: Record<string, string>) {
+  const session = await auth.api.getSession({
+    headers: new Headers(headers),
+  });
+
+  if (!session?.user?.id) {
+    throw new ORPCError("UNAUTHORIZED", { message: "Authentication required" });
+  }
+
+  return session.user;
+}
+
+export const watchlistProcedures = {
+  getWatchlist: protectedProcedure
+    .input(z.object({}))
+    .handler(async ({ context }) => {
+      const user = await requireSessionUser(context.headers);
+
+      const [proposalSubscriptions, repositorySubscriptions, upgradeSubscriptions, authorSubscriptions] = await Promise.all([
+        prisma.proposalSubscription.findMany({
+          where: { user_id: user.id },
+          orderBy: { created_at: "desc" },
+          include: {
+            eips: {
+              select: {
+                eip_number: true,
+                title: true,
+                eip_snapshots: { select: { status: true } },
+              },
+            },
+            repositories: { select: { name: true } },
+          },
+        }),
+        prisma.repositorySubscription.findMany({
+          where: { user_id: user.id },
+          orderBy: { created_at: "desc" },
+          include: {
+            repositories: { select: { name: true } },
+          },
+        }),
+        prisma.upgradeSubscription.findMany({
+          where: { user_id: user.id },
+          orderBy: { created_at: "desc" },
+          include: {
+            upgrades: { select: { slug: true, name: true } },
+          },
+        }),
+        prisma.authorSubscription.findMany({
+          where: { user_id: user.id },
+          orderBy: { created_at: "desc" },
+        }),
+      ]);
+
+      return {
+        proposals: proposalSubscriptions.map((sub) => {
+          const repo = sub.repositories.name === "ethereum/ERCs" ? "erc" : sub.repositories.name === "ethereum/RIPs" ? "rip" : "eip";
+          return {
+            id: sub.id,
+            type: "proposal" as const,
+            repo,
+            number: sub.eips.eip_number,
+            title: sub.eips.title || "",
+            status: sub.eips.eip_snapshots?.status || null,
+            createdAt: sub.created_at.toISOString(),
+            path: getProposalPath(repo, sub.eips.eip_number),
+          };
+        }),
+        repositories: repositorySubscriptions.map((sub) => {
+          const repo = sub.repositories.name === "ethereum/ERCs" ? "erc" : sub.repositories.name === "ethereum/RIPs" ? "rip" : "eip";
+          return {
+            id: sub.id,
+            type: "repository" as const,
+            repo,
+            label: repo === "erc" ? "All ERCs" : repo === "rip" ? "All RIPs" : "All EIPs",
+            createdAt: sub.created_at.toISOString(),
+            path: getRepositoryPath(repo as any),
+          };
+        }),
+        upgrades: upgradeSubscriptions.map((sub) => ({
+          id: sub.id,
+          type: "upgrade" as const,
+          slug: sub.upgrades.slug,
+          name: sub.upgrades.name || sub.upgrades.slug,
+          createdAt: sub.created_at.toISOString(),
+          path: `/upgrade/${sub.upgrades.slug}`,
+        })),
+        authors: authorSubscriptions.map((sub) => ({
+          id: sub.id,
+          type: "author" as const,
+          name: sub.author_name,
+          createdAt: sub.created_at.toISOString(),
+          path: `/author/${encodeURIComponent(sub.author_name)}`,
+        })),
+      };
+    }),
+
+  toggleWatch: protectedProcedure
+    .input(z.object({
+      itemType: z.enum(["proposal", "repository", "upgrade", "author"]),
+      itemId: z.string(), // for proposal: "repo-number", for repository: "repo", for upgrade: "slug", for author: "name"
+    }))
+    .handler(async ({ context, input }) => {
+      const user = await requireSessionUser(context.headers);
+      
+      switch (input.itemType) {
+        case "proposal": {
+          const [repoStr, numberStr] = input.itemId.split("-");
+          const repo = repoStr as "eip" | "erc" | "rip";
+          const number = parseInt(numberStr, 10);
+          
+          const proposal = await resolveProposal(repo, number);
+          if (!proposal) throw new ORPCError("NOT_FOUND", { message: "Proposal not found" });
+          
+          const existing = await prisma.proposalSubscription.findUnique({
+            where: { user_id_eip_id_repository_id: { user_id: user.id, eip_id: proposal.eipId, repository_id: proposal.repositoryId } }
+          });
+          
+          if (existing) {
+            await prisma.proposalSubscription.delete({ where: { id: existing.id } });
+            return { watched: false };
+          } else {
+            await prisma.proposalSubscription.create({
+              data: { user_id: user.id, eip_id: proposal.eipId, repository_id: proposal.repositoryId }
+            });
+            return { watched: true };
+          }
+        }
+        
+        case "repository": {
+          const repo = input.itemId as "eip" | "erc" | "rip";
+          const repository = await resolveRepository(repo);
+          if (!repository) throw new ORPCError("NOT_FOUND", { message: "Repository not found" });
+          
+          const existing = await prisma.repositorySubscription.findUnique({
+            where: { user_id_repository_id: { user_id: user.id, repository_id: repository.repositoryId } }
+          });
+          
+          if (existing) {
+            await prisma.repositorySubscription.delete({ where: { id: existing.id } });
+            return { watched: false };
+          } else {
+            await prisma.repositorySubscription.create({
+              data: { user_id: user.id, repository_id: repository.repositoryId }
+            });
+            return { watched: true };
+          }
+        }
+        
+        case "upgrade": {
+          const slug = input.itemId;
+          const upgrade = await resolveUpgrade(slug);
+          if (!upgrade) throw new ORPCError("NOT_FOUND", { message: "Upgrade not found" });
+          
+          const existing = await prisma.upgradeSubscription.findUnique({
+            where: { user_id_upgrade_id: { user_id: user.id, upgrade_id: upgrade.id } }
+          });
+          
+          if (existing) {
+            await prisma.upgradeSubscription.delete({ where: { id: existing.id } });
+            return { watched: false };
+          } else {
+            await prisma.upgradeSubscription.create({
+              data: { user_id: user.id, upgrade_id: upgrade.id }
+            });
+            return { watched: true };
+          }
+        }
+        
+        case "author": {
+          const author_name = input.itemId;
+          
+          const existing = await prisma.authorSubscription.findUnique({
+            where: { user_id_author_name: { user_id: user.id, author_name } }
+          });
+          
+          if (existing) {
+            await prisma.authorSubscription.delete({ where: { id: existing.id } });
+            return { watched: false };
+          } else {
+            await prisma.authorSubscription.create({
+              data: { user_id: user.id, author_name }
+            });
+            return { watched: true };
+          }
+        }
+      }
+    })
+};

--- a/src/server/orpc/procedures/watchlist.ts
+++ b/src/server/orpc/procedures/watchlist.ts
@@ -79,7 +79,7 @@ export const watchlistProcedures = {
             repo,
             label: repo === "erc" ? "All ERCs" : repo === "rip" ? "All RIPs" : "All EIPs",
             createdAt: sub.created_at.toISOString(),
-            path: getRepositoryPath(repo as any),
+            path: getRepositoryPath(repo as "eip" | "erc" | "rip"),
           };
         }),
         upgrades: upgradeSubscriptions.map((sub) => ({

--- a/src/server/orpc/router.ts
+++ b/src/server/orpc/router.ts
@@ -20,6 +20,7 @@ import { feedbackProcedures } from './procedures/feedback'
 import { pageCommentProcedures } from './procedures/pageComment'
 import { commentVoteProcedures } from './procedures/commentVote'
 import { subscriptionsProcedures } from './procedures/subscriptions'
+import { watchlistProcedures } from './procedures/watchlist'
 
 export const router = {
   auth: authProcedures,
@@ -44,4 +45,5 @@ export const router = {
   pageComment: pageCommentProcedures,
   commentVote: commentVoteProcedures,
   subscriptions: subscriptionsProcedures,
+  watchlist: watchlistProcedures,
 }


### PR DESCRIPTION
## Overview
This PR introduces two major features to improve user engagement and personalization:
1. **Year in Review Insights (`/insights/review/[year]`)**: A highly visual, animated dashboard highlighting key governance metrics, proposal statuses, category breakdowns, and top contributors for any given year.
2. **Watchlist Dashboard (`/dashboard/watchlist`)**: A centralized place for authenticated users to pin and track their favorite EIPs, repositories, network upgrades, and authors.

## Key Changes
- **Database Schema**: Added `AuthorSubscription` model to enable users to watch specific authors, and generated the corresponding migration file.
- **Backend (oRPC)**:
  - Added `getYearInReview` to `insights.ts` (using safe `$queryRaw` tagged templates to prevent SQL injection).
  - Added `getWatchlist` and `toggleWatch` procedures to a new `watchlist.ts` router.
- **Frontend Components**:
  - Implemented reusable `<WatchToggle />` button with optimistic UI updates.
  - Implemented `/dashboard/watchlist/page.tsx` utilizing Framer Motion and Radix UI primitives.
  - Implemented `/insights/review/[year]/page.tsx` utilizing `recharts` for rich visualizations.

## Bug Fixes (Unrelated Pre-existing)
- Fixed a pre-existing TypeScript type error related to the `stripe` package API version that was failing the CI build.

## Quality Assurance
- Passed all strict TypeScript checks (`npm run build` succeeds).
- Resolves all linting issues for the newly created files (`npm run lint` succeeds).

## Screenshots
_(adding shortly)_

## How to Test Locally
1. `npm install`
2. Set up `.env` with `DATABASE_URL` (PostgreSQL)
3. `npx prisma generate && npx prisma db push`
4. `npm run dev`
5. Visit `/insights/review/2024` for the Year in Review page
6. Log in and visit `/dashboard/watchlist` for the Watchlist Dashboard