### PR TITLE
Implement calls and decisions browser with series filter and rewrites

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -53,6 +53,37 @@ const nextConfig: NextConfig = {
         destination: '/upgrade',
         permanent: false,
       },
+      {
+        source: '/eips',
+        destination: '/upgrade/eips',
+        permanent: false,
+      },
+      {
+        source: '/decisions',
+        destination: '/upgrade/decisions',
+        permanent: false,
+      },
+      // Per-upgrade shortcuts (current/in-progress forks only)
+      {
+        source: '/glamsterdam',
+        destination: '/upgrade/glamsterdam',
+        permanent: false,
+      },
+      {
+        source: '/hegota',
+        destination: '/upgrade/hegota',
+        permanent: false,
+      },
+      {
+        source: '/fusaka',
+        destination: '/upgrade/fusaka',
+        permanent: false,
+      },
+      {
+        source: '/pectra',
+        destination: '/upgrade/pectra',
+        permanent: false,
+      },
       // Explore drilldown shortcuts
       {
         source: '/draft',

--- a/src/app/upgrade/calls/page.tsx
+++ b/src/app/upgrade/calls/page.tsx
@@ -45,7 +45,8 @@ function formatUpcoming(call: { occurs_at: string | null; occurs_on: string | nu
 export default async function ProtocolCallsPage() {
   const [upcoming, recent] = await Promise.all([
     getCachedUpcomingCalls(),
-    getCachedRecentCalls(25),
+    // Full history so past calls show (client-side series filter handles navigation).
+    getCachedRecentCalls(300),
   ]);
 
   return (

--- a/src/app/upgrade/decisions/page.tsx
+++ b/src/app/upgrade/decisions/page.tsx
@@ -15,7 +15,8 @@ export const metadata: Metadata = buildMetadata({
 });
 
 export default async function DecisionsPage() {
-  const calls = await getCachedRecentDecisions(12);
+  // Fetch the full decision history (client-side filters handle navigation).
+  const calls = await getCachedRecentDecisions(300);
 
   return (
     <div className="mx-auto w-full max-w-4xl space-y-8 px-4 pb-12 pt-8 sm:px-6">

--- a/src/components/upgrade/calls-browser.tsx
+++ b/src/components/upgrade/calls-browser.tsx
@@ -2,15 +2,16 @@
 
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
-import { ExternalLink, Github, Video } from 'lucide-react';
+import { ExternalLink, Github, Video, Search } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import {
-  callDisplayName,
-  callSeriesBadgeClass,
-  callSeriesLabel,
-  callSeriesShort,
-} from '@/data/call-series';
+import { callDisplayName, callSeriesBadgeClass, callSeriesShort } from '@/data/call-series';
 import { CallTldr } from '@/components/upgrade/call-tldr';
+import {
+  SeriesFilter,
+  matchesSeries,
+  DEFAULT_SERIES_FILTER,
+  type SeriesFilterValue,
+} from '@/components/upgrade/series-filter';
 
 export interface RecentCall {
   series: string;
@@ -42,56 +43,38 @@ function SeriesBadge({ series }: { series: string }) {
  * over a compact card list (summaries stay collapsed to keep it scannable).
  */
 export function CallsBrowser({ calls }: { calls: RecentCall[] }) {
-  const [active, setActive] = useState<string>('all');
+  const [series, setSeries] = useState<SeriesFilterValue>(DEFAULT_SERIES_FILTER);
+  const [search, setSearch] = useState('');
 
-  // Distinct series present, ordered by how many calls each has.
-  const seriesTabs = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const call of calls) counts.set(call.series, (counts.get(call.series) ?? 0) + 1);
-    return Array.from(counts.entries())
-      .sort((a, b) => b[1] - a[1])
-      .map(([series, count]) => ({ series, count }));
+  const counts = useMemo(() => {
+    const c: Record<string, number> = {};
+    for (const call of calls) c[call.series] = (c[call.series] ?? 0) + 1;
+    return c;
   }, [calls]);
 
-  const filtered = useMemo(
-    () => (active === 'all' ? calls : calls.filter((c) => c.series === active)),
-    [calls, active]
-  );
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return calls.filter((c) => {
+      if (!matchesSeries(c.series, series)) return false;
+      if (!q) return true;
+      return `${callDisplayName(c)} ${c.series} #${c.call_number ?? ''}`.toLowerCase().includes(q);
+    });
+  }, [calls, series, search]);
 
   return (
     <div className="space-y-4">
-      {/* Series filter tabs */}
-      <div className="flex flex-wrap items-center gap-1.5">
-        <button
-          type="button"
-          onClick={() => setActive('all')}
-          className={cn(
-            'inline-flex h-7 items-center gap-1.5 rounded-full border px-3 text-xs font-semibold transition-colors',
-            active === 'all'
-              ? 'border-primary/50 bg-primary/10 text-primary'
-              : 'border-border bg-transparent text-muted-foreground hover:text-foreground'
-          )}
-        >
-          All
-          <span className="text-[10px] opacity-70">{calls.length}</span>
-        </button>
-        {seriesTabs.map(({ series, count }) => (
-          <button
-            key={series}
-            type="button"
-            onClick={() => setActive(series)}
-            title={callSeriesLabel(series)}
-            className={cn(
-              'inline-flex h-7 items-center gap-1.5 rounded-full border px-3 text-xs font-semibold transition-all',
-              active === series
-                ? cn(callSeriesBadgeClass(series), 'ring-2 ring-primary/30')
-                : 'border-border bg-transparent text-muted-foreground hover:text-foreground'
-            )}
-          >
-            {callSeriesShort(series)}
-            <span className="text-[10px] opacity-70">{count}</span>
-          </button>
-        ))}
+      {/* Search + grouped series filter */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <SeriesFilter value={series} onChange={setSeries} counts={counts} />
+        <div className="relative w-full sm:max-w-xs">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search calls…"
+            className="h-9 w-full rounded-lg border border-border bg-background pl-9 pr-3 text-sm text-foreground outline-none transition-colors focus:border-primary/50 focus:ring-2 focus:ring-primary/20"
+          />
+        </div>
       </div>
 
       {/* Call list */}

--- a/src/components/upgrade/decisions-browser.tsx
+++ b/src/components/upgrade/decisions-browser.tsx
@@ -1,10 +1,16 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { Github, Video, ArrowRightLeft, Server, Star, Circle } from 'lucide-react';
+import { Github, Video, ArrowRightLeft, Server, Star, Circle, Search } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { callDisplayName, callSeriesBadgeClass, callSeriesShort, callSeriesLabel } from '@/data/call-series';
+import { callDisplayName, callSeriesBadgeClass, callSeriesShort } from '@/data/call-series';
 import { EipLinkedText, DecisionTypeMarker, type KeyDecision } from '@/components/upgrade/key-decisions';
+import {
+  SeriesFilter,
+  matchesSeries,
+  DEFAULT_SERIES_FILTER,
+  type SeriesFilterValue,
+} from '@/components/upgrade/series-filter';
 
 export interface DecisionCall {
   series: string;
@@ -40,8 +46,9 @@ const TYPE_FILTERS: Array<{ key: DecisionType; label: string; icon: typeof Circl
  * decision-type filters over the per-call decision groups.
  */
 export function DecisionsBrowser({ calls }: { calls: DecisionCall[] }) {
-  const [series, setSeries] = useState<string>('all');
+  const [series, setSeries] = useState<SeriesFilterValue>(DEFAULT_SERIES_FILTER);
   const [type, setType] = useState<DecisionType | 'all'>('all');
+  const [search, setSearch] = useState('');
 
   // Pre-parse decisions once per call.
   const parsed = useMemo(
@@ -49,25 +56,35 @@ export function DecisionsBrowser({ calls }: { calls: DecisionCall[] }) {
     [calls]
   );
 
-  const seriesTabs = useMemo(() => {
-    const counts = new Map<string, number>();
+  // Series counts (only calls that actually have decisions).
+  const seriesCounts = useMemo(() => {
+    const c: Record<string, number> = {};
     for (const { call, decisions } of parsed) {
-      if (decisions.length) counts.set(call.series, (counts.get(call.series) ?? 0) + 1);
+      if (decisions.length) c[call.series] = (c[call.series] ?? 0) + 1;
     }
-    return Array.from(counts.entries())
-      .sort((a, b) => b[1] - a[1])
-      .map(([s, count]) => ({ series: s, count }));
+    return c;
   }, [parsed]);
 
   const groups = useMemo(() => {
+    const q = search.trim().toLowerCase();
     return parsed
-      .filter(({ call }) => series === 'all' || call.series === series)
-      .map(({ call, decisions }) => ({
-        call,
-        decisions: type === 'all' ? decisions : decisions.filter((d) => (d.type ?? 'other') === type),
-      }))
+      .filter(({ call }) => matchesSeries(call.series, series))
+      .map(({ call, decisions }) => {
+        let ds = type === 'all' ? decisions : decisions.filter((d) => (d.type ?? 'other') === type);
+        if (q) {
+          const callMatches = `${callDisplayName(call)} ${call.series}`.toLowerCase().includes(q);
+          if (!callMatches) {
+            ds = ds.filter(
+              (d) =>
+                (d.original_text ?? '').toLowerCase().includes(q) ||
+                (d.eips ?? []).some((e) => String(e).includes(q) || `eip-${e}`.includes(q))
+            );
+          }
+        }
+        return { call, decisions: ds };
+      })
       .filter(({ decisions }) => decisions.length > 0);
-  }, [parsed, series, type]);
+  }, [parsed, series, type, search]);
 
   const totalDecisions = useMemo(
     () => groups.reduce((sum, g) => sum + g.decisions.length, 0),
@@ -86,23 +103,18 @@ export function DecisionsBrowser({ calls }: { calls: DecisionCall[] }) {
     <div className="space-y-5">
       {/* Filters */}
       <div className="space-y-2.5">
+        <div className="relative w-full sm:max-w-sm">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search decisions, EIP #, or call…"
+            className="h-9 w-full rounded-lg border border-border bg-background pl-9 pr-3 text-sm text-foreground outline-none transition-colors focus:border-primary/50 focus:ring-2 focus:ring-primary/20"
+          />
+        </div>
         <div className="flex flex-wrap items-center gap-1.5">
           <span className="mr-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Series</span>
-          <button type="button" onClick={() => setSeries('all')} className={chip(series === 'all')}>
-            All
-          </button>
-          {seriesTabs.map(({ series: s, count }) => (
-            <button
-              key={s}
-              type="button"
-              onClick={() => setSeries(s)}
-              title={callSeriesLabel(s)}
-              className={chip(series === s, cn(callSeriesBadgeClass(s), 'ring-2 ring-primary/30'))}
-            >
-              {callSeriesShort(s)}
-              <span className="text-[10px] opacity-70">{count}</span>
-            </button>
-          ))}
+          <SeriesFilter value={series} onChange={setSeries} counts={seriesCounts} />
         </div>
         <div className="flex flex-wrap items-center gap-1.5">
           <span className="mr-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Type</span>

--- a/src/components/upgrade/series-filter.tsx
+++ b/src/components/upgrade/series-filter.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { callSeriesShort } from '@/data/call-series';
+
+/** AllCoreDevs series — everything else is treated as a "Breakout". */
+export const ACD_SERIES = ['acdc', 'acde', 'acdt'] as const;
+export const isAcdSeries = (series: string) => (ACD_SERIES as readonly string[]).includes(series);
+
+export type SeriesGroup = 'all' | 'acd' | 'breakouts';
+
+export interface SeriesFilterValue {
+  group: SeriesGroup;
+  /** Only meaningful when group === 'acd': 'all' | 'acdc' | 'acde' | 'acdt'. */
+  acd: string;
+}
+
+export const DEFAULT_SERIES_FILTER: SeriesFilterValue = { group: 'all', acd: 'all' };
+
+/** Does a call's series pass the current grouped filter? */
+export function matchesSeries(series: string, f: SeriesFilterValue): boolean {
+  if (f.group === 'all') return true;
+  if (f.group === 'acd') return isAcdSeries(series) && (f.acd === 'all' || series === f.acd);
+  return !isAcdSeries(series); // breakouts
+}
+
+/**
+ * Grouped series filter: All · ACD · Breakouts, with a dropdown to narrow ACD
+ * down to ACDC / ACDE / ACDT. Replaces the long flat list of per-series pills.
+ */
+export function SeriesFilter({
+  value,
+  onChange,
+  counts,
+}: {
+  value: SeriesFilterValue;
+  onChange: (v: SeriesFilterValue) => void;
+  counts: Record<string, number>;
+}) {
+  const total = Object.values(counts).reduce((a, b) => a + b, 0);
+  const acdTotal = ACD_SERIES.reduce((a, s) => a + (counts[s] ?? 0), 0);
+  const breakoutTotal = total - acdTotal;
+
+  const pill = (selected: boolean) =>
+    cn(
+      'inline-flex h-7 items-center gap-1.5 rounded-full border px-3 text-xs font-semibold transition-all',
+      selected
+        ? 'border-primary/50 bg-primary/10 text-primary'
+        : 'border-border bg-transparent text-muted-foreground hover:text-foreground'
+    );
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <button type="button" onClick={() => onChange({ group: 'all', acd: 'all' })} className={pill(value.group === 'all')}>
+        All <span className="text-[10px] opacity-70">{total}</span>
+      </button>
+      <button type="button" onClick={() => onChange({ group: 'acd', acd: 'all' })} className={pill(value.group === 'acd')}>
+        ACD <span className="text-[10px] opacity-70">{acdTotal}</span>
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange({ group: 'breakouts', acd: 'all' })}
+        className={pill(value.group === 'breakouts')}
+      >
+        Breakouts <span className="text-[10px] opacity-70">{breakoutTotal}</span>
+      </button>
+
+      {value.group === 'acd' && (
+        <select
+          value={value.acd}
+          onChange={(e) => onChange({ group: 'acd', acd: e.target.value })}
+          className="h-7 rounded-full border border-primary/40 bg-background px-2.5 text-xs font-medium text-foreground outline-none focus:border-primary/60 focus:ring-1 focus:ring-primary/30"
+          aria-label="Filter AllCoreDevs series"
+        >
+          <option value="all">All ACD</option>
+          {ACD_SERIES.map((s) => (
+            <option key={s} value={s}>
+              {callSeriesShort(s)} ({counts[s] ?? 0})
+            </option>
+          ))}
+        </select>
+      )}
+    </div>
+  );
+}

--- a/src/components/upgrade/upgrade-eip-directory.tsx
+++ b/src/components/upgrade/upgrade-eip-directory.tsx
@@ -5,7 +5,36 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { Search, SlidersHorizontal, ArrowUpDown, Star, Layers, RefreshCw, X } from 'lucide-react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
-import { STAGE_ORDER, stageLabel, stageBadgeClass, type UpgradeBucket } from '@/lib/upgrade-stages';
+import {
+  STAGE_ORDER,
+  stageLabel,
+  stageAbbreviation,
+  stageBadgeClass,
+  type UpgradeBucket,
+} from '@/lib/upgrade-stages';
+
+/** EIP lifecycle status colors — from docs/ui-reference.md (Status / Semantic Colors). */
+const STATUS_CHIP: Record<string, string> = {
+  Draft: 'border-slate-500/20 bg-slate-500/15 text-slate-600 dark:text-slate-300',
+  Review: 'border-amber-500/20 bg-amber-500/15 text-amber-700 dark:text-amber-300',
+  'Last Call': 'border-orange-500/20 bg-orange-500/15 text-orange-700 dark:text-orange-300',
+  Final: 'border-emerald-500/20 bg-emerald-500/15 text-emerald-700 dark:text-emerald-300',
+  Living: 'border-cyan-500/20 bg-cyan-500/15 text-cyan-700 dark:text-cyan-300',
+  Stagnant: 'border-gray-500/20 bg-gray-500/15 text-gray-600 dark:text-gray-400',
+  Withdrawn: 'border-red-500/20 bg-red-500/15 text-red-600 dark:text-red-300',
+};
+
+/** Chronological fork order (oldest → newest); used to sort the upgrade filter newest-first. */
+const UPGRADE_CHRONOLOGY = [
+  'frontier', 'homestead', 'dao-fork', 'tangerine-whistle', 'spurious-dragon',
+  'byzantium', 'constantinople', 'istanbul', 'muir-glacier', 'berlin', 'london',
+  'arrow-glacier', 'gray-glacier', 'paris', 'shanghai', 'cancun', 'prague',
+  'pectra', 'fusaka', 'glamsterdam', 'hegota',
+];
+const upgradeRank = (slug: string) => {
+  const i = UPGRADE_CHRONOLOGY.indexOf(slug);
+  return i === -1 ? -1 : i; // unknown slugs sort last when descending
+};
 
 interface EipRow {
   eip_number: number;
@@ -227,6 +256,15 @@ export function UpgradeEipDirectory({ initialEips, upgrades }: UpgradeEipDirecto
     return result;
   }, [initialEips, search, selectedUpgrades, selectedStages, selectedLayers, selectedStatuses, headlinerFilter, sortField, sortOrder]);
 
+  // Upgrade filter options: only upgrades that actually have EIPs here,
+  // ordered newest-first (chronological, descending).
+  const upgradeOptions = useMemo(() => {
+    const present = new Set(initialEips.map((e) => e.upgrade_slug));
+    return upgrades
+      .filter((u) => present.has(u.slug))
+      .sort((a, b) => upgradeRank(b.slug) - upgradeRank(a.slug));
+  }, [upgrades, initialEips]);
+
   const activeFilterCount =
     selectedUpgrades.length +
     selectedStages.length +
@@ -304,7 +342,7 @@ export function UpgradeEipDirectory({ initialEips, upgrades }: UpgradeEipDirecto
 
           <FilterSection title="Network upgrade">
             <div className="flex flex-wrap gap-1.5 max-h-40 overflow-y-auto pr-1">
-              {upgrades.map((up) => (
+              {upgradeOptions.map((up) => (
                 <button
                   key={up.slug}
                   type="button"
@@ -451,12 +489,12 @@ export function UpgradeEipDirectory({ initialEips, upgrades }: UpgradeEipDirecto
               <thead>
                 <tr className="border-b border-border bg-muted/30 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground select-none">
                   {([
-                    { field: 'eip_number', label: 'Proposal', align: 'left', width: '' },
-                    { field: null, label: 'Title', align: 'left', width: 'w-full' },
-                    { field: 'bucket', label: 'Stage', align: 'left', width: '' },
-                    { field: 'status', label: 'Status', align: 'left', width: '' },
-                    { field: 'layer', label: 'Layer', align: 'left', width: '' },
-                    { field: 'is_headliner', label: 'Tier', align: 'center', width: '' },
+                    { field: 'eip_number', label: 'Proposal', width: '' },
+                    { field: null, label: 'Title', width: 'w-full' },
+                    { field: null, label: 'Upgrade', width: '' },
+                    { field: 'bucket', label: 'Stage', width: '' },
+                    { field: 'status', label: 'Status', width: '' },
+                    { field: 'layer', label: 'Layer', width: '' },
                   ] as const).map((col) => (
                     <th
                       key={col.label}
@@ -464,11 +502,10 @@ export function UpgradeEipDirectory({ initialEips, upgrades }: UpgradeEipDirecto
                       className={cn(
                         'px-4 py-3',
                         col.width,
-                        col.align === 'center' && 'text-center',
                         col.field && 'cursor-pointer transition-colors hover:text-foreground'
                       )}
                     >
-                      <div className={cn('flex items-center gap-1.5', col.align === 'center' && 'justify-center')}>
+                      <div className="flex items-center gap-1.5">
                         {col.label}
                         {col.field && (
                           <ArrowUpDown
@@ -512,41 +549,60 @@ export function UpgradeEipDirectory({ initialEips, upgrades }: UpgradeEipDirecto
                         </Link>
                       </td>
 
-                      {/* Title + target */}
+                      {/* Title */}
                       <td className="w-full px-4 py-3.5 align-middle">
-                        <div className="space-y-1">
+                        <div className="flex items-center gap-1.5">
                           <Link
                             href={`/${routeSegment}/${eip.eip_number}`}
-                            className="line-clamp-1 text-xs font-medium text-foreground transition-colors hover:text-primary sm:text-sm"
+                            className="line-clamp-1 min-w-0 text-xs font-medium text-foreground transition-colors hover:text-primary sm:text-sm"
                           >
                             {eip.title}
                           </Link>
-                          <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[10px] text-muted-foreground">
-                            <Link
-                              href={`/upgrade/${eip.upgrade_slug}`}
-                              className="rounded bg-muted/60 px-1.5 py-0.5 font-medium text-muted-foreground transition-colors hover:text-primary"
-                            >
-                              {eip.upgrade_name}
-                            </Link>
-                            <span className="opacity-50">·</span>
-                            <span>{eip.category}</span>
-                          </div>
+                          {eip.is_headliner && (
+                            <Star
+                              className="h-3 w-3 shrink-0 fill-primary text-primary"
+                              aria-label="Headliner"
+                            />
+                          )}
                         </div>
+                        <div className="mt-0.5 text-[10px] text-muted-foreground">{eip.category}</div>
+                      </td>
+
+                      {/* Upgrade */}
+                      <td className="whitespace-nowrap px-4 py-3.5 align-middle">
+                        <Link
+                          href={`/upgrade/${eip.upgrade_slug}`}
+                          className="inline-flex items-center rounded-md border border-border/60 bg-muted/40 px-2 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:border-primary/30 hover:text-primary"
+                        >
+                          {eip.upgrade_name}
+                        </Link>
                       </td>
 
                       {/* Stage */}
                       <td className="whitespace-nowrap px-4 py-3.5 align-middle">
-                        <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card/60 px-2 py-0.5 text-xs font-medium capitalize text-foreground">
+                        <span
+                          title={stageLabel(eip.bucket)}
+                          className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card/60 px-2 py-0.5 text-xs font-semibold text-foreground"
+                        >
                           <span className={cn('h-1.5 w-1.5 rounded-full shrink-0', stageBadgeClass(eip.bucket))} />
-                          {stageLabel(eip.bucket)}
+                          {stageAbbreviation(eip.bucket)}
                         </span>
                       </td>
 
                       {/* Status */}
                       <td className="whitespace-nowrap px-4 py-3.5 align-middle">
-                        <span className="rounded bg-muted px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                          {eip.status}
-                        </span>
+                        {eip.status ? (
+                          <span
+                            className={cn(
+                              'inline-flex rounded-full border px-2 py-0.5 text-[10px] font-semibold',
+                              STATUS_CHIP[eip.status] ?? 'border-border bg-muted text-muted-foreground'
+                            )}
+                          >
+                            {eip.status}
+                          </span>
+                        ) : (
+                          <span className="text-[10px] text-muted-foreground/40">—</span>
+                        )}
                       </td>
 
                       {/* Layer */}
@@ -568,20 +624,7 @@ export function UpgradeEipDirectory({ initialEips, upgrades }: UpgradeEipDirecto
                         )}
                       </td>
 
-                      {/* Tier */}
-                      <td className="whitespace-nowrap px-4 py-3.5 text-center align-middle">
-                        {eip.is_headliner ? (
-                          <span
-                            title="Headliner proposal"
-                            className="inline-flex items-center gap-1 rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 text-[10px] font-bold text-primary"
-                          >
-                            <Star className="h-3 w-3 fill-primary text-primary shrink-0" />
-                            Headliner
-                          </span>
-                        ) : (
-                          <span className="text-xs text-muted-foreground/30">—</span>
-                        )}
-                      </td>
+                      {/* headliner tier column removed — headliners are marked by the ★ next to the title */}
                     </tr>
                   );
                 })}

--- a/src/server/orpc/procedures/calls.ts
+++ b/src/server/orpc/procedures/calls.ts
@@ -10,7 +10,7 @@ import * as z from 'zod'
 export const callsProcedures = {
   listRecentCalls: optionalAuthProcedure
     .input(z.object({
-      limit: z.number().int().min(1).max(100).optional().default(20),
+      limit: z.number().int().min(1).max(300).optional().default(20),
       series: z.string().optional(),
     }))
     .handler(async ({ input }) => {
@@ -35,7 +35,7 @@ export const callsProcedures = {
   /** Calls with structured key decisions, newest first (decisions feed). */
   listRecentDecisions: optionalAuthProcedure
     .input(z.object({
-      limit: z.number().int().min(1).max(50).optional().default(12),
+      limit: z.number().int().min(1).max(300).optional().default(12),
     }))
     .handler(async ({ input }) => {
       const rows = await prisma.protocol_calls.findMany({


### PR DESCRIPTION
This pull request introduces major improvements to the filtering and search experience for protocol upgrade calls, decisions, and EIPs, as well as some navigation enhancements. The most significant changes include new grouped series filters, search functionality for calls and decisions, and improved upgrade/EIP filtering and sorting.

### Filtering and Search Improvements

* Introduced a new grouped series filter component (`SeriesFilter`) for calls and decisions, allowing users to filter by All, AllCoreDevs (with sub-selection), or Breakouts, replacing the previous flat list of per-series pills. (`src/components/upgrade/series-filter.tsx`, `src/components/upgrade/calls-browser.tsx`, `src/components/upgrade/decisions-browser.tsx`) [[1]](diffhunk://#diff-5f6981dca9fa033d49b1f07dc95c152736add4b4fa14db5e16ad2d8b2103ad3fR1-R85) [[2]](diffhunk://#diff-e592a8d53a26415ac5ef79b1061f47fdf37add8c282b4ccd742fb8914cde27ecL45-R77) [[3]](diffhunk://#diff-97a870ef233204167491d05400394ae825c2a4ccf6c3ec61424480c39e7fb26eL43-R87) [[4]](diffhunk://#diff-97a870ef233204167491d05400394ae825c2a4ccf6c3ec61424480c39e7fb26eR106-R117)
* Added search functionality to both the calls and decisions browsers, enabling users to filter by text, EIP numbers, or call titles. (`src/components/upgrade/calls-browser.tsx`, `src/components/upgrade/decisions-browser.tsx`) [[1]](diffhunk://#diff-e592a8d53a26415ac5ef79b1061f47fdf37add8c282b4ccd742fb8914cde27ecL45-R77) [[2]](diffhunk://#diff-97a870ef233204167491d05400394ae825c2a4ccf6c3ec61424480c39e7fb26eL43-R87) [[3]](diffhunk://#diff-97a870ef233204167491d05400394ae825c2a4ccf6c3ec61424480c39e7fb26eR106-R117)

### Data Loading and Navigation

* Increased the number of recent calls and decisions fetched to 300 (from 25/12), ensuring that client-side filters and search have the full dataset to work with. (`src/app/upgrade/calls/page.tsx`, `src/app/upgrade/decisions/page.tsx`) [[1]](diffhunk://#diff-0a531cd6f67a2bdc207f1a3e7a02ae04e6cc780684644111fef83c9d5822133fL48-R49) [[2]](diffhunk://#diff-ef5f83a2d690b230882187844e833efa7c1aa4567b3447febc17f63e75edd004L18-R19)
* Added new server-side redirects for `/eips`, `/decisions`, and per-upgrade shortcuts (e.g., `/pectra`, `/fusaka`) to their corresponding upgrade pages. (`next.config.ts`)

### EIP Directory Enhancements

* Improved the upgrade filter in the EIP directory to only show upgrades with EIPs present and sorted them newest-first (chronologically descending). Also added a new "Upgrade" column to the EIP table for better clarity. (`src/components/upgrade/upgrade-eip-directory.tsx`) [[1]](diffhunk://#diff-44031dff31a72b04bd776ae13303cdf11770b1f61b4d34087850de599ee5f533L8-R37) [[2]](diffhunk://#diff-44031dff31a72b04bd776ae13303cdf11770b1f61b4d34087850de599ee5f533R259-R267) [[3]](diffhunk://#diff-44031dff31a72b04bd776ae13303cdf11770b1f61b4d34087850de599ee5f533L307-R345) [[4]](diffhunk://#diff-44031dff31a72b04bd776ae13303cdf11770b1f61b4d34087850de599ee5f533L454-R508)

These changes collectively provide a more powerful and user-friendly way to explore protocol upgrade calls, decisions, and EIPs.