### PR TITLE
Replace Space Grotesk with Inter font for improved readability

### DIFF
--- a/src/app/assets/page.tsx
+++ b/src/app/assets/page.tsx
@@ -381,16 +381,16 @@ export default function AssetsPage() {
         <SectionHead
           label="05 — Typography"
           title="Type Scale"
-          description="Two font families: Space Grotesk for UI and body copy, Libre Baskerville for decorative headings (.dec-title)."
+          description="Two font families: Inter for UI and body copy, Libre Baskerville for decorative headings (.dec-title)."
         />
 
         {/* Font families */}
         <div className="mb-6 grid gap-4 sm:grid-cols-2">
           <div className="rounded-xl border border-border bg-card/60 p-5">
-            <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">Primary — Space Grotesk</p>
+            <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">Primary — Inter</p>
             <p className="mt-3 font-sans text-2xl font-semibold text-foreground">Aa Bb Cc 0–9</p>
             <p className="mt-2 font-sans text-sm text-muted-foreground">Used for all UI text, navigation, body copy, and labels.</p>
-            <code className="mt-3 block text-[10px] text-muted-foreground">--font-space-grotesk · var(--font-sans)</code>
+            <code className="mt-3 block text-[10px] text-muted-foreground">--font-inter · var(--font-sans)</code>
           </div>
           <div className="rounded-xl border border-border bg-card/60 p-5">
             <p className="mb-1 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">Decorative — Libre Baskerville</p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,7 +34,7 @@ html.persona-theme-transition *::after {
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-space-grotesk);
+  --font-sans: var(--font-inter);
   --font-mono: var(--font-libre-baskerville);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -276,7 +276,7 @@ html.persona-theme-transition *::after {
 }
 
 html, body, #__next {
-  font-family: var(--font-space-grotesk);
+  font-family: var(--font-inter);
 }
 
 @layer utilities {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Libre_Baskerville as LibreBaskervilleFont, Space_Grotesk as SpaceGroteskFont } from "next/font/google";
+import { Libre_Baskerville as LibreBaskervilleFont, Inter as InterFont } from "next/font/google";
 import "katex/dist/katex.min.css";
 import "./globals.css";
 import "@/lib/orpc.server";
@@ -17,10 +17,10 @@ const Libre_Baskerville = LibreBaskervilleFont({
   weight: ["400", "700"],
 });
 
-const Space_Grotesk = SpaceGroteskFont({
-  variable: "--font-space-grotesk",
+// Body font: Inter — high legibility for UI/body text at small sizes.
+const Inter = InterFont({
+  variable: "--font-inter",
   subsets: ["latin"],
-  weight: ["300", "400", "500", "600", "700"],
 });
 
 
@@ -69,7 +69,7 @@ export default function RootLayout({
         />
       </head>
       <body
-        className={`${Libre_Baskerville.variable} ${Space_Grotesk.variable} antialiased`}
+        className={`${Libre_Baskerville.variable} ${Inter.variable} antialiased`}
       >
         <Providers>
           <ShellSwitcher>{children}</ShellSwitcher>


### PR DESCRIPTION
This pull request updates the primary UI and body font throughout the application from "Space Grotesk" to "Inter" for improved legibility, especially at small sizes. The change is reflected in both the codebase and UI documentation, ensuring consistency in font usage across all components.

**Font Family Migration:**

* Replaced all usage of `Space Grotesk` with `Inter` for the primary UI/body font, including updating the import from `Space_Grotesk` to `Inter` in `layout.tsx` and changing the associated CSS variable to `--font-inter`. [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L2-R2) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L20-L23) [[3]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L72-R72) [[4]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412L37-R37) [[5]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412L279-R279)

**UI Documentation Update:**

* Updated the font documentation and code samples in `AssetsPage` to reference "Inter" as the primary font instead of "Space Grotesk".