### PR TITLE
Map ACDTCL series for CL breakouts and update call series

### DIFF
--- a/src/app/upgrade/decisions/page.tsx
+++ b/src/app/upgrade/decisions/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { Suspense } from 'react';
 import '@/lib/orpc.server';
 import { buildMetadata } from '@/lib/seo';
 import { getCachedRecentDecisions } from '@/lib/upgrade-data.server';
@@ -19,7 +20,7 @@ export default async function DecisionsPage() {
   const calls = await getCachedRecentDecisions(300);
 
   return (
-    <div className="mx-auto w-full max-w-4xl space-y-8 px-4 pb-12 pt-8 sm:px-6">
+    <div className="mx-auto w-full max-w-6xl space-y-8 px-4 pb-12 pt-8 sm:px-6">
       <header>
         <h1 className="dec-title persona-title text-balance text-3xl font-semibold tracking-tight leading-[1.1] sm:text-4xl">
           Protocol decisions
@@ -37,7 +38,9 @@ export default async function DecisionsPage() {
           fetched alongside call summaries).
         </p>
       ) : (
-        <DecisionsBrowser calls={calls} />
+        <Suspense fallback={null}>
+          <DecisionsBrowser calls={calls} />
+        </Suspense>
       )}
     </div>
   );

--- a/src/app/upgrade/page.tsx
+++ b/src/app/upgrade/page.tsx
@@ -214,36 +214,36 @@ export default async function UpgradeIndexPage() {
               {activity.map((event, index) => (
                 <li
                   key={`${event.commit_date}-${event.eip_number}-${index}`}
-                  className="flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-2.5 text-sm"
+                  className="flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-3 text-sm"
                 >
-                  <GitCommit className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  <GitCommit className="h-4 w-4 shrink-0 text-muted-foreground" />
                   {event.eip_number && (
                     <Link
                       href={`/eip/${event.eip_number}`}
-                      className="font-mono text-xs font-semibold text-primary hover:underline"
+                      className="font-mono text-sm font-semibold text-primary hover:underline"
                     >
                       EIP-{event.eip_number}
                     </Link>
                   )}
-                  <span className="hidden max-w-56 truncate text-xs text-muted-foreground md:inline">
+                  <span className="hidden max-w-72 truncate text-sm text-muted-foreground md:inline">
                     {event.title}
                   </span>
-                  <span className="text-xs text-muted-foreground">
+                  <span className="text-sm text-muted-foreground">
                     {event.event_type === 'removed' ? 'removed from' : `${event.event_type} to`}
                   </span>
                   <StageBadge bucket={event.bucket} abbreviated />
                   {event.upgrade_slug && (
                     <>
-                      <span className="text-xs text-muted-foreground">in</span>
+                      <span className="text-sm text-muted-foreground">in</span>
                       <Link
                         href={`/upgrade/${event.upgrade_slug}`}
-                        className="text-xs font-medium text-foreground hover:text-primary"
+                        className="text-sm font-medium text-foreground hover:text-primary"
                       >
                         {event.upgrade_name ?? event.upgrade_slug}
                       </Link>
                     </>
                   )}
-                  <span className="ml-auto shrink-0 text-[11px] text-muted-foreground">
+                  <span className="ml-auto shrink-0 text-xs text-muted-foreground">
                     {event.commit_date ? timeAgo(event.commit_date) : ''}
                   </span>
                 </li>

--- a/src/components/upgrade/decisions-browser.tsx
+++ b/src/components/upgrade/decisions-browser.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Github, Video, ArrowRightLeft, Server, Star, Circle, Search } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { callDisplayName, callSeriesBadgeClass, callSeriesShort } from '@/data/call-series';
@@ -45,10 +46,56 @@ const TYPE_FILTERS: Array<{ key: DecisionType; label: string; icon: typeof Circl
  * Client browser for protocol decisions: colorful per-series tabs plus
  * decision-type filters over the per-call decision groups.
  */
+const DECISION_TYPES = ['stage_change', 'devnet_inclusion', 'headliner_selected', 'other'] as const;
+
 export function DecisionsBrowser({ calls }: { calls: DecisionCall[] }) {
-  const [series, setSeries] = useState<SeriesFilterValue>(DEFAULT_SERIES_FILTER);
-  const [type, setType] = useState<DecisionType | 'all'>('all');
-  const [search, setSearch] = useState('');
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // Initialise from the URL so shared links restore the exact filter state.
+  const [series, setSeries] = useState<SeriesFilterValue>(() => {
+    const g = searchParams.get('series');
+    if (g === 'acd') return { group: 'acd', acd: searchParams.get('acd') ?? 'all' };
+    if (g === 'breakouts') return { group: 'breakouts', acd: 'all' };
+    return DEFAULT_SERIES_FILTER;
+  });
+  const [type, setType] = useState<DecisionType | 'all'>(() => {
+    const t = searchParams.get('type');
+    return (DECISION_TYPES as readonly string[]).includes(t ?? '') ? (t as DecisionType) : 'all';
+  });
+  const [search, setSearch] = useState(() => searchParams.get('q') ?? '');
+
+  // Reflect the current filters into the URL (shareable, back-button friendly).
+  const syncUrl = (next: {
+    series?: SeriesFilterValue;
+    type?: DecisionType | 'all';
+    search?: string;
+  }) => {
+    const s = next.series ?? series;
+    const t = next.type ?? type;
+    const q = (next.search ?? search).trim();
+    const params = new URLSearchParams();
+    if (s.group !== 'all') params.set('series', s.group);
+    if (s.group === 'acd' && s.acd !== 'all') params.set('acd', s.acd);
+    if (t && t !== 'all') params.set('type', t);
+    if (q) params.set('q', q);
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  };
+
+  const changeSeries = (v: SeriesFilterValue) => {
+    setSeries(v);
+    syncUrl({ series: v });
+  };
+  const changeType = (t: DecisionType | 'all') => {
+    setType(t);
+    syncUrl({ type: t });
+  };
+  const changeSearch = (v: string) => {
+    setSearch(v);
+    syncUrl({ search: v });
+  };
 
   // Pre-parse decisions once per call.
   const parsed = useMemo(
@@ -107,22 +154,22 @@ export function DecisionsBrowser({ calls }: { calls: DecisionCall[] }) {
           <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <input
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => changeSearch(e.target.value)}
             placeholder="Search decisions, EIP #, or call…"
             className="h-9 w-full rounded-lg border border-border bg-background pl-9 pr-3 text-sm text-foreground outline-none transition-colors focus:border-primary/50 focus:ring-2 focus:ring-primary/20"
           />
         </div>
         <div className="flex flex-wrap items-center gap-1.5">
           <span className="mr-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Series</span>
-          <SeriesFilter value={series} onChange={setSeries} counts={seriesCounts} />
+          <SeriesFilter value={series} onChange={changeSeries} counts={seriesCounts} />
         </div>
         <div className="flex flex-wrap items-center gap-1.5">
           <span className="mr-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Type</span>
-          <button type="button" onClick={() => setType('all')} className={chip(type === 'all')}>
+          <button type="button" onClick={() => changeType('all')} className={chip(type === 'all')}>
             All
           </button>
           {TYPE_FILTERS.map(({ key, label, icon: Icon }) => (
-            <button key={key} type="button" onClick={() => setType(key)} className={chip(type === key)}>
+            <button key={key} type="button" onClick={() => changeType(key)} className={chip(type === key)}>
               <Icon className="h-3.5 w-3.5" />
               {label}
             </button>

--- a/src/data/call-series.ts
+++ b/src/data/call-series.ts
@@ -29,6 +29,11 @@ export const CALL_SERIES: Record<string, CallSeriesMeta> = {
     short: 'ACDT',
     badgeClass: 'border-cyan-500/30 bg-cyan-500/15 text-cyan-700 dark:text-cyan-300',
   },
+  acdtcl: {
+    label: 'AllCoreDevs — Testing CL Breakout',
+    short: 'ACDT-CL',
+    badgeClass: 'border-teal-500/30 bg-teal-500/15 text-teal-700 dark:text-teal-300',
+  },
   epbs: {
     label: 'ePBS Breakout',
     short: 'ePBS',

--- a/src/lib/call-artifacts.ts
+++ b/src/lib/call-artifacts.ts
@@ -23,6 +23,7 @@ const ARTIFACTS_BASE =
 /** Normalized series slug → the manifest/artifact directory key. */
 export function getRemoteSeries(series: string): string {
   const map: Record<string, string> = {
+    acdtcl: 'acdt',
     price: 'glamsterdamrepricings',
     tli: 'trustlesslogindex',
     pqts: 'pqtransactionsignatures',
@@ -77,7 +78,8 @@ async function fetchArtifact(series: string, callId: string, files: string[]): P
 }
 
 export async function fetchTranscriptCues(series: string, callId: string): Promise<TranscriptCue[] | null> {
-  const raw = await fetchArtifact(series, callId, ['transcript_corrected.vtt', 'transcript.vtt']);
+  const files = series === 'acdtcl' ? ['transcript_cl.vtt'] : ['transcript_corrected.vtt', 'transcript.vtt'];
+  const raw = await fetchArtifact(series, callId, files);
   if (!raw || !raw.includes('WEBVTT')) return null;
   const cues = parseVtt(raw);
   return cues.length > 0 ? cues : null;
@@ -136,7 +138,8 @@ export function parseChat(raw: string): ChatMessage[] {
 }
 
 export async function fetchChatMessages(series: string, callId: string): Promise<ChatMessage[] | null> {
-  const raw = await fetchArtifact(series, callId, ['chat.txt']);
+  const files = series === 'acdtcl' ? ['chat_cl.txt'] : ['chat.txt'];
+  const raw = await fetchArtifact(series, callId, files);
   if (!raw) return null;
   const parsed = parseChat(raw);
   return parsed.length > 0 ? parsed : null;


### PR DESCRIPTION
This pull request introduces several improvements to the protocol decisions browser and related UI, focusing on enhanced usability, shareable filter state, and support for a new call series. The most significant changes include making filter state (series, type, search) shareable via the URL, UI refinements for better readability, and support for the new "ACDT-CL" call series with appropriate artifact handling.

**Decisions browser improvements:**

* The `DecisionsBrowser` component now syncs filter state (series, type, search) to the URL, allowing users to share links with exact filter settings and improving back/forward navigation. Filter state is initialized from the URL on load. (`src/components/upgrade/decisions-browser.tsx`) [[1]](diffhunk://#diff-97a870ef233204167491d05400394ae825c2a4ccf6c3ec61424480c39e7fb26eR49-R98) [[2]](diffhunk://#diff-97a870ef233204167491d05400394ae825c2a4ccf6c3ec61424480c39e7fb26eL110-R172)
* The `DecisionsBrowser` is now wrapped in a `Suspense` boundary in the page component for improved data loading handling. (`src/app/upgrade/decisions/page.tsx`) [[1]](diffhunk://#diff-ef5f83a2d690b230882187844e833efa7c1aa4567b3447febc17f63e75edd004R2) [[2]](diffhunk://#diff-ef5f83a2d690b230882187844e833efa7c1aa4567b3447febc17f63e75edd004R41-R43)

**UI and accessibility enhancements:**

* Increased the maximum page width for the decisions page and improved the sizing of elements in the upgrade activity list for better readability, especially on larger screens. (`src/app/upgrade/decisions/page.tsx`, `src/app/upgrade/page.tsx`) [[1]](diffhunk://#diff-ef5f83a2d690b230882187844e833efa7c1aa4567b3447febc17f63e75edd004L22-R23) [[2]](diffhunk://#diff-5b99c3b7c3f3aa5464f60b5e45188f9896da3e1d03b845fdbacdfe92c29d80d5L217-R246)

**Support for new call series (ACDT-CL):**

* Added the new `acdtcl` (AllCoreDevs — Testing CL Breakout) call series to the call series metadata, including label, short name, and badge styling. (`src/data/call-series.ts`)
* Updated artifact fetching logic to support the new `acdtcl` series, including mapping to the correct remote directory and handling unique transcript and chat file names. (`src/lib/call-artifacts.ts`) [[1]](diffhunk://#diff-578bcfb455a507da51355384781980bf3ba9c76fb114cb54e6d54ae0df05e986R26) [[2]](diffhunk://#diff-578bcfb455a507da51355384781980bf3ba9c76fb114cb54e6d54ae0df05e986L80-R82) [[3]](diffhunk://#diff-578bcfb455a507da51355384781980bf3ba9c76fb114cb54e6d54ae0df05e986L139-R142)