### PR TITLE
Use static timeline data for pre-scheduler upgrades

### DIFF
--- a/src/app/upgrade/[slug]/page.tsx
+++ b/src/app/upgrade/[slug]/page.tsx
@@ -113,7 +113,7 @@ export default async function UpgradeDetailPage({ params }: Props) {
     const staticData = compositionFromStaticTimeline(slug);
     if (staticData) {
       composition = staticData.composition;
-      if (timeline.length <= 1) timeline = staticData.timeline;
+      timeline = staticData.timeline;
     }
   }
 


### PR DESCRIPTION
This pull request makes a small adjustment to the logic for loading timeline data in the `UpgradeDetailPage` component. Now, whenever static data is available, the timeline will always be set from `staticData.timeline`, regardless of its previous length. ([src/app/upgrade/[slug]/page.tsxL116-R116](diffhunk://#diff-935b70267805df3feed4fc8a5a98fd45f04f1c979d15fc0fc1317627f5ced6b3L116-R116))