### PR TITLE
Enhance timeline and calls features with anchor linking and copy button

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -44,6 +44,11 @@ const nextConfig: NextConfig = {
         permanent: false,
       },
       {
+        source: '/calls/:series/:number',
+        destination: '/upgrade/calls/:series/:number',
+        permanent: false,
+      },
+      {
         source: '/devnets',
         destination: '/upgrade/devnets',
         permanent: false,

--- a/src/components/upgrade/upgrade-detail-body.tsx
+++ b/src/components/upgrade/upgrade-detail-body.tsx
@@ -68,6 +68,51 @@ export function UpgradeDetailBody({
     };
   }, [slug]);
 
+  useEffect(() => {
+    const handleHashScroll = () => {
+      const hash = window.location.hash.toUpperCase();
+      if (!hash) return;
+
+      const mapping: Record<string, string> = {
+        '#DFI': 'stage-declined',
+        '#PFI': 'stage-proposed',
+        '#CFI': 'stage-considered',
+        '#SFI': 'stage-scheduled',
+        '#INCLUDED': 'stage-included',
+        '#DECLINED': 'stage-declined',
+        '#PROPOSED': 'stage-proposed',
+        '#CONSIDERED': 'stage-considered',
+        '#SCHEDULED': 'stage-scheduled',
+        '#CHART': 'timeline-chart',
+        '#TIMELINE': 'timeline-chart',
+        '#ACTIVITY': 'activity',
+        '#CHANGES': 'activity',
+        '#ARTICLES': 'related-articles',
+      };
+
+      const targetId = mapping[hash] || hash.slice(1).toLowerCase();
+
+      if (targetId === 'stage-declined') {
+        setIsDeclinedExpanded(true);
+      }
+
+      setTimeout(() => {
+        const element = document.getElementById(targetId) || document.getElementById(hash.slice(1));
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      }, 100);
+    };
+
+    const initialTimeout = setTimeout(handleHashScroll, 300);
+
+    window.addEventListener('hashchange', handleHashScroll);
+    return () => {
+      clearTimeout(initialTimeout);
+      window.removeEventListener('hashchange', handleHashScroll);
+    };
+  }, []);
+
   const normalizedQuery = searchQuery.trim().toLowerCase();
   const hasLayerData = composition.some((eip) => eip.curation?.layer);
   const isFiltering = Boolean(normalizedQuery) || layerFilter !== 'all';

--- a/src/components/upgrade/upgrade-timeline-chart.tsx
+++ b/src/components/upgrade/upgrade-timeline-chart.tsx
@@ -7,6 +7,7 @@ import { scaleLinear } from '@visx/scale';
 import { Plus, Minus, RotateCcw, Download } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
+import { CopyLinkButton } from '@/components/header';
 
 type StatusType = 'included' | 'scheduled' | 'declined' | 'considered' | 'proposed';
 
@@ -197,6 +198,12 @@ export function UpgradeTimelineChart({ data, upgradeName }: UpgradeTimelineChart
             </p>
           </div>
           <div className="flex items-center gap-1 flex-shrink-0">
+            {/* Copy Chart Link */}
+            <CopyLinkButton
+              sectionId="timeline-chart"
+              className="h-8 w-8 rounded-lg bg-card/90 backdrop-blur-sm border border-border"
+              tooltipLabel="Copy chart link"
+            />
             {/* Include DFI Checkbox */}
             <label className="mr-1 inline-flex items-center gap-1.5 cursor-pointer rounded-lg bg-card/90 backdrop-blur-sm border border-border px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors">
               <input


### PR DESCRIPTION
This pull request introduces several improvements to the upgrade detail and timeline chart components, focusing on enhanced navigation and user experience. The main changes include adding hash-based deep linking and scrolling to specific sections, as well as a new button for copying direct links to the timeline chart.

### Navigation and Deep Linking Enhancements

* Added a `useEffect` in `upgrade-detail-body.tsx` to handle scrolling to specific sections based on URL hash fragments (e.g., `#DFI`, `#CHART`). This includes mapping common hash values to section IDs, expanding the declined section if relevant, and supporting smooth scrolling on initial load and hash changes.

* Updated `next.config.ts` to add a new redirect for `/calls/:series/:number` to `/upgrade/calls/:series/:number`, improving routing consistency for call-related URLs.

### Timeline Chart Usability

* Added a `CopyLinkButton` to the timeline chart, allowing users to easily copy a direct link to the chart section. This improves shareability and user navigation.
* Imported `CopyLinkButton` into `upgrade-timeline-chart.tsx` to support the new feature.