### PR TITLE
Add default value to updated_at in NotificationOutbox and NotifierCheckpoint

### DIFF
--- a/prisma/migrations/20260714000000_notifier_updated_at_default/migration.sql
+++ b/prisma/migrations/20260714000000_notifier_updated_at_default/migration.sql
@@ -1,0 +1,12 @@
+-- The scheduler writes notification_outbox / notifier_checkpoint with the raw `pg` driver,
+-- not Prisma. Prisma's @updatedAt is a client-side feature and emits no database default,
+-- so those raw INSERTs supplied no updated_at and tripped the NOT NULL constraint:
+--   "null value in column \"updated_at\" of relation \"notification_outbox\"
+--    violates not-null constraint"  (Proposal Status Notifier, 2026-07-14)
+-- Giving the columns a DB-level default makes them safe for any writer, Prisma or raw SQL.
+
+-- AlterTable
+ALTER TABLE "notification_outbox" ALTER COLUMN "updated_at" SET DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "notifier_checkpoint" ALTER COLUMN "updated_at" SET DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -636,7 +636,9 @@ model NotificationOutbox {
   failed_at                  DateTime?
   error                      String?
   created_at                 DateTime                @default(now())
-  updated_at                 DateTime                @updatedAt
+  // @default(now()) is required on top of @updatedAt: the scheduler inserts here with raw
+  // SQL (not Prisma), and @updatedAt alone emits no DB default -> NOT NULL violation.
+  updated_at                 DateTime                @default(now()) @updatedAt
   proposal_subscription      ProposalSubscription?   @relation(fields: [proposal_subscription_id], references: [id], onDelete: SetNull)
   repository_subscription    RepositorySubscription? @relation(fields: [repository_subscription_id], references: [id], onDelete: SetNull)
   upgrade_subscription       UpgradeSubscription?    @relation(fields: [upgrade_subscription_id], references: [id], onDelete: SetNull)
@@ -651,7 +653,8 @@ model NotificationOutbox {
 model NotifierCheckpoint {
   key        String   @id
   cursor     String?
-  updated_at DateTime @updatedAt
+  // Same reason as notification_outbox: written by the scheduler via raw SQL.
+  updated_at DateTime @default(now()) @updatedAt
 
   @@map("notifier_checkpoint")
 }


### PR DESCRIPTION
This pull request addresses issues with the `updated_at` fields in the `notification_outbox` and `notifier_checkpoint` tables, ensuring that both Prisma and raw SQL writers (such as the scheduler) can safely insert records without violating NOT NULL constraints. The changes add database-level defaults and adjust the Prisma schema to prevent errors encountered when using raw SQL inserts.

**Database migration and schema adjustments:**

* Added a database-level default of `CURRENT_TIMESTAMP` to the `updated_at` columns in both `notification_outbox` and `notifier_checkpoint` tables, ensuring that inserts from any source will not violate NOT NULL constraints.
* Updated the Prisma schema for `NotificationOutbox` and `NotifierCheckpoint` models to include both `@default(now())` and `@updatedAt` on the `updated_at` fields, aligning the schema with the new database defaults and supporting inserts from raw SQL. [[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL639-R641) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL654-R657)