### PR TITLE
Add editorial signals and filtering for PRs in board view

### DIFF
--- a/src/app/(tools)/board/agenda/layout.tsx
+++ b/src/app/(tools)/board/agenda/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import { buildMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = buildMetadata({
+  title: "Agenda Maker",
+  description: "Build the EIP Editing Office Hour agenda from the live PR board — status moves and drafts pre-sorted.",
+  path: "/board/agenda",
+  keywords: ["EIP editing office hour", "agenda", "EIP editors", "protocol call agenda"],
+});
+
+export default function AgendaLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/(tools)/board/agenda/page.tsx
+++ b/src/app/(tools)/board/agenda/page.tsx
@@ -1,0 +1,590 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, Check, ChevronDown, ChevronRight, ClipboardPaste, Copy, RotateCcw, Search } from "lucide-react";
+import { client } from "@/lib/orpc";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+
+type Candidate = {
+  prNumber: number;
+  title: string | null;
+  author: string | null;
+  repo: string;
+  repoShort: string;
+  url: string;
+  isNew: boolean;
+  waitDays: number;
+  bucket: "final" | "lastcall" | "review" | "glamsterdam" | "draft";
+};
+
+type BucketKey = "final" | "lastcall" | "review" | "glamsterdam" | "draft";
+
+const BUCKETS: { key: BucketKey; heading: string; defaultChecked: boolean; collapsed: boolean }[] = [
+  { key: "glamsterdam", heading: "Glamsterdam EIPs promoted to Review", defaultChecked: true, collapsed: false },
+  { key: "final", heading: "To Final", defaultChecked: true, collapsed: false },
+  { key: "lastcall", heading: "To Last Call", defaultChecked: true, collapsed: false },
+  { key: "review", heading: "Review", defaultChecked: true, collapsed: false },
+  { key: "draft", heading: "Draft", defaultChecked: false, collapsed: true },
+];
+
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+const MONTHS_ABBR = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"];
+
+const rowKey = (c: Candidate) => `${c.repoShort}#${c.prNumber}`;
+
+/** Next occurrence of a weekday (e.g. Tuesday) as yyyy-mm-dd, for a sensible default date. */
+function defaultDateISO(): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + 7);
+  return d.toISOString().slice(0, 10);
+}
+
+function displayDate(iso: string): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  if (!y || !m || !d) return iso;
+  return `${MONTHS[m - 1]} ${d}, ${y}`;
+}
+
+/** savvytime slug: "jul-21-2026" + "4pm" / "430pm". */
+function savvytimeUrl(iso: string, time: string): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  const [hh, mm] = time.split(":").map(Number);
+  if (!y || !m || !d || Number.isNaN(hh)) return "https://savvytime.com/converter/utc";
+  const dateSlug = `${MONTHS_ABBR[m - 1]}-${d}-${y}`;
+  const ampm = hh < 12 ? "am" : "pm";
+  const h12 = hh % 12 || 12;
+  const timeSlug = `${h12}${mm ? String(mm).padStart(2, "0") : ""}${ampm}`;
+  return `https://savvytime.com/converter/utc/${dateSlug}/${timeSlug}`;
+}
+
+type ParsedAgenda = {
+  dateISO?: string;
+  time?: string;
+  editor?: string;
+  zoom?: string;
+  acd: string;
+  misc: string;
+  prs: { key: string; url: string; ref: string }[];
+};
+
+/** Parse an existing agenda body back into builder state (round-trip of the generated markdown). */
+function parseAgenda(md: string): ParsedAgenda {
+  const out: ParsedAgenda = { acd: "", misc: "", prs: [] };
+
+  const dt = md.match(/\[([A-Za-z]+)\s+(\d+),\s*(\d{4}),\s*(\d{1,2}):(\d{2})\s*UTC\]/);
+  if (dt) {
+    const mi = MONTHS.findIndex((m) => m.toLowerCase() === dt[1].toLowerCase());
+    if (mi >= 0) {
+      out.dateISO = `${dt[3]}-${String(mi + 1).padStart(2, "0")}-${dt[2].padStart(2, "0")}`;
+      out.time = `${dt[4].padStart(2, "0")}:${dt[5]}`;
+    }
+  }
+  const ed = md.match(/Editor\s*-\s*(@?[\w-]+)/i);
+  if (ed) out.editor = ed[1];
+  const zm = md.match(/Zoom:\s*\[Link\]\(([^)]+)\)/i);
+  if (zm && !/ZOOM_LINK/i.test(zm[1])) out.zoom = zm[1];
+
+  // Group lines under their "### Heading".
+  const sections: Record<string, string[]> = {};
+  let heading: string | null = null;
+  for (const line of md.split(/\r?\n/)) {
+    const h = line.match(/^###\s+(.*)/);
+    if (h) {
+      heading = h[1].replace(/`/g, "").trim().toLowerCase();
+      sections[heading] = [];
+      continue;
+    }
+    if (heading) sections[heading].push(line);
+  }
+  const textOf = (key: string) => {
+    const t = (sections[key] ?? []).join("\n").trim();
+    return t === "_TBA_" ? "" : t;
+  };
+  out.acd = textOf("acd related");
+  out.misc = textOf("misc");
+
+  // PR lines can appear in any section; match by the GitHub pull URL.
+  const urlRe = /https:\/\/github\.com\/[\w.-]+\/([\w.-]+)\/pull\/(\d+)/i;
+  for (const secLines of Object.values(sections)) {
+    for (const line of secLines) {
+      const m = line.match(urlRe);
+      if (!m) continue;
+      const refM = line.match(/\bRef:\s*(.+)$/i);
+      out.prs.push({
+        key: `${m[1].toLowerCase()}#${m[2]}`,
+        url: m[0],
+        ref: refM ? refM[1].trim() : "",
+      });
+    }
+  }
+  return out;
+}
+
+export default function AgendaMakerPage() {
+  // ── Meeting header fields ──
+  const [meetingNo, setMeetingNo] = useState("");
+  const [dateISO, setDateISO] = useState(defaultDateISO);
+  const [time, setTime] = useState("16:00");
+  const [editor, setEditor] = useState("");
+  const [zoom, setZoom] = useState("");
+
+  // ── Free-text sections (judgement calls) ──
+  const [acdText, setAcdText] = useState("");
+  const [miscText, setMiscText] = useState("");
+
+  // ── Candidate data + selection ──
+  const [candidates, setCandidates] = useState<Candidate[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [included, setIncluded] = useState<Record<string, boolean>>({});
+  const [refs, setRefs] = useState<Record<string, string>>({});
+  const [search, setSearch] = useState("");
+  const [includeTitles, setIncludeTitles] = useState(true);
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>(
+    Object.fromEntries(BUCKETS.map((b) => [b.key, b.collapsed])),
+  );
+  const [copied, setCopied] = useState(false);
+  const [showImport, setShowImport] = useState(false);
+  const [importText, setImportText] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const data = await client.tools.getAgendaCandidates({});
+        if (cancelled) return;
+        setCandidates(data);
+        // Seed default selection: small status buckets checked, the big draft pool opt-in.
+        const seed: Record<string, boolean> = {};
+        for (const c of data) {
+          const b = BUCKETS.find((x) => x.key === c.bucket);
+          seed[rowKey(c)] = b?.defaultChecked ?? false;
+        }
+        setIncluded(seed);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }, 0);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, []);
+
+  const grouped = useMemo(() => {
+    const g: Record<BucketKey, Candidate[]> = { glamsterdam: [], final: [], lastcall: [], review: [], draft: [] };
+    for (const c of candidates ?? []) g[c.bucket].push(c);
+    return g;
+  }, [candidates]);
+
+  const matchesSearch = (c: Candidate) => {
+    if (!search.trim()) return true;
+    const q = search.toLowerCase();
+    return (
+      String(c.prNumber).includes(q) ||
+      (c.title ?? "").toLowerCase().includes(q) ||
+      (c.author ?? "").toLowerCase().includes(q)
+    );
+  };
+
+  const toggle = (key: string) => setIncluded((prev) => ({ ...prev, [key]: !prev[key] }));
+  const setRef = (key: string, val: string) => setRefs((prev) => ({ ...prev, [key]: val }));
+
+  const selectedCount = (b: BucketKey) => grouped[b].filter((c) => included[rowKey(c)]).length;
+
+  const bulk = (b: BucketKey, on: boolean) =>
+    setIncluded((prev) => {
+      const next = { ...prev };
+      for (const c of grouped[b]) if (matchesSearch(c)) next[rowKey(c)] = on;
+      return next;
+    });
+
+  const resetAll = () => {
+    setMeetingNo("");
+    setEditor("");
+    setZoom("");
+    setAcdText("");
+    setMiscText("");
+    setRefs({});
+    setSearch("");
+    setIncluded(
+      Object.fromEntries(
+        (candidates ?? []).map((c) => [rowKey(c), BUCKETS.find((x) => x.key === c.bucket)?.defaultChecked ?? false]),
+      ),
+    );
+  };
+
+  const applyImport = () => {
+    if (!candidates) {
+      toast.error("Still loading the board — try again in a moment.");
+      return;
+    }
+    const parsed = parseAgenda(importText);
+    if (parsed.dateISO) setDateISO(parsed.dateISO);
+    if (parsed.time) setTime(parsed.time);
+    if (parsed.editor) setEditor(parsed.editor);
+    if (parsed.zoom) setZoom(parsed.zoom);
+    setAcdText(parsed.acd);
+
+    const candKeys = new Set(candidates.map(rowKey));
+    const nextIncluded: Record<string, boolean> = Object.fromEntries(candidates.map((c) => [rowKey(c), false]));
+    const nextRefs: Record<string, string> = {};
+    const orphans: { url: string; ref: string }[] = [];
+    for (const pr of parsed.prs) {
+      if (candKeys.has(pr.key)) {
+        nextIncluded[pr.key] = true;
+        if (pr.ref) nextRefs[pr.key] = pr.ref;
+      } else {
+        orphans.push({ url: pr.url, ref: pr.ref });
+      }
+    }
+    setIncluded(nextIncluded);
+    setRefs(nextRefs);
+
+    // PRs from the imported agenda that are no longer open (merged/closed) can't be re-checked —
+    // carry them into Misc so nothing is silently dropped.
+    let misc = parsed.misc;
+    if (orphans.length) {
+      const carried = orphans.map((o) => `- ${o.url}${o.ref ? `  Ref: ${o.ref}` : ""}`).join("\n");
+      misc = misc ? `${misc}\n${carried}` : carried;
+      toast.info(`${orphans.length} imported PR(s) aren't open on the board anymore — moved to Misc.`);
+    }
+    setMiscText(misc);
+
+    setShowImport(false);
+    setImportText("");
+    toast.success("Agenda imported", { description: `${parsed.prs.length} PR(s) parsed.` });
+  };
+
+  const markdown = useMemo(() => {
+    const line = (c: Candidate) => {
+      const ref = refs[rowKey(c)]?.trim();
+      return `- ${c.url}${includeTitles && c.title ? `  ${c.title}` : ""}${ref ? `  Ref: ${ref}` : ""}`;
+    };
+    const section = (b: BucketKey) => {
+      const items = grouped[b].filter((c) => included[rowKey(c)]).map(line);
+      return items.length ? items.join("\n") : "_TBA_";
+    };
+    const editorLine = editor.trim() ? (editor.trim().startsWith("@") ? editor.trim() : `@${editor.trim()}`) : "@";
+
+    return `### UTC Date & Time
+
+[${displayDate(dateISO)}, ${time} UTC](${savvytimeUrl(dateISO, time)})
+
+### Agenda
+
+Editor - ${editorLine}
+EIP Board: https://eipsinsight.com/board
+Zoom: [Link](${zoom.trim() || "ZOOM_LINK"})
+
+### ACD related
+${acdText.trim() || "_TBA_"}
+
+### Glamsterdam EIPs promoted to \`Review\`
+${section("glamsterdam")}
+
+### To Final
+${section("final")}
+
+### To Last Call
+${section("lastcall")}
+
+### Review
+${section("review")}
+
+### Misc
+${miscText.trim() || "_TBA_"}
+
+### Draft
+
+${section("draft")}
+
+### Call Series
+
+EIP Editing Office Hour
+
+### Autopilot Mode
+
+- [x] Use autopilot (recommended defaults for this call series)`;
+  }, [dateISO, time, editor, zoom, acdText, miscText, grouped, included, refs, includeTitles]);
+
+  const issueTitle = `EIP Editing Office Hour (EIP + ERC) Meeting #${meetingNo.trim() || "NN"}, ${displayDate(dateISO)}`;
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(markdown);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+      toast.success("Agenda body copied", { description: "Paste it into the ethereum/pm issue body." });
+    } catch {
+      toast.error("Failed to copy");
+    }
+  };
+
+  const copyTitle = async () => {
+    try {
+      await navigator.clipboard.writeText(issueTitle);
+      toast.success("Issue title copied");
+    } catch {
+      toast.error("Failed to copy");
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b border-border bg-background/85 backdrop-blur-xl">
+        <div className="mx-auto max-w-7xl px-4 py-3 sm:px-6">
+          <Link
+            href="/board"
+            className="mb-2 inline-flex items-center gap-2 text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Back to Board
+          </Link>
+          <h1 className="dec-title persona-title text-balance text-3xl font-semibold leading-[1.1] tracking-tight sm:text-4xl">
+            Office Hour Agenda Maker
+          </h1>
+          <p className="mt-1.5 max-w-3xl text-sm leading-relaxed text-muted-foreground sm:text-base">
+            Status moves (Final / Last Call / Review) and drafts are pulled live from the PR board and pre-sorted. Tick what
+            you want, add references, then copy the ready-to-paste agenda.
+          </p>
+        </div>
+      </div>
+
+      <div className="mx-auto grid max-w-7xl gap-4 px-4 py-5 sm:px-6 lg:grid-cols-[1fr_minmax(360px,42%)]">
+        {/* ── Builder ── */}
+        <div className="space-y-4">
+          {/* Meeting header */}
+          <section className="rounded-xl border border-border bg-card/60 p-4">
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-sm font-semibold text-foreground">Meeting details</h2>
+              <div className="flex items-center gap-1.5">
+                <button
+                  onClick={() => setShowImport((v) => !v)}
+                  className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-muted/50 px-2 text-xs text-foreground transition-colors hover:bg-muted"
+                >
+                  <ClipboardPaste className="h-3 w-3" /> Import
+                </button>
+                <button
+                  onClick={resetAll}
+                  className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-muted/50 px-2 text-xs text-foreground transition-colors hover:bg-muted"
+                >
+                  <RotateCcw className="h-3 w-3" /> Reset
+                </button>
+              </div>
+            </div>
+
+            {showImport && (
+              <div className="mb-3 rounded-lg border border-dashed border-border bg-muted/30 p-3">
+                <p className="mb-2 text-xs text-muted-foreground">
+                  Paste an existing agenda body to edit it — the date, editor, Zoom, sections, PR selections, and refs are
+                  restored. PRs that have since merged/closed drop to Misc.
+                </p>
+                <textarea
+                  value={importText}
+                  onChange={(e) => setImportText(e.target.value)}
+                  rows={5}
+                  placeholder="Paste agenda markdown…"
+                  className={textareaCls}
+                />
+                <div className="mt-2 flex gap-2">
+                  <button
+                    onClick={applyImport}
+                    disabled={!importText.trim() || loading}
+                    className="inline-flex h-8 items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-3 text-xs font-medium text-primary transition-colors hover:bg-primary/15 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    Import agenda
+                  </button>
+                  <button
+                    onClick={() => {
+                      setShowImport(false);
+                      setImportText("");
+                    }}
+                    className="inline-flex h-8 items-center rounded-md border border-border bg-muted/60 px-3 text-xs text-foreground transition-colors hover:bg-muted"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+            <div className="grid gap-3 sm:grid-cols-2">
+              <Field label="Meeting #">
+                <input value={meetingNo} onChange={(e) => setMeetingNo(e.target.value)} placeholder="107" className={inputCls} />
+              </Field>
+              <Field label="Editor (GitHub handle)">
+                <input value={editor} onChange={(e) => setEditor(e.target.value)} placeholder="@samwilsn" className={inputCls} />
+              </Field>
+              <Field label="Date (UTC)">
+                <input type="date" value={dateISO} onChange={(e) => setDateISO(e.target.value)} className={inputCls} />
+              </Field>
+              <Field label="Time (UTC, 24h)">
+                <input type="time" value={time} onChange={(e) => setTime(e.target.value)} className={inputCls} />
+              </Field>
+              <Field label="Zoom link" full>
+                <input value={zoom} onChange={(e) => setZoom(e.target.value)} placeholder="https://us02web.zoom.us/j/…" className={inputCls} />
+              </Field>
+            </div>
+          </section>
+
+          {/* Free-text sections */}
+          <section className="rounded-xl border border-border bg-card/60 p-4">
+            <h2 className="mb-3 text-sm font-semibold text-foreground">Manual sections</h2>
+            <div className="space-y-3">
+              <Field label="ACD related">
+                <textarea value={acdText} onChange={(e) => setAcdText(e.target.value)} rows={2} placeholder="Leave blank for _TBA_ — no reliable signal for ACD items, editor's call" className={textareaCls} />
+              </Field>
+              <Field label="Misc">
+                <textarea value={miscText} onChange={(e) => setMiscText(e.target.value)} rows={3} placeholder="Leave blank for _TBA_" className={textareaCls} />
+              </Field>
+            </div>
+          </section>
+
+          {/* Auto buckets */}
+          <section className="rounded-xl border border-border bg-card/60 p-4">
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+              <h2 className="text-sm font-semibold text-foreground">Pull requests from the board</h2>
+              <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <input type="checkbox" checked={includeTitles} onChange={(e) => setIncludeTitles(e.target.checked)} className="accent-primary" />
+                Include titles
+              </label>
+            </div>
+            <div className="relative mb-3">
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+              <input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Filter by PR #, title, author"
+                className="h-9 w-full rounded-md border border-border bg-muted/60 pl-8 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary/50 focus:outline-none focus:ring-1 focus:ring-primary/30"
+              />
+            </div>
+
+            {loading ? (
+              <p className="py-8 text-center text-sm text-muted-foreground">Loading candidates…</p>
+            ) : (
+              <div className="space-y-2">
+                {BUCKETS.map((b) => {
+                  const rows = grouped[b.key].filter(matchesSearch);
+                  const isCollapsed = collapsed[b.key];
+                  return (
+                    <div key={b.key} className="rounded-lg border border-border/70">
+                      <div className="flex items-center justify-between gap-2 px-3 py-2">
+                        <button
+                          onClick={() => setCollapsed((p) => ({ ...p, [b.key]: !p[b.key] }))}
+                          className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground"
+                        >
+                          {isCollapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+                          {b.heading}
+                          <span className="text-xs text-muted-foreground">
+                            {selectedCount(b.key)}/{grouped[b.key].length} selected
+                          </span>
+                        </button>
+                        <div className="flex items-center gap-1 text-[11px]">
+                          <button onClick={() => bulk(b.key, true)} className="rounded px-1.5 py-0.5 text-muted-foreground hover:bg-muted hover:text-foreground">All</button>
+                          <button onClick={() => bulk(b.key, false)} className="rounded px-1.5 py-0.5 text-muted-foreground hover:bg-muted hover:text-foreground">None</button>
+                        </div>
+                      </div>
+
+                      {!isCollapsed && (
+                        <div className="max-h-96 overflow-y-auto border-t border-border/70">
+                          {rows.length === 0 ? (
+                            <p className="px-3 py-4 text-center text-xs text-muted-foreground">No matching PRs.</p>
+                          ) : (
+                            rows.map((c) => {
+                              const key = rowKey(c);
+                              const on = !!included[key];
+                              return (
+                                <div key={key} className={cn("flex items-start gap-2 border-b border-border/50 px-3 py-2 last:border-0", on && "bg-primary/5")}>
+                                  <input type="checkbox" checked={on} onChange={() => toggle(key)} className="mt-0.5 accent-primary" />
+                                  <div className="min-w-0 flex-1">
+                                    <div className="flex items-center gap-2 text-xs">
+                                      <a href={c.url} target="_blank" rel="noopener noreferrer" className="font-mono font-semibold text-primary hover:underline">
+                                        {c.repoShort} #{c.prNumber}
+                                      </a>
+                                      {c.isNew && <span className="rounded bg-emerald-500/15 px-1 text-[10px] text-emerald-600 dark:text-emerald-400">new</span>}
+                                      <span className="text-[10px] text-muted-foreground">{c.waitDays}d</span>
+                                    </div>
+                                    <p className="truncate text-xs text-foreground">{c.title ?? "Untitled"}</p>
+                                    {on && (
+                                      <input
+                                        value={refs[key] ?? ""}
+                                        onChange={(e) => setRef(key, e.target.value)}
+                                        placeholder="Ref: (optional link/note)"
+                                        className="mt-1 h-6 w-full rounded border border-border bg-background px-1.5 text-[11px] text-foreground placeholder:text-muted-foreground focus:border-primary/50 focus:outline-none"
+                                      />
+                                    )}
+                                  </div>
+                                </div>
+                              );
+                            })
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+        </div>
+
+        {/* ── Live preview ── */}
+        <div className="lg:sticky lg:top-4 lg:self-start">
+          <section className="rounded-xl border border-border bg-card/60 p-4">
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-sm font-semibold text-foreground">Agenda preview</h2>
+              <button
+                onClick={copy}
+                className="inline-flex h-8 items-center gap-1.5 rounded-md border border-primary/30 bg-primary/10 px-3 text-xs font-medium text-primary transition-colors hover:bg-primary/15"
+              >
+                {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                {copied ? "Copied" : "Copy body"}
+              </button>
+            </div>
+
+            {/* The GitHub issue title (separate field from the body). */}
+            <div className="mb-3">
+              <span className="mb-1 block text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                Issue title
+              </span>
+              <div className="flex items-center gap-1.5">
+                <input readOnly value={issueTitle} className={cn(inputCls, "font-mono text-xs")} />
+                <button
+                  onClick={copyTitle}
+                  title="Copy issue title"
+                  className="inline-flex h-9 shrink-0 items-center gap-1 rounded-md border border-border bg-muted/60 px-2.5 text-xs text-foreground transition-colors hover:bg-muted"
+                >
+                  <Copy className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            </div>
+
+            <pre className="max-h-[62vh] overflow-auto rounded-lg border border-border bg-muted/40 p-3 text-[11px] leading-relaxed text-foreground">
+              {markdown}
+            </pre>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const inputCls =
+  "h-9 w-full rounded-md border border-border bg-muted/60 px-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary/50 focus:outline-none focus:ring-1 focus:ring-primary/30";
+const textareaCls =
+  "w-full resize-y rounded-md border border-border bg-muted/60 px-2.5 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary/50 focus:outline-none focus:ring-1 focus:ring-primary/30";
+
+function Field({ label, children, full }: { label: string; children: React.ReactNode; full?: boolean }) {
+  return (
+    <label className={cn("block", full && "sm:col-span-2")}>
+      <span className="mb-1 block text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/src/app/(tools)/board/page.tsx
+++ b/src/app/(tools)/board/page.tsx
@@ -9,16 +9,20 @@ import {
   ArrowLeft,
   ArrowUp,
   ArrowUpDown,
+  Bell,
+  CalendarClock,
   ChevronDown,
   ChevronLeft,
   ChevronRight,
   ChevronUp,
   ExternalLink,
   Flame,
+  GitMerge,
   Info,
   Minus,
   RotateCcw,
   Search,
+  Users,
   X,
 } from "lucide-react";
 import Link from "next/link";
@@ -36,6 +40,13 @@ type PRRow = {
   govState: string;
   waitDays: number;
   processType: string;
+  needsAttention: boolean;
+  attentionReason: string | null;
+  hasConflicts: boolean;
+  stagnantPreamble: boolean;
+  ethbotReview: boolean;
+  authorIsPreambleAuthor: boolean;
+  hasParticipants: boolean;
 };
 
 type BoardData = {
@@ -50,6 +61,8 @@ type StatsData = {
   processTypes: { type: string; count: number }[];
   govStates: { state: string; label: string; count: number }[];
   totalOpen: number;
+  needsAttention: number;
+  hasConflicts: number;
 };
 
 type RepoKey = "" | "eips" | "ercs" | "rips";
@@ -184,6 +197,8 @@ function BoardBrowser() {
     return s === "pr" || s === "created" || s === "wait" ? s : DEFAULT_SORT;
   });
   const [sortDir, setSortDir] = useState<SortDir>(() => (searchParams.get("dir") === "asc" ? "asc" : "desc"));
+  const [needsAttention, setNeedsAttention] = useState(() => searchParams.get("attn") === "1");
+  const [hasConflicts, setHasConflicts] = useState(() => searchParams.get("conflict") === "1");
 
   const [loading, setLoading] = useState(true);
   const [statsLoading, setStatsLoading] = useState(true);
@@ -207,6 +222,8 @@ function BoardBrowser() {
   const govFilter = selectedGovStates.length ? selectedGovStates : undefined;
   const processFilter = selectedProcessTypes.length ? selectedProcessTypes : undefined;
   const searchFilter = debouncedSearch || undefined;
+  const attnFilter = needsAttention || undefined;
+  const conflictFilter = hasConflicts || undefined;
 
   // Mirror state into the URL so "Copy link" (and browser back/refresh) actually work.
   useEffect(() => {
@@ -220,9 +237,11 @@ function BoardBrowser() {
     if (pageSize !== DEFAULT_PAGE_SIZE) p.set("size", String(pageSize));
     if (sortBy !== DEFAULT_SORT) p.set("sort", sortBy);
     if (sortDir !== DEFAULT_DIR) p.set("dir", sortDir);
+    if (needsAttention) p.set("attn", "1");
+    if (hasConflicts) p.set("conflict", "1");
     const qs = p.toString();
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
-  }, [repo, selectedGovStates, selectedProcessTypes, debouncedSearch, page, pageSize, sortBy, sortDir, pathname, router]);
+  }, [repo, selectedGovStates, selectedProcessTypes, debouncedSearch, page, pageSize, sortBy, sortDir, needsAttention, hasConflicts, pathname, router]);
 
   useEffect(() => {
     let cancelled = false;
@@ -258,6 +277,8 @@ function BoardBrowser() {
           pageSize,
           sortBy,
           sortDir,
+          needsAttention: attnFilter,
+          hasConflicts: conflictFilter,
         });
         if (!cancelled) setData(d);
       } catch (err) {
@@ -270,7 +291,7 @@ function BoardBrowser() {
       cancelled = true;
       clearTimeout(timer);
     };
-  }, [typedRepo, govFilter, processFilter, searchFilter, page, pageSize, sortBy, sortDir]);
+  }, [typedRepo, govFilter, processFilter, searchFilter, page, pageSize, sortBy, sortDir, attnFilter, conflictFilter]);
 
   const totalMatching = data?.total ?? 0;
   const rows = data?.rows ?? [];
@@ -283,7 +304,9 @@ function BoardBrowser() {
     selectedProcessTypes.length > 0 ||
     Boolean(search) ||
     sortBy !== DEFAULT_SORT ||
-    sortDir !== DEFAULT_DIR;
+    sortDir !== DEFAULT_DIR ||
+    needsAttention ||
+    hasConflicts;
 
   const toggleGovState = (state: string) => {
     setPage(1);
@@ -312,7 +335,18 @@ function BoardBrowser() {
     setSearch("");
     setSortBy(DEFAULT_SORT);
     setSortDir(DEFAULT_DIR);
+    setNeedsAttention(false);
+    setHasConflicts(false);
     setPage(1);
+  };
+
+  const toggleAttention = () => {
+    setPage(1);
+    setNeedsAttention((v) => !v);
+  };
+  const toggleConflicts = () => {
+    setPage(1);
+    setHasConflicts((v) => !v);
   };
 
   const orderedProcessTypes = useMemo(() => {
@@ -333,6 +367,8 @@ function BoardBrowser() {
       search: searchFilter,
       sortBy,
       sortDir,
+      needsAttention: attnFilter,
+      hasConflicts: conflictFilter,
     };
     const firstPage = await client.tools.getOpenPRBoard({ ...query, page: 1, pageSize: exportPageSize });
 
@@ -455,14 +491,23 @@ function BoardBrowser() {
                 oldest at the top.
               </p>
             </div>
-            <button
-              onClick={() => setShowInfo((v) => !v)}
-              className="inline-flex h-9 shrink-0 items-center gap-1 rounded-md border border-border bg-muted/60 px-2.5 text-xs text-foreground transition-colors hover:border-primary/40 hover:bg-primary/10"
-            >
-              <Info className="h-3.5 w-3.5" />
-              Info
-              {showInfo ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
-            </button>
+            <div className="flex shrink-0 items-center gap-2">
+              <Link
+                href="/board/agenda"
+                className="inline-flex h-9 items-center gap-1.5 rounded-md border border-primary/30 bg-primary/10 px-2.5 text-xs font-medium text-primary transition-colors hover:bg-primary/15"
+              >
+                <CalendarClock className="h-3.5 w-3.5" />
+                Agenda maker
+              </Link>
+              <button
+                onClick={() => setShowInfo((v) => !v)}
+                className="inline-flex h-9 items-center gap-1 rounded-md border border-border bg-muted/60 px-2.5 text-xs text-foreground transition-colors hover:border-primary/40 hover:bg-primary/10"
+              >
+                <Info className="h-3.5 w-3.5" />
+                Info
+                {showInfo ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+              </button>
+            </div>
           </div>
 
           {showInfo && (
@@ -619,6 +664,46 @@ function BoardBrowser() {
             </div>
           </div>
 
+          <div className="mt-3 border-t border-border pt-3">
+            <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+              Editor signals
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={toggleAttention}
+                aria-pressed={needsAttention}
+                title="PRs the scheduler flagged as needing an editor's attention"
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors",
+                  needsAttention
+                    ? "border-rose-500/40 bg-rose-500/10 text-rose-700 dark:text-rose-300"
+                    : "border-border bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground",
+                )}
+              >
+                <Bell className="h-3.5 w-3.5" /> Needs attention{" "}
+                <span className={cn("opacity-70 transition-opacity", statsLoading && "animate-pulse opacity-40")}>
+                  ({stats?.needsAttention ?? 0})
+                </span>
+              </button>
+              <button
+                onClick={toggleConflicts}
+                aria-pressed={hasConflicts}
+                title="PRs with merge conflicts — the author must resolve before review"
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors",
+                  hasConflicts
+                    ? "border-orange-500/40 bg-orange-500/10 text-orange-700 dark:text-orange-300"
+                    : "border-border bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground",
+                )}
+              >
+                <GitMerge className="h-3.5 w-3.5" /> Merge conflicts{" "}
+                <span className={cn("opacity-70 transition-opacity", statsLoading && "animate-pulse opacity-40")}>
+                  ({stats?.hasConflicts ?? 0})
+                </span>
+              </button>
+            </div>
+          </div>
+
           {hasActiveFilters && (
             <div className="mt-3 border-t border-border pt-3">
               <div className="flex flex-wrap gap-2 text-[11px]">
@@ -633,6 +718,8 @@ function BoardBrowser() {
                 {selectedProcessTypes.map((p) => (
                   <ActiveFilter key={p} label={`Process: ${p}`} onClear={() => toggleProcessType(p)} />
                 ))}
+                {needsAttention && <ActiveFilter label="Needs attention" onClear={() => setNeedsAttention(false)} />}
+                {hasConflicts && <ActiveFilter label="Merge conflicts" onClear={() => setHasConflicts(false)} />}
                 {search && <ActiveFilter label={`Search: ${search}`} onClear={() => setSearch("")} />}
               </div>
             </div>
@@ -751,6 +838,12 @@ function BoardBrowser() {
                             <span className="truncate leading-snug">{row.title || "Untitled"}</span>
                             <ExternalLink className="h-3 w-3 shrink-0 opacity-0 transition-opacity group-hover:opacity-60" />
                           </a>
+                          <SignalBadges row={row} />
+                          {row.attentionReason && (
+                            <p className="mt-1 truncate text-[10px] text-rose-600 dark:text-rose-400" title={row.attentionReason}>
+                              {row.attentionReason}
+                            </p>
+                          )}
                         </td>
                         <td className="px-3 py-2 text-muted-foreground">
                           {row.author ? (
@@ -865,6 +958,64 @@ function BoardBrowser() {
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+/** Compact editorial-signal pills, shown under a PR's title. */
+function SignalBadges({ row }: { row: PRRow }) {
+  const badges: { key: string; label: string; title: string; cls: string; Icon?: typeof GitMerge }[] = [];
+  if (row.hasConflicts)
+    badges.push({
+      key: "conflict",
+      label: "Conflicts",
+      title: "Merge conflicts — author must resolve before this can be reviewed",
+      cls: "border-orange-500/30 bg-orange-500/10 text-orange-700 dark:text-orange-300",
+      Icon: GitMerge,
+    });
+  if (row.stagnantPreamble)
+    badges.push({
+      key: "stagnant",
+      label: "Stale preamble",
+      title: "Preamble status has gone stale",
+      cls: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+    });
+  if (row.ethbotReview)
+    badges.push({
+      key: "ethbot",
+      label: "Bot escalated",
+      title: "The eth-bot flagged this for editor review",
+      cls: "border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-300",
+    });
+  if (row.authorIsPreambleAuthor)
+    badges.push({
+      key: "author",
+      label: "By EIP author",
+      title: "Opened by the EIP's own preamble author",
+      cls: "border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300",
+    });
+  if (row.hasParticipants)
+    badges.push({
+      key: "participants",
+      label: "Discussed",
+      title: "Other people are already participating on this PR",
+      cls: "border-border bg-muted text-muted-foreground",
+      Icon: Users,
+    });
+
+  if (badges.length === 0) return null;
+  return (
+    <div className="mt-1 flex flex-wrap gap-1">
+      {badges.map((b) => (
+        <span
+          key={b.key}
+          title={b.title}
+          className={cn("inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] font-medium", b.cls)}
+        >
+          {b.Icon && <b.Icon className="h-2.5 w-2.5" />}
+          {b.label}
+        </span>
+      ))}
     </div>
   );
 }

--- a/src/server/orpc/procedures/tools.ts
+++ b/src/server/orpc/procedures/tools.ts
@@ -17,7 +17,11 @@ const PROCESS_TYPE_SQL = `CASE
   WHEN p.labels @> ARRAY['c-new']::text[] THEN 'New EIP'
   WHEN LOWER(COALESCE(p.title, '')) ~ 'website|jekyll|_config' THEN 'Website'
   WHEN LOWER(COALESCE(p.title, '')) ~ 'update eip-1[: ]' OR LOWER(COALESCE(p.title, '')) = 'update eip-1' THEN 'EIP-1'
-  WHEN p.labels && ARRAY['c-status', 'c-update']::text[] THEN 'Status Change'
+  -- Only c-status is a real status change (the eth-bot sets it when the preamble status: line
+  -- changes). c-update just means "edits an existing proposal" = a Content Edit, NOT a Status
+  -- Change. We can't diff-check (PR file contents aren't stored) and title matching is too noisy
+  -- ("remove ... -> ..." etc.), so the label is the reliable signal.
+  WHEN p.labels @> ARRAY['c-status']::text[] THEN 'Status Change'
   ELSE 'Content Edit'
 END`;
 
@@ -365,9 +369,12 @@ const repoIds = await getRepoIds(input.repo);
       pageSize: z.number().default(10),
       sortBy: z.enum(['wait', 'pr', 'created']).default('wait'),
       sortDir: z.enum(['asc', 'desc']).default('desc'),
+      // Editorial signals the scheduler computes in pr_governance_state.
+      needsAttention: z.boolean().optional(),
+      hasConflicts: z.boolean().optional(),
     }))
     .handler(async ({ context, input }) => {
-const { repo, govState, processType, search, page, pageSize, sortBy, sortDir } = input;
+const { repo, govState, processType, search, page, pageSize, sortBy, sortDir, needsAttention, hasConflicts } = input;
       const offset = (page - 1) * pageSize;
       const govStates = typeof govState === 'string' ? [govState] : (govState ?? []);
       const processTypes = typeof processType === 'string' ? [processType] : (processType ?? []);
@@ -388,6 +395,13 @@ const { repo, govState, processType, search, page, pageSize, sortBy, sortDir } =
         gov_state: string;
         wait_days: number;
         process_type: string;
+        needs_attention: boolean;
+        attention_reason: string | null;
+        has_conflicts: boolean;
+        stagnant_preamble: boolean;
+        ethbot_review: boolean;
+        author_is_preamble_author: boolean;
+        has_participants: boolean;
         total_count: bigint;
       }>>(`
         WITH base AS (
@@ -411,7 +425,14 @@ const { repo, govState, processType, search, page, pageSize, sortBy, sortDir } =
             GREATEST(EXTRACT(DAY FROM (NOW() - COALESCE(gs.waiting_since, p.created_at, NOW())))::int, 0) AS wait_days,
             CASE WHEN COALESCE(gs.category, '') = 'Tooling' THEN 'Content Edit'
               ELSE COALESCE(gs.category, ${PROCESS_TYPE_SQL})
-            END AS process_type
+            END AS process_type,
+            COALESCE(gs.needs_editor_attention, false) AS needs_attention,
+            gs.reason AS attention_reason,
+            COALESCE(gs.has_merge_conflicts, false) AS has_conflicts,
+            COALESCE(gs.has_stagnant_preamble_status, false) AS stagnant_preamble,
+            COALESCE(gs.ethbot_needs_editor_review, false) AS ethbot_review,
+            COALESCE(gs.opened_by_preamble_author, false) AS author_is_preamble_author,
+            COALESCE(gs.has_other_participants, false) AS has_participants
           FROM pull_requests p
           JOIN repositories r ON p.repository_id = r.id
           LEFT JOIN pr_governance_state gs
@@ -429,12 +450,14 @@ const { repo, govState, processType, search, page, pageSize, sortBy, sortDir } =
               OR LOWER(COALESCE(title, '')) LIKE '%' || LOWER($4) || '%'
               OR LOWER(COALESCE(author, '')) LIKE '%' || LOWER($4) || '%'
             ))
+            AND ($7::boolean IS NULL OR needs_attention = $7)
+            AND ($8::boolean IS NULL OR has_conflicts = $8)
         )
         SELECT f.*, (SELECT COUNT(*) FROM filtered)::bigint AS total_count
         FROM filtered f
         ORDER BY ${orderColumn} ${orderDirection}, f.pr_number DESC
         LIMIT $5 OFFSET $6
-      `, repo || null, govStates.length ? govStates : null, processTypes.length ? processTypes : null, search || null, pageSize, offset);
+      `, repo || null, govStates.length ? govStates : null, processTypes.length ? processTypes : null, search || null, pageSize, offset, needsAttention ?? null, hasConflicts ?? null);
 
       const total = results.length > 0 ? Number(results[0].total_count) : 0;
 
@@ -454,6 +477,13 @@ const { repo, govState, processType, search, page, pageSize, sortBy, sortDir } =
           govState: r.gov_state,
           waitDays: r.wait_days,
           processType: r.process_type,
+          needsAttention: r.needs_attention,
+          attentionReason: r.attention_reason,
+          hasConflicts: r.has_conflicts,
+          stagnantPreamble: r.stagnant_preamble,
+          ethbotReview: r.ethbot_review,
+          authorIsPreambleAuthor: r.author_is_preamble_author,
+          hasParticipants: r.has_participants,
         })),
       };
     }),
@@ -547,10 +577,121 @@ const { repo, govState, search } = input;
         ORDER BY count DESC
       `, repo || null, search || null);
 
+      // Editorial-signal counts (filtered by repo + govState + search, same as the board list).
+      const signalResults = await prisma.$queryRawUnsafe<Array<{
+        needs_attention: bigint; has_conflicts: bigint;
+      }>>(`
+        WITH base AS (
+          SELECT
+            p.pr_number, p.title, p.author,
+            COALESCE(
+              gs.subcategory,
+              CASE COALESCE(gs.current_state, 'NO_STATE')
+                WHEN 'WAITING_ON_EDITOR' THEN 'Waiting on Editor'
+                WHEN 'WAITING_ON_AUTHOR' THEN 'Waiting on Author'
+                WHEN 'DRAFT' THEN 'AWAITED'
+                ELSE 'Uncategorized'
+              END
+            ) AS gov_state,
+            COALESCE(gs.needs_editor_attention, false) AS needs_attention,
+            COALESCE(gs.has_merge_conflicts, false) AS has_conflicts
+          FROM pull_requests p
+          JOIN repositories r ON p.repository_id = r.id
+          LEFT JOIN pr_governance_state gs
+            ON p.pr_number = gs.pr_number AND p.repository_id = gs.repository_id
+          WHERE p.state = 'open'
+            AND ($1::text IS NULL OR LOWER(SPLIT_PART(r.name, '/', 2)) = LOWER($1))
+            AND COALESCE(gs.category, '') != 'Tooling'
+        )
+        SELECT
+          COUNT(*) FILTER (WHERE needs_attention)::bigint AS needs_attention,
+          COUNT(*) FILTER (WHERE has_conflicts)::bigint AS has_conflicts
+        FROM base
+        WHERE ($2::text[] IS NULL OR cardinality($2::text[]) = 0 OR gov_state = ANY($2::text[]))
+          AND ($3::text IS NULL OR (
+            pr_number::text LIKE '%' || $3 || '%'
+            OR LOWER(COALESCE(title, '')) LIKE '%' || LOWER($3) || '%'
+            OR LOWER(COALESCE(author, '')) LIKE '%' || LOWER($3) || '%'
+          ))
+      `, repo || null, govStates.length ? govStates : null, search || null);
+
       return {
         processTypes: ptResults.map(r => ({ type: r.process_type, count: Number(r.count) })),
         govStates: gsResults.map(r => ({ state: r.state, label: r.label, count: Number(r.count) })),
         totalOpen: gsResults.reduce((sum, r) => sum + Number(r.count), 0),
+        needsAttention: Number(signalResults[0]?.needs_attention ?? 0),
+        hasConflicts: Number(signalResults[0]?.has_conflicts ?? 0),
       };
+    }),
+
+  // ──── Agenda candidates: open PRs pre-bucketed for the EIP Editing Office Hour agenda ────
+  // Status-change moves (To Final / Last Call / Review) come from `c-status` titles ("Move to X")
+  // — there is no s-lastcall label, so the title is the only signal that covers Last Call. The
+  // Draft pool is the s-draft label (new proposals + move-to-draft), excluding the multi-status
+  // meta doc (EIP-1) via the single-status-label guard.
+  getAgendaCandidates: optionalAuthProcedure
+    .input(z.object({}))
+    .handler(async () => {
+      const rows = await prisma.$queryRawUnsafe<Array<{
+        pr_number: number;
+        title: string | null;
+        author: string | null;
+        repo_name: string;
+        repo_short: string;
+        is_new: boolean;
+        wait_days: number;
+        bucket: string;
+      }>>(`
+        WITH glam AS (
+          SELECT c.eip_number
+          FROM upgrade_composition_current c
+          JOIN upgrades u ON c.upgrade_id = u.id
+          WHERE u.slug = 'glamsterdam'
+        ),
+        base AS (
+          SELECT
+            p.pr_number,
+            p.title,
+            p.author,
+            r.name AS repo_name,
+            LOWER(SPLIT_PART(r.name, '/', 2)) AS repo_short,
+            p.labels @> ARRAY['c-new']::text[] AS is_new,
+            p.labels @> ARRAY['c-status']::text[] AS is_status_change,
+            p.labels @> ARRAY['s-draft']::text[] AS is_s_draft,
+            (SELECT COUNT(*) FROM unnest(p.labels) l WHERE l LIKE 's-%') AS status_label_count,
+            GREATEST(EXTRACT(DAY FROM (NOW() - COALESCE(gs.waiting_since, p.created_at, NOW())))::int, 0) AS wait_days,
+            LOWER(COALESCE(p.title, '')) AS lt,
+            NULLIF((regexp_match(p.title, '(?:EIP|ERC)-(\\d+)'))[1], '')::int AS eip_num
+          FROM pull_requests p
+          JOIN repositories r ON p.repository_id = r.id
+          LEFT JOIN pr_governance_state gs
+            ON p.pr_number = gs.pr_number AND p.repository_id = gs.repository_id
+          WHERE p.state = 'open'
+        )
+        SELECT pr_number, title, author, repo_name, repo_short, is_new, wait_days,
+          CASE
+            WHEN is_status_change AND lt ~ 'move to final' THEN 'final'
+            WHEN is_status_change AND lt ~ 'move to last call' THEN 'lastcall'
+            WHEN is_status_change AND lt ~ 'move to review' AND eip_num IN (SELECT eip_number FROM glam) THEN 'glamsterdam'
+            WHEN is_status_change AND lt ~ 'move to review' THEN 'review'
+            ELSE 'draft'
+          END AS bucket
+        FROM base
+        WHERE (is_status_change AND lt ~ 'move to (final|last call|review)')
+           OR (is_s_draft AND status_label_count = 1 AND (is_new OR is_status_change))
+        ORDER BY repo_short, pr_number DESC
+      `);
+
+      return rows.map(r => ({
+        prNumber: r.pr_number,
+        title: r.title,
+        author: r.author,
+        repo: r.repo_name,
+        repoShort: r.repo_short,
+        url: `https://github.com/${r.repo_name}/pull/${r.pr_number}`,
+        isNew: r.is_new,
+        waitDays: r.wait_days,
+        bucket: r.bucket as 'final' | 'lastcall' | 'review' | 'glamsterdam' | 'draft',
+      }));
     }),
 };


### PR DESCRIPTION
This pull request adds new "editorial signal" features to the PR board, allowing editors to quickly filter and identify pull requests that need attention or have merge conflicts. It introduces new UI elements for these signals, updates the backend to provide and filter by these signals, and enhances the PR listing with badges and reasons for attention. Additionally, it refines the classification of PR process types for more accurate labeling.

**Editorial signal features:**

* Adds "Needs attention" and "Merge conflicts" filters to the PR board UI, with toggle buttons and active filter indicators. These are also reflected in the URL for shareable links. [[1]](diffhunk://#diff-84bdeb9a096a7b4f27519e6a7ed947edccdfae6f4059805f8d4e708af04218c9R200-R201) [[2]](diffhunk://#diff-84bdeb9a096a7b4f27519e6a7ed947edccdfae6f4059805f8d4e708af04218c9R240-R244) [[3]](diffhunk://#diff-84bdeb9a096a7b4f27519e6a7ed947edccdfae6f4059805f8d4e708af04218c9R338-R351) [[4]](diffhunk://#diff-84bdeb9a096a7b4f27519e6a7ed947edccdfae6f4059805f8d4e708af04218c9R667-R706) [[5]](diffhunk://#diff-84bdeb9a096a7b4f27519e6a7ed947edccdfae6f4059805f8d4e708af04218c9R721-R722)
* Displays compact signal badges (e.g., "Conflicts", "Stale preamble", "Bot escalated") under each PR's title, and shows the reason for attention when applicable. [[1]](diffhunk://#diff-84bdeb9a096a7b4f27519e6a7ed947edccdfae6f4059805f8d4e708af04218c9R841-R846) [[2]](diffhunk://#diff-84bdeb9a096a7b4f27519e6a7ed947edccdfae6f4059805f8d4e708af04218c9R965-R1022)

**Backend and API enhancements:**

* Updates the backend API to support filtering by `needsAttention` and `hasConflicts`, and includes additional editorial signal fields in PR data (e.g., `stagnantPreamble`, `ethbotReview`). [[1]](diffhunk://#diff-fc05cff2abe8e6e1321f6b8b9ea2cb104c35afa365cf403014f14de3c9784e6cR372-R377) [[2]](diffhunk://#diff-fc05cff2abe8e6e1321f6b8b9ea2cb104c35afa365cf403014f14de3c9784e6cR398-R404) [[3]](diffhunk://#diff-fc05cff2abe8e6e1321f6b8b9ea2cb104c35afa365cf403014f14de3c9784e6cL414-R435) [[4]](diffhunk://#diff-fc05cff2abe8e6e1321f6b8b9ea2cb104c35afa365cf403014f14de3c9784e6cR453-R460) [[5]](diffhunk://#diff-fc05cff2abe8e6e1321f6b8b9ea2cb104c35afa365cf403014f14de3c9784e6cR480-R486)
* Updates the PR process type classification logic to more accurately distinguish "Status Change" PRs, only using the `c-status` label and not `c-update`.

**UI/UX improvements:**

* Adds a prominent link to the new "Agenda Maker" tool in the PR board header, and introduces a new layout for the agenda page with SEO metadata. [[1]](diffhunk://#diff-6ec5c1629764621ceeb2cd005d5ac24a0e36104348bc83207dfdf1bd1d24504fR1-R13) [[2]](diffhunk://#diff-84bdeb9a096a7b4f27519e6a7ed947edccdfae6f4059805f8d4e708af04218c9R494-R511)

These changes collectively improve the editor workflow by making it easier to identify, filter, and act on PRs that require special attention.