### PR TITLE
Enhance Weekly Recap Generator and refine admin UI

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -382,6 +382,13 @@ export default function AdminPage() {
               <Users className="h-4 w-4" />
               Client Priority
             </Link>
+            <Link
+              href="/admin/weekly-recap"
+              className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+            >
+              <Send className="h-4 w-4" />
+              Weekly Recap
+            </Link>
           </div>
         </div>
       </section>

--- a/src/app/admin/weekly-recap/page.tsx
+++ b/src/app/admin/weekly-recap/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { client } from "@/lib/orpc";
 import { toast } from "sonner";
 import {
@@ -9,20 +9,17 @@ import {
   Calendar,
   Check,
   CheckSquare,
+  ChevronLeft,
   Clock,
   Copy,
   FileText,
   Flame,
-  GitMerge,
-  GitPullRequest,
   Layers,
   Loader2,
   RefreshCw,
   Search,
-  Send,
-  Sparkles,
+  Shield,
   Square,
-  Terminal,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -30,22 +27,16 @@ import { Badge } from "@/components/ui/badge";
 
 type WeeklyData = Awaited<ReturnType<typeof client.dashboard.getWeeklyRecap>>;
 
-const labelClass = "mb-1 block text-[11px] font-semibold uppercase tracking-wider text-muted-foreground";
-const inputClass = "w-full rounded-md border border-border bg-muted/40 px-3 py-1.5 text-sm text-foreground focus:border-primary/50 focus:ring-1 focus:ring-primary/30 transition-all outline-none";
+const labelClass = "mb-1.5 block text-[11px] font-semibold uppercase tracking-wider text-muted-foreground";
+const inputClass = "w-full rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm text-foreground focus:border-primary/50 focus:ring-1 focus:ring-primary/30 transition-all outline-none";
 
 export default function WeeklyRecapPage() {
-  const router = useRouter();
-  
   // App States
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
   const [data, setData] = useState<WeeklyData | null>(null);
-  const [categories, setCategories] = useState<Array<{ id: string; name: string }>>([]);
   
-  // Blog Post Fields
-  const [title, setTitle] = useState(`Ethereum Standards Weekly - ${new Date().toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}`);
-  const [slug, setSlug] = useState(`ethereum-standards-weekly-${new Date().toISOString().slice(0, 10)}`);
-  const [selectedCategory, setSelectedCategory] = useState("");
+  // Parameter State
+  const [recapDate, setRecapDate] = useState(new Date().toISOString().slice(0, 10));
   
   // Selection States (IDs of items to include in report)
   const [selectedProposals, setSelectedProposals] = useState<Record<number, boolean>>({});
@@ -73,25 +64,13 @@ export default function WeeklyRecapPage() {
   const [ecosystemAdoption, setEcosystemAdoption] = useState("");
   const [watchNextWeek, setWatchNextWeek] = useState("");
   const [spotlightInfo, setSpotlightInfo] = useState("");
-  
-  // Live Compiled Markdown
-  const [markdown, setMarkdown] = useState("");
 
   // Load Data
   const loadData = async () => {
     setLoading(true);
     try {
-      const [recapData, blogCats] = await Promise.all([
-        client.dashboard.getWeeklyRecap({}),
-        client.blog.listCategories(),
-      ]);
+      const recapData = await client.dashboard.getWeeklyRecap({});
       setData(recapData);
-      setCategories(blogCats);
-      if (blogCats.length > 0) {
-        // Pre-select Newsletter or News if present
-        const newsCat = blogCats.find(c => c.name.toLowerCase().includes("newsletter") || c.name.toLowerCase().includes("news"));
-        setSelectedCategory(newsCat?.id || blogCats[0].id);
-      }
 
       // Pre-fill selection objects to true
       const proposalsSel: Record<number, boolean> = {};
@@ -123,7 +102,7 @@ export default function WeeklyRecapPage() {
       setSelectedLastCalls(lastCallSel);
 
     } catch (error) {
-      toast.error("Failed to load recap data");
+      toast.error("Failed to load weekly recap data");
       console.error(error);
     } finally {
       setLoading(false);
@@ -153,9 +132,9 @@ export default function WeeklyRecapPage() {
           benefits: cur.benefits || [],
           tradeoffs: cur.tradeoffs || [],
         });
-        toast.success("Layman curation loaded successfully!");
+        toast.success(`Curation loaded for EIP-${num}!`);
       } else {
-        // Fallback info from generic EIP meta
+        // Fallback info
         setFeaturedDetails({
           number: num,
           title: `EIP-${num}`,
@@ -163,7 +142,7 @@ export default function WeeklyRecapPage() {
           benefits: [],
           tradeoffs: [],
         });
-        toast.info("No customized layman curation found; using default placeholders.");
+        toast.info(`No customized layman curation found; using default placeholders.`);
       }
     } catch {
       toast.error("Failed to query EIP curation details");
@@ -172,15 +151,21 @@ export default function WeeklyRecapPage() {
     }
   };
 
-  // Compile Live Markdown whenever fields or selections change
-  useEffect(() => {
-    if (!data) return;
+  // Compile Markdown Content on demand
+  const generateMarkdown = () => {
+    if (!data) return "";
 
-    let md = `# ${title}\n\n`;
-    md += `Ethereum protocol upgrades, governance decisions, and EIP analysis — delivered to your inbox every week.\n\n---\n\n`;
+    const formattedDate = new Date(recapDate).toLocaleDateString("en-US", {
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+    });
+
+    let md = `# Ethereum Standards Weekly Recap - ${formattedDate}\n\n`;
+    md += `Ethereum protocol upgrades, governance decisions, and EIP analysis — compiled directly from EIPsInsight.\n\n---\n\n`;
 
     // 1. STANDARDS IN MOTION
-    md += `## 1. Standards in Motion\n\n`;
+    md += `## 3.1 Standards in Motion\n\n`;
     
     // New EIPs/ERCs
     const selectedNew = data.newProposals.filter(p => selectedProposals[p.number]);
@@ -219,7 +204,7 @@ export default function WeeklyRecapPage() {
     }
 
     // 2. GOVERNANCE & UPGRADE WATCH
-    md += `## 2. Governance & Upgrade Watch\n\n`;
+    md += `## 3.2 Governance & Upgrade Watch\n\n`;
     
     // Call Decisions
     const selectedCallData = data.recentCalls.filter(c => selectedCalls[`${c.series}-${c.number}`]);
@@ -256,7 +241,7 @@ export default function WeeklyRecapPage() {
 
     // 3. FEATURED PROPOSAL
     if (featuredDetails) {
-      md += `## 3. Featured Proposal: EIP-${featuredDetails.number}\n\n`;
+      md += `## 3.3 Featured Proposal: EIP-${featuredDetails.number}\n\n`;
       md += `### 🔍 ${featuredDetails.title}\n\n`;
       if (featuredDetails.summary) {
         md += `**Problem and Technical Approach:**\n${featuredDetails.summary}\n\n`;
@@ -275,7 +260,7 @@ export default function WeeklyRecapPage() {
     }
 
     // 4. CONTRIBUTOR CORNER
-    md += `## 4. Contributor Corner\n\n`;
+    md += `## 3.4 Contributor Corner\n\n`;
     
     // Last Calls seeking review
     const selectedLast = data.lastCallEIPs.filter(lc => selectedLastCalls[lc.number]);
@@ -290,7 +275,7 @@ export default function WeeklyRecapPage() {
     md += `* Check editor activities and contributions on the [Editors Leaderboard](https://eipsinsight.com/analytics/editors).\n\n`;
 
     // 5. WHAT TO WATCH NEXT WEEK
-    md += `## 5. What to Watch Next Week\n\n`;
+    md += `## 3.5 What to Watch Next Week\n\n`;
     const selectedUpcomingData = data.upcomingCalls.filter(c => selectedUpcoming[`${c.series}-${c.callNumber || c.issueNumber}`]);
     if (selectedUpcomingData.length > 0) {
       md += `### 🗓️ Scheduled Core Meetings & Office Hours\n`;
@@ -307,429 +292,406 @@ export default function WeeklyRecapPage() {
 
     // ROTATING SECTIONS
     if (spotlightInfo.trim()) {
-      md += `## 🎙️ Standards Spotlight\n\n${spotlightInfo}\n\n`;
+      md += `## 4.1 Standards Spotlight\n\n${spotlightInfo}\n\n`;
     }
     if (enterpriseBrief.trim()) {
-      md += `## 🏢 Enterprise Brief: Why This Matters to Businesses\n\n${enterpriseBrief}\n\n`;
+      md += `## 4.2 Enterprise Brief: Why This Matters to Businesses\n\n${enterpriseBrief}\n\n`;
     }
     if (ecosystemAdoption.trim()) {
-      md += `## 🚀 Ecosystem Adoption & Implementations\n\n${ecosystemAdoption}\n\n`;
+      md += `## 4.3 Ecosystem Adoption & Implementations\n\n${ecosystemAdoption}\n\n`;
     }
 
-    setMarkdown(md);
-  }, [
-    title, data, selectedProposals, selectedChanges, selectedPRs, selectedDevnets,
-    selectedCalls, selectedUpcoming, selectedLastCalls, featuredDetails,
-    manualAcdHighlights, enterpriseBrief, ecosystemAdoption, watchNextWeek, spotlightInfo
-  ]);
-
-  // Actions
-  const handleCopy = () => {
-    navigator.clipboard.writeText(markdown);
-    toast.success("Markdown copied to clipboard!");
+    return md;
   };
 
-  const handleCreateDraft = async () => {
-    if (!title.trim() || !slug.trim()) {
-      toast.error("Please provide a Title and Slug for the draft");
+  const handleCopyMarkdown = () => {
+    const md = generateMarkdown();
+    if (!md) {
+      toast.error("No data available to compile");
       return;
     }
-    setSaving(true);
-    try {
-      await client.blog.create({
-        title,
-        slug,
-        content: markdown,
-        published: false,
-        categoryId: selectedCategory || null,
-        excerpt: `Weekly Ethereum Standards & Governance updates for ${new Date().toLocaleDateString("en", { month: "short", day: "numeric" })}.`,
-      });
-      toast.success("Blog draft created successfully!");
-      router.push("/admin/blogs");
-    } catch (err: any) {
-      toast.error(err.message || "Failed to create blog draft");
-    } finally {
-      setSaving(false);
-    }
+    navigator.clipboard.writeText(md);
+    toast.success("Markdown compiled and copied to clipboard!");
   };
 
   if (loading) {
     return (
-      <div className="flex h-screen items-center justify-center bg-background text-foreground">
-        <Loader2 className="h-10 w-10 animate-spin text-primary" />
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <div className="flex flex-col items-center gap-3">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+          <p className="text-sm text-muted-foreground">Gathering weekly metrics...</p>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-slate-950 p-6 text-slate-100 font-sans">
-      <div className="mx-auto max-w-[1600px] space-y-6">
-        
-        {/* Header */}
-        <div className="flex items-center justify-between border-b border-slate-800 pb-4">
-          <div>
-            <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-primary">
-              <Sparkles className="h-4 w-4" /> Admin Tools
+    <div className="min-h-screen bg-background">
+      
+      {/* ── Subheader ── */}
+      <section className="border-b border-border bg-card/60">
+        <div className="page-shell py-8">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <div className="inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs uppercase tracking-wide text-primary">
+                <Shield className="h-3.5 w-3.5" />
+                Admin Console
+              </div>
+              <h1 className="dec-title persona-title mt-3 text-balance text-3xl font-semibold tracking-tight leading-[1.1] sm:text-4xl">
+                Weekly Recap Generator
+              </h1>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Evaluate standards, ACD calls, and devnets, then compile and copy the recap markdown.
+              </p>
             </div>
-            <h1 className="text-3xl font-extrabold tracking-tight text-white mt-1">Weekly Recap Generator</h1>
-          </div>
-          <div className="flex items-center gap-3">
-            <Button variant="outline" onClick={loadData} className="border-slate-800 hover:bg-slate-900 text-slate-300">
-              <RefreshCw className="mr-2 h-4 w-4" /> Reload Data
-            </Button>
-            <Button onClick={handleCopy} className="bg-slate-800 hover:bg-slate-700 text-white">
-              <Copy className="mr-2 h-4 w-4" /> Copy Markdown
-            </Button>
-            <Button onClick={handleCreateDraft} disabled={saving} className="bg-primary hover:bg-primary/95 text-black font-semibold">
-              {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Send className="mr-2 h-4 w-4" />}
-              Publish Blog Draft
-            </Button>
-          </div>
-        </div>
-
-        {/* Two-Column Workspace */}
-        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-          
-          {/* LEFT: Controls, Toggles, & Inputs */}
-          <div className="space-y-6 max-h-[85vh] overflow-y-auto pr-2 custom-scrollbar">
             
-            {/* Metadata Card */}
-            <Card className="border-slate-800 bg-slate-900/60 backdrop-blur-md">
-              <CardHeader className="py-4">
-                <CardTitle className="text-sm font-semibold uppercase tracking-wider text-slate-300">Post Metadata</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                  <div>
-                    <label className={labelClass}>Post Title</label>
-                    <input value={title} onChange={e => setTitle(e.target.value)} className={inputClass} />
-                  </div>
-                  <div>
-                    <label className={labelClass}>URL Slug</label>
-                    <input value={slug} onChange={e => setSlug(e.target.value)} className={inputClass} />
-                  </div>
-                </div>
-                <div>
-                  <label className={labelClass}>Blog Category</label>
-                  <select 
-                    value={selectedCategory} 
-                    onChange={e => setSelectedCategory(e.target.value)} 
-                    className="w-full rounded-md border border-border bg-slate-900 px-3 py-1.5 text-sm text-foreground focus:border-primary/50 outline-none"
-                  >
-                    <option value="">No Category</option>
-                    {categories.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
-                  </select>
-                </div>
-              </CardContent>
-            </Card>
+            <div className="flex items-center gap-3 self-start sm:self-auto">
+              <Link href="/admin">
+                <Button variant="outline" className="border-border hover:bg-muted">
+                  <ChevronLeft className="mr-1.5 h-4 w-4" /> Back to Dashboard
+                </Button>
+              </Link>
+              <Button onClick={handleCopyMarkdown} className="bg-primary hover:bg-primary/95 text-black font-semibold shadow-md">
+                <Copy className="mr-1.5 h-4 w-4" /> Copy Recap Markdown
+              </Button>
+            </div>
+          </div>
+        </div>
+      </section>
 
-            {/* Standards in Motion Toggles */}
-            <Card className="border-slate-800 bg-slate-900/60 backdrop-blur-md">
-              <CardHeader className="py-4 flex flex-row items-center justify-between">
-                <CardTitle className="text-sm font-semibold uppercase tracking-wider text-slate-300 flex items-center gap-2">
-                  <Flame className="h-4 w-4 text-orange-500" /> 1. Standards in Motion
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {/* New proposals */}
-                <div>
-                  <h4 className="text-xs font-bold text-slate-400 mb-2">New Proposals (Last 7 Days)</h4>
-                  {data?.newProposals.length === 0 ? (
-                    <p className="text-xs text-slate-500 italic">No new proposals found.</p>
-                  ) : (
-                    <div className="space-y-2">
-                      {data?.newProposals.map(p => (
-                        <div key={p.number} className="flex items-start gap-2.5 text-sm">
-                          <button onClick={() => setSelectedProposals(prev => ({ ...prev, [p.number]: !prev[p.number] }))} className="text-slate-400 hover:text-white mt-0.5">
-                            {selectedProposals[p.number] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
-                          </button>
-                          <span className="text-slate-300">
-                            <Badge variant="outline" className="mr-1 bg-slate-950 text-[10px] py-0">{p.status}</Badge>
-                            EIP-{p.number}: {p.title}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-
-                {/* Status Transitions */}
-                <div className="border-t border-slate-800 pt-4">
-                  <h4 className="text-xs font-bold text-slate-400 mb-2">Status Transitions (Last 7 Days)</h4>
-                  {data?.statusChanges.length === 0 ? (
-                    <p className="text-xs text-slate-500 italic">No status transitions found.</p>
-                  ) : (
-                    <div className="space-y-2">
-                      {data?.statusChanges.map(sc => {
-                        const key = `${sc.number}-${sc.to}`;
-                        return (
-                          <div key={key} className="flex items-start gap-2.5 text-sm">
-                            <button onClick={() => setSelectedChanges(prev => ({ ...prev, [key]: !prev[key] }))} className="text-slate-400 hover:text-white mt-0.5">
-                              {selectedChanges[key] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
-                            </button>
-                            <span className="text-slate-300">
-                              EIP-{sc.number} ➔ <span className="text-primary font-semibold">{sc.to}</span> ({sc.title})
-                            </span>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-
-                {/* Merged PRs */}
-                <div className="border-t border-slate-800 pt-4">
-                  <h4 className="text-xs font-bold text-slate-400 mb-2">Merged Pull Requests</h4>
-                  {data?.mergedPRs.length === 0 ? (
-                    <p className="text-xs text-slate-500 italic">No merged PRs found.</p>
-                  ) : (
-                    <div className="space-y-2">
-                      {data?.mergedPRs.map(pr => (
-                        <div key={pr.number} className="flex items-start gap-2.5 text-sm">
-                          <button onClick={() => setSelectedPRs(prev => ({ ...prev, [pr.number]: !prev[pr.number] }))} className="text-slate-400 hover:text-white mt-0.5">
-                            {selectedPRs[pr.number] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
-                          </button>
-                          <span className="text-slate-300">
-                            PR #{pr.number}: {pr.title} (by @{pr.author})
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Governance & Upgrade watch Toggles */}
-            <Card className="border-slate-800 bg-slate-900/60 backdrop-blur-md">
-              <CardHeader className="py-4">
-                <CardTitle className="text-sm font-semibold uppercase tracking-wider text-slate-300 flex items-center gap-2">
-                  <Layers className="h-4 w-4 text-indigo-500" /> 2. Governance & Upgrade Watch
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {/* Recent calls decisions */}
-                <div>
-                  <h4 className="text-xs font-bold text-slate-400 mb-2">Recent ACD Calls & Decisions</h4>
-                  {data?.recentCalls.length === 0 ? (
-                    <p className="text-xs text-slate-500 italic">No recent calls found.</p>
-                  ) : (
-                    <div className="space-y-3">
-                      {data?.recentCalls.map(c => {
-                        const key = `${c.series}-${c.number}`;
-                        return (
-                          <div key={key} className="flex items-start gap-2.5 text-sm">
-                            <button onClick={() => setSelectedCalls(prev => ({ ...prev, [key]: !prev[key] }))} className="text-slate-400 hover:text-white mt-0.5">
-                              {selectedCalls[key] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
-                            </button>
-                            <div className="text-slate-300 flex-1">
-                              <p className="font-semibold text-white">{c.displayName || `${c.series} #${c.number}`}</p>
-                              {c.tldr && <p className="text-xs text-slate-400 mt-0.5">{String(c.tldr)}</p>}
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-
-                {/* Manual governance notes */}
-                <div className="border-t border-slate-800 pt-4">
-                  <label className={labelClass}>Manual Call Highlights & Governance Notes</label>
-                  <textarea 
-                    value={manualAcdHighlights} 
-                    onChange={e => setManualAcdHighlights(e.target.value)} 
-                    placeholder="Enter manual bullet points or decisions from Core Dev calls..." 
-                    className="w-full h-20 rounded-md border border-border bg-slate-900 px-3 py-1.5 text-sm text-foreground outline-none resize-y"
-                  />
-                </div>
-
-                {/* Active Devnets */}
-                <div className="border-t border-slate-800 pt-4">
-                  <h4 className="text-xs font-bold text-slate-400 mb-2">Devnets Progression</h4>
-                  {data?.devnets.length === 0 ? (
-                    <p className="text-xs text-slate-500 italic">No devnets specs found.</p>
-                  ) : (
-                    <div className="space-y-2">
-                      {data?.devnets.map(d => (
-                        <div key={d.id} className="flex items-start gap-2.5 text-sm">
-                          <button onClick={() => setSelectedDevnets(prev => ({ ...prev, [d.id]: !prev[d.id] }))} className="text-slate-400 hover:text-white mt-0.5">
-                            {selectedDevnets[d.id] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
-                          </button>
-                          <span className="text-slate-300">
-                            {d.series.toUpperCase()} Devnet {d.number}: {d.title} ({d.active ? "Active" : "Closed"})
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Featured Proposal Selector */}
-            <Card className="border-slate-800 bg-slate-900/60 backdrop-blur-md">
-              <CardHeader className="py-4">
-                <CardTitle className="text-sm font-semibold uppercase tracking-wider text-slate-300 flex items-center gap-2">
-                  <BookOpen className="h-4 w-4 text-emerald-500" /> 3. Featured Proposal
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="flex gap-2">
-                  <div className="relative flex-1">
-                    <input 
-                      placeholder="EIP or ERC Number (e.g. 7702)" 
-                      value={featuredEipNumber} 
-                      onChange={e => setFeaturedEipNumber(e.target.value)} 
-                      className="w-full rounded-md border border-border bg-muted/40 pl-8 pr-3 py-1.5 text-sm outline-none"
-                    />
-                    <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
-                  </div>
-                  <Button onClick={handleLoadCuration} disabled={loadingCuration} className="bg-emerald-600 hover:bg-emerald-500 text-white font-medium">
-                    {loadingCuration ? <Loader2 className="h-4 w-4 animate-spin" /> : "Load Curation"}
-                  </Button>
-                </div>
-
-                {featuredDetails && (
-                  <div className="rounded-lg border border-emerald-950 bg-emerald-950/20 p-4 space-y-2">
-                    <p className="text-xs font-bold text-emerald-400 uppercase tracking-wider">Loaded Proposal</p>
-                    <p className="text-sm font-bold text-white">EIP-{featuredDetails.number}: {featuredDetails.title}</p>
-                    {featuredDetails.summary ? (
-                      <p className="text-xs text-slate-300 line-clamp-3 leading-relaxed">{featuredDetails.summary}</p>
-                    ) : (
-                      <p className="text-xs text-slate-500 italic">No summary found in database.</p>
-                    )}
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-
-            {/* Contributor corner & upcoming schedules */}
-            <Card className="border-slate-800 bg-slate-900/60 backdrop-blur-md">
-              <CardHeader className="py-4">
-                <CardTitle className="text-sm font-semibold uppercase tracking-wider text-slate-300 flex items-center gap-2">
-                  <Calendar className="h-4 w-4 text-yellow-500" /> 4 & 5. Corner & Next Week
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {/* Last Calls */}
-                <div>
-                  <h4 className="text-xs font-bold text-slate-400 mb-2">EIPs in Last Call</h4>
-                  {data?.lastCallEIPs.length === 0 ? (
-                    <p className="text-xs text-slate-500 italic">No EIPs currently in Last Call.</p>
-                  ) : (
-                    <div className="space-y-2">
-                      {data?.lastCallEIPs.map(lc => (
-                        <div key={lc.number} className="flex items-start gap-2.5 text-sm">
-                          <button onClick={() => setSelectedLastCalls(prev => ({ ...prev, [lc.number]: !prev[lc.number] }))} className="text-slate-400 hover:text-white mt-0.5">
-                            {selectedLastCalls[lc.number] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
-                          </button>
-                          <span className="text-slate-300">
-                            EIP-{lc.number}: {lc.title} (Deadline: {lc.deadline || "None"})
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-
-                {/* Upcoming meetings */}
-                <div className="border-t border-slate-800 pt-4">
-                  <h4 className="text-xs font-bold text-slate-400 mb-2">Upcoming ACD & Coordination Calls</h4>
-                  {data?.upcomingCalls.length === 0 ? (
-                    <p className="text-xs text-slate-500 italic">No upcoming calls found.</p>
-                  ) : (
-                    <div className="space-y-2">
-                      {data?.upcomingCalls.map(c => {
-                        const key = `${c.series}-${c.callNumber || c.issueNumber}`;
-                        return (
-                          <div key={key} className="flex items-start gap-2.5 text-sm">
-                            <button onClick={() => setSelectedUpcoming(prev => ({ ...prev, [key]: !prev[key] }))} className="text-slate-400 hover:text-white mt-0.5">
-                              {selectedUpcoming[key] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
-                            </button>
-                            <span className="text-slate-300">
-                              {c.title} {c.occursOn ? `(${c.occursOn})` : ""}
-                            </span>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-
-                {/* Manual watchlist/schedules */}
-                <div className="border-t border-slate-800 pt-4">
-                  <label className={labelClass}>Manual Schedule / What to Watch Next Week</label>
-                  <textarea 
-                    value={watchNextWeek} 
-                    onChange={e => setWatchNextWeek(e.target.value)} 
-                    placeholder="Enter deadlines, office hours details, or specific PRs to watch next week..." 
-                    className="w-full h-20 rounded-md border border-border bg-slate-900 px-3 py-1.5 text-sm text-foreground outline-none resize-y"
-                  />
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Optional rotating sections */}
-            <Card className="border-slate-800 bg-slate-900/60 backdrop-blur-md">
-              <CardHeader className="py-4">
-                <CardTitle className="text-sm font-semibold uppercase tracking-wider text-slate-300">Rotating Editorial Sections</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div>
-                  <label className={labelClass}>Standards Spotlight (Author/Editor Feature)</label>
-                  <textarea 
-                    value={spotlightInfo} 
-                    onChange={e => setSpotlightInfo(e.target.value)} 
-                    placeholder="Feature a contributor, editor, or project this week..." 
-                    className="w-full h-20 rounded-md border border-border bg-slate-900 px-3 py-1.5 text-sm text-foreground outline-none resize-y"
-                  />
-                </div>
-                <div>
-                  <label className={labelClass}>Enterprise Brief</label>
-                  <textarea 
-                    value={enterpriseBrief} 
-                    onChange={e => setEnterpriseBrief(e.target.value)} 
-                    placeholder="Translate protocol changes into enterprise or business impacts..." 
-                    className="w-full h-20 rounded-md border border-border bg-slate-900 px-3 py-1.5 text-sm text-foreground outline-none resize-y"
-                  />
-                </div>
-                <div>
-                  <label className={labelClass}>Ecosystem Adoption</label>
-                  <textarea 
-                    value={ecosystemAdoption} 
-                    onChange={e => setEcosystemAdoption(e.target.value)} 
-                    placeholder="Highlight projects implementing recently finalized EIPs/ERCs..." 
-                    className="w-full h-20 rounded-md border border-border bg-slate-900 px-3 py-1.5 text-sm text-foreground outline-none resize-y"
-                  />
-                </div>
-              </CardContent>
-            </Card>
-
+      {/* ── Main Content ── */}
+      <div className="page-shell py-10">
+        <div className="max-w-4xl mx-auto space-y-8">
+          
+          {/* Metadata */}
+          <div className="rounded-xl border border-border bg-card/40 p-6">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div>
+                <label className={labelClass}>Recap Date</label>
+                <input 
+                  type="date" 
+                  value={recapDate} 
+                  onChange={e => setRecapDate(e.target.value)} 
+                  className={inputClass} 
+                />
+              </div>
+              <div className="flex items-end">
+                <Button onClick={loadData} variant="outline" className="w-full border-border hover:bg-muted">
+                  <RefreshCw className="mr-2 h-4 w-4" /> Refresh Database Signals
+                </Button>
+              </div>
+            </div>
           </div>
 
-          {/* RIGHT: Live Compiled Preview */}
-          <div className="space-y-6">
-            <Card className="border-slate-800 bg-slate-900/40 backdrop-blur-md h-full flex flex-col">
-              <CardHeader className="py-4 flex flex-row items-center justify-between border-b border-slate-800">
-                <CardTitle className="text-sm font-semibold uppercase tracking-wider text-slate-300 flex items-center gap-2">
-                  <FileText className="h-4 w-4 text-primary" /> Live Markdown Output
-                </CardTitle>
-                <div className="text-[10px] text-slate-500 font-mono">Real-time compilation</div>
-              </CardHeader>
-              <CardContent className="p-0 flex-1 flex flex-col min-h-[60vh]">
-                <textarea 
-                  value={markdown} 
-                  onChange={e => setMarkdown(e.target.value)} 
-                  className="w-full flex-1 bg-slate-950/60 p-6 text-sm text-slate-300 font-mono focus:outline-none resize-none leading-relaxed border-0"
+          {/* 3.1 Standards in Motion */}
+          <div className="rounded-xl border border-border bg-card/40 p-6 space-y-6">
+            <h2 className="text-lg font-bold text-foreground flex items-center gap-2 border-b border-border pb-3">
+              <Flame className="h-5 w-5 text-orange-500" /> 3.1 Standards in Motion
+            </h2>
+            
+            {/* New proposals */}
+            <div className="space-y-3">
+              <h3 className="text-xs font-bold uppercase tracking-wider text-muted-foreground">New Proposals Introductions (Last 7 Days)</h3>
+              {data?.newProposals.length === 0 ? (
+                <p className="text-xs text-muted-foreground italic">No new proposals introduced in this window.</p>
+              ) : (
+                <div className="grid gap-2">
+                  {data?.newProposals.map(p => (
+                    <label key={p.number} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors cursor-pointer">
+                      <button 
+                        type="button"
+                        onClick={() => setSelectedProposals(prev => ({ ...prev, [p.number]: !prev[p.number] }))} 
+                        className="text-muted-foreground hover:text-foreground mt-0.5"
+                      >
+                        {selectedProposals[p.number] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
+                      </button>
+                      <div className="text-sm">
+                        <Badge variant="outline" className="mr-2 bg-background/80 text-[10px] py-0">{p.status}</Badge>
+                        <span className="font-semibold text-foreground">EIP-{p.number}:</span> {p.title}
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Status Transitions */}
+            <div className="space-y-3 pt-4 border-t border-border/60">
+              <h3 className="text-xs font-bold uppercase tracking-wider text-muted-foreground">Lifecycle & Status Changes</h3>
+              {data?.statusChanges.length === 0 ? (
+                <p className="text-xs text-muted-foreground italic">No status transitions found.</p>
+              ) : (
+                <div className="grid gap-2">
+                  {data?.statusChanges.map(sc => {
+                    const key = `${sc.number}-${sc.to}`;
+                    return (
+                      <label key={key} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors cursor-pointer">
+                        <button 
+                          type="button"
+                          onClick={() => setSelectedChanges(prev => ({ ...prev, [key]: !prev[key] }))} 
+                          className="text-muted-foreground hover:text-foreground mt-0.5"
+                        >
+                          {selectedChanges[key] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
+                        </button>
+                        <div className="text-sm">
+                          <span className="font-semibold text-foreground">EIP-{sc.number}</span> transitioned from <Badge variant="outline" className="bg-background">{sc.from}</Badge> ➔ <Badge className="bg-primary/25 text-primary">{sc.to}</Badge> ({sc.title})
+                        </div>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            {/* Merged PRs */}
+            <div className="space-y-3 pt-4 border-t border-border/60">
+              <h3 className="text-xs font-bold uppercase tracking-wider text-muted-foreground">Recently Merged PRs</h3>
+              {data?.mergedPRs.length === 0 ? (
+                <p className="text-xs text-muted-foreground italic">No recently merged pull requests.</p>
+              ) : (
+                <div className="grid gap-2">
+                  {data?.mergedPRs.map(pr => (
+                    <label key={pr.number} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors cursor-pointer">
+                      <button 
+                        type="button"
+                        onClick={() => setSelectedPRs(prev => ({ ...prev, [pr.number]: !prev[pr.number] }))} 
+                        className="text-muted-foreground hover:text-foreground mt-0.5"
+                      >
+                        {selectedPRs[pr.number] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
+                      </button>
+                      <div className="text-sm">
+                        <span className="font-semibold text-foreground">PR #{pr.number}:</span> {pr.title} <span className="text-xs text-muted-foreground">by @{pr.author}</span>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* 3.2 Governance & Upgrade Watch */}
+          <div className="rounded-xl border border-border bg-card/40 p-6 space-y-6">
+            <h2 className="text-lg font-bold text-foreground flex items-center gap-2 border-b border-border pb-3">
+              <Layers className="h-5 w-5 text-indigo-500" /> 3.2 Governance & Upgrade Watch
+            </h2>
+
+            {/* Recent calls decisions */}
+            <div className="space-y-3">
+              <h3 className="text-xs font-bold uppercase tracking-wider text-muted-foreground">Recent ACD Meetings & Decisions</h3>
+              {data?.recentCalls.length === 0 ? (
+                <p className="text-xs text-muted-foreground italic">No recent core developer calls recorded.</p>
+              ) : (
+                <div className="grid gap-2">
+                  {data?.recentCalls.map(c => {
+                    const key = `${c.series}-${c.number}`;
+                    return (
+                      <label key={key} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors cursor-pointer">
+                        <button 
+                          type="button"
+                          onClick={() => setSelectedCalls(prev => ({ ...prev, [key]: !prev[key] }))} 
+                          className="text-muted-foreground hover:text-foreground mt-0.5"
+                        >
+                          {selectedCalls[key] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
+                        </button>
+                        <div className="text-sm flex-1">
+                          <p className="font-semibold text-foreground">{c.displayName || `${c.series} #${c.number}`}</p>
+                          {c.tldr && <p className="text-xs text-muted-foreground mt-0.5">{String(c.tldr)}</p>}
+                        </div>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            {/* Manual highlights */}
+            <div className="space-y-1.5 pt-4 border-t border-border/60">
+              <label className={labelClass}>Manual Call Highlights / Decisions</label>
+              <textarea 
+                value={manualAcdHighlights} 
+                onChange={e => setManualAcdHighlights(e.target.value)} 
+                placeholder="Include custom bullet points, notes, or specific decisions discussed during AllCoreDevs..." 
+                className="w-full h-24 rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm text-foreground focus:border-primary/50 outline-none resize-y"
+              />
+            </div>
+
+            {/* Devnets */}
+            <div className="space-y-3 pt-4 border-t border-border/60">
+              <h3 className="text-xs font-bold uppercase tracking-wider text-muted-foreground">Devnets Progression</h3>
+              {data?.devnets.length === 0 ? (
+                <p className="text-xs text-muted-foreground italic">No active devnet updates found.</p>
+              ) : (
+                <div className="grid gap-2">
+                  {data?.devnets.map(d => (
+                    <label key={d.id} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors cursor-pointer">
+                      <button 
+                        type="button"
+                        onClick={() => setSelectedDevnets(prev => ({ ...prev, [d.id]: !prev[d.id] }))} 
+                        className="text-muted-foreground hover:text-foreground mt-0.5"
+                      >
+                        {selectedDevnets[d.id] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
+                      </button>
+                      <div className="text-sm">
+                        <span className="font-semibold text-foreground">{d.series.toUpperCase()} Devnet {d.number}:</span> {d.title} <Badge className={d.active ? "bg-emerald-500/20 text-emerald-400" : "bg-slate-500/20 text-slate-400"}>{d.active ? "Active" : "Closed"}</Badge>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* 3.3 Featured Proposal */}
+          <div className="rounded-xl border border-border bg-card/40 p-6 space-y-6">
+            <h2 className="text-lg font-bold text-foreground flex items-center gap-2 border-b border-border pb-3">
+              <BookOpen className="h-5 w-5 text-emerald-500" /> 3.3 Featured Proposal
+            </h2>
+            
+            <div className="flex gap-2">
+              <div className="relative flex-1">
+                <input 
+                  placeholder="Enter EIP or ERC number (e.g. 7702)" 
+                  value={featuredEipNumber} 
+                  onChange={e => setFeaturedEipNumber(e.target.value)} 
+                  className="w-full rounded-lg border border-border bg-muted/40 pl-9 pr-3 py-2 text-sm outline-none"
                 />
-              </CardContent>
-            </Card>
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              </div>
+              <Button onClick={handleLoadCuration} disabled={loadingCuration} className="bg-emerald-600 hover:bg-emerald-500 text-white font-medium">
+                {loadingCuration ? <Loader2 className="h-4 w-4 animate-spin" /> : "Fetch Curation"}
+              </Button>
+            </div>
+
+            {featuredDetails && (
+              <div className="rounded-lg border border-emerald-900 bg-emerald-950/20 p-4 space-y-2">
+                <p className="text-xs font-bold text-emerald-400 uppercase tracking-wider">Featured EIP details loaded</p>
+                <h4 className="text-sm font-bold text-white">EIP-{featuredDetails.number}: {featuredDetails.title}</h4>
+                {featuredDetails.summary ? (
+                  <p className="text-xs text-slate-300 leading-relaxed mt-1">{featuredDetails.summary}</p>
+                ) : (
+                  <p className="text-xs text-slate-500 italic">No summary found in database curations.</p>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* 3.4 Contributor Corner & 3.5 Watch Next Week */}
+          <div className="rounded-xl border border-border bg-card/40 p-6 space-y-6">
+            <h2 className="text-lg font-bold text-foreground flex items-center gap-2 border-b border-border pb-3">
+              <Calendar className="h-5 w-5 text-yellow-500" /> 3.4 Contributor Corner & 3.5 What to Watch
+            </h2>
+            
+            {/* Last Calls */}
+            <div className="space-y-3">
+              <h3 className="text-xs font-bold uppercase tracking-wider text-muted-foreground">EIPs Currently in Last Call</h3>
+              {data?.lastCallEIPs.length === 0 ? (
+                <p className="text-xs text-muted-foreground italic">No EIPs in Last Call this week.</p>
+              ) : (
+                <div className="grid gap-2">
+                  {data?.lastCallEIPs.map(lc => (
+                    <label key={lc.number} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors cursor-pointer">
+                      <button 
+                        type="button"
+                        onClick={() => setSelectedLastCalls(prev => ({ ...prev, [lc.number]: !prev[lc.number] }))} 
+                        className="text-muted-foreground hover:text-foreground mt-0.5"
+                      >
+                        {selectedLastCalls[lc.number] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
+                      </button>
+                      <div className="text-sm">
+                        <span className="font-semibold text-foreground">EIP-{lc.number}:</span> {lc.title} <span className="text-xs text-orange-400">(Deadline: {lc.deadline || "Immediate"})</span>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Upcoming calls schedule */}
+            <div className="space-y-3 pt-4 border-t border-border/60">
+              <h3 className="text-xs font-bold uppercase tracking-wider text-muted-foreground">Scheduled Meetings & Calls</h3>
+              {data?.upcomingCalls.length === 0 ? (
+                <p className="text-xs text-muted-foreground italic">No scheduled calls found.</p>
+              ) : (
+                <div className="grid gap-2">
+                  {data?.upcomingCalls.map(c => {
+                    const key = `${c.series}-${c.callNumber || c.issueNumber}`;
+                    return (
+                      <label key={key} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors cursor-pointer">
+                        <button 
+                          type="button"
+                          onClick={() => setSelectedUpcoming(prev => ({ ...prev, [key]: !prev[key] }))} 
+                          className="text-muted-foreground hover:text-foreground mt-0.5"
+                        >
+                          {selectedUpcoming[key] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
+                        </button>
+                        <div className="text-sm">
+                          <span className="font-semibold text-foreground">{c.title}</span> {c.occursOn ? `on ${c.occursOn}` : ""}
+                        </div>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            {/* Manual watch notes */}
+            <div className="space-y-1.5 pt-4 border-t border-border/60">
+              <label className={labelClass}>Manual Schedule / What to Watch Next Week</label>
+              <textarea 
+                value={watchNextWeek} 
+                onChange={e => setWatchNextWeek(e.target.value)} 
+                placeholder="Include custom deadlines, upcoming AMAs, specific PRs to watch..." 
+                className="w-full h-24 rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm text-foreground focus:border-primary/50 outline-none resize-y"
+              />
+            </div>
+          </div>
+
+          {/* Optional Rotating Sections */}
+          <div className="rounded-xl border border-border bg-card/40 p-6 space-y-6">
+            <h2 className="text-lg font-bold text-foreground flex items-center gap-2 border-b border-border pb-3">
+              <FileText className="h-5 w-5 text-sky-500" /> 4. Optional Rotating Sections
+            </h2>
+
+            <div className="space-y-1.5">
+              <label className={labelClass}>4.1 Standards Spotlight (Author/Editor Feature)</label>
+              <textarea 
+                value={spotlightInfo} 
+                onChange={e => setSpotlightInfo(e.target.value)} 
+                placeholder="Spotlight an author, editor, active reviewer or ecosystem contributor..." 
+                className="w-full h-20 rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm text-foreground focus:border-primary/50 outline-none resize-y"
+              />
+            </div>
+            <div className="space-y-1.5 pt-2">
+              <label className={labelClass}>4.2 Enterprise Brief</label>
+              <textarea 
+                value={enterpriseBrief} 
+                onChange={e => setEnterpriseBrief(e.target.value)} 
+                placeholder="Explain the business or enterprise impact of this week's upgrades..." 
+                className="w-full h-20 rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm text-foreground focus:border-primary/50 outline-none resize-y"
+              />
+            </div>
+            <div className="space-y-1.5 pt-2">
+              <label className={labelClass}>4.3 Ecosystem Adoption</label>
+              <textarea 
+                value={ecosystemAdoption} 
+                onChange={e => setEcosystemAdoption(e.target.value)} 
+                placeholder="Highlight projects adopting or implementing recently finalized standards..." 
+                className="w-full h-20 rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm text-foreground focus:border-primary/50 outline-none resize-y"
+              />
+            </div>
+          </div>
+
+          {/* Action Row */}
+          <div className="flex items-center justify-between border-t border-border pt-6">
+            <p className="text-xs text-muted-foreground">Select and input items, then click compile to copy.</p>
+            <Button onClick={handleCopyMarkdown} className="bg-primary hover:bg-primary/95 text-black font-semibold px-6 shadow-md">
+              <Copy className="mr-1.5 h-4 w-4" /> Copy Recap Markdown
+            </Button>
           </div>
 
         </div>
-
       </div>
+
     </div>
   );
 }

--- a/src/app/admin/weekly-recap/page.tsx
+++ b/src/app/admin/weekly-recap/page.tsx
@@ -1,0 +1,735 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { client } from "@/lib/orpc";
+import { toast } from "sonner";
+import {
+  BookOpen,
+  Calendar,
+  Check,
+  CheckSquare,
+  Clock,
+  Copy,
+  FileText,
+  Flame,
+  GitMerge,
+  GitPullRequest,
+  Layers,
+  Loader2,
+  RefreshCw,
+  Search,
+  Send,
+  Sparkles,
+  Square,
+  Terminal,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+type WeeklyData = Awaited<ReturnType<typeof client.dashboard.getWeeklyRecap>>;
+
+const labelClass = "mb-1 block text-[11px] font-semibold uppercase tracking-wider text-muted-foreground";
+const inputClass = "w-full rounded-md border border-border bg-muted/40 px-3 py-1.5 text-sm text-foreground focus:border-primary/50 focus:ring-1 focus:ring-primary/30 transition-all outline-none";
+
+export default function WeeklyRecapPage() {
+  const router = useRouter();
+  
+  // App States
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [data, setData] = useState<WeeklyData | null>(null);
+  const [categories, setCategories] = useState<Array<{ id: string; name: string }>>([]);
+  
+  // Blog Post Fields
+  const [title, setTitle] = useState(`Ethereum Standards Weekly - ${new Date().toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}`);
+  const [slug, setSlug] = useState(`ethereum-standards-weekly-${new Date().toISOString().slice(0, 10)}`);
+  const [selectedCategory, setSelectedCategory] = useState("");
+  
+  // Selection States (IDs of items to include in report)
+  const [selectedProposals, setSelectedProposals] = useState<Record<number, boolean>>({});
+  const [selectedChanges, setSelectedChanges] = useState<Record<string, boolean>>({});
+  const [selectedPRs, setSelectedPRs] = useState<Record<number, boolean>>({});
+  const [selectedDevnets, setSelectedDevnets] = useState<Record<string, boolean>>({});
+  const [selectedCalls, setSelectedCalls] = useState<Record<string, boolean>>({});
+  const [selectedUpcoming, setSelectedUpcoming] = useState<Record<string, boolean>>({});
+  const [selectedLastCalls, setSelectedLastCalls] = useState<Record<number, boolean>>({});
+  
+  // Featured Proposal Field
+  const [featuredEipNumber, setFeaturedEipNumber] = useState("");
+  const [loadingCuration, setLoadingCuration] = useState(false);
+  const [featuredDetails, setFeaturedDetails] = useState<{
+    number: number;
+    title: string;
+    summary: string;
+    benefits: string[];
+    tradeoffs: string[];
+  } | null>(null);
+
+  // Manual Inputs / Rotating sections
+  const [manualAcdHighlights, setManualAcdHighlights] = useState("");
+  const [enterpriseBrief, setEnterpriseBrief] = useState("");
+  const [ecosystemAdoption, setEcosystemAdoption] = useState("");
+  const [watchNextWeek, setWatchNextWeek] = useState("");
+  const [spotlightInfo, setSpotlightInfo] = useState("");
+  
+  // Live Compiled Markdown
+  const [markdown, setMarkdown] = useState("");
+
+  // Load Data
+  const loadData = async () => {
+    setLoading(true);
+    try {
+      const [recapData, blogCats] = await Promise.all([
+        client.dashboard.getWeeklyRecap({}),
+        client.blog.listCategories(),
+      ]);
+      setData(recapData);
+      setCategories(blogCats);
+      if (blogCats.length > 0) {
+        // Pre-select Newsletter or News if present
+        const newsCat = blogCats.find(c => c.name.toLowerCase().includes("newsletter") || c.name.toLowerCase().includes("news"));
+        setSelectedCategory(newsCat?.id || blogCats[0].id);
+      }
+
+      // Pre-fill selection objects to true
+      const proposalsSel: Record<number, boolean> = {};
+      recapData.newProposals.forEach(p => proposalsSel[p.number] = true);
+      setSelectedProposals(proposalsSel);
+
+      const changesSel: Record<string, boolean> = {};
+      recapData.statusChanges.forEach(sc => changesSel[`${sc.number}-${sc.to}`] = true);
+      setSelectedChanges(changesSel);
+
+      const prsSel: Record<number, boolean> = {};
+      recapData.mergedPRs.forEach(pr => prsSel[pr.number] = true);
+      setSelectedPRs(prsSel);
+
+      const devnetsSel: Record<string, boolean> = {};
+      recapData.devnets.forEach(d => devnetsSel[d.id] = true);
+      setSelectedDevnets(devnetsSel);
+
+      const callsSel: Record<string, boolean> = {};
+      recapData.recentCalls.forEach(c => callsSel[`${c.series}-${c.number}`] = true);
+      setSelectedCalls(callsSel);
+
+      const upcomingSel: Record<string, boolean> = {};
+      recapData.upcomingCalls.forEach(c => upcomingSel[`${c.series}-${c.callNumber || c.issueNumber}`] = true);
+      setSelectedUpcoming(upcomingSel);
+
+      const lastCallSel: Record<number, boolean> = {};
+      recapData.lastCallEIPs.forEach(lc => lastCallSel[lc.number] = true);
+      setSelectedLastCalls(lastCallSel);
+
+    } catch (error) {
+      toast.error("Failed to load recap data");
+      console.error(error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  // Pre-fetch Curation details for Featured Proposal
+  const handleLoadCuration = async () => {
+    const num = parseInt(featuredEipNumber, 10);
+    if (isNaN(num)) {
+      toast.error("Please enter a valid EIP/ERC number");
+      return;
+    }
+    setLoadingCuration(true);
+    try {
+      const curations = await client.curations.getEipCurations({ eipNumbers: [num] });
+      if (curations.length > 0) {
+        const cur = curations[0];
+        setFeaturedDetails({
+          number: num,
+          title: cur.layman_title || `EIP-${num}`,
+          summary: cur.layman_summary || "",
+          benefits: cur.benefits || [],
+          tradeoffs: cur.tradeoffs || [],
+        });
+        toast.success("Layman curation loaded successfully!");
+      } else {
+        // Fallback info from generic EIP meta
+        setFeaturedDetails({
+          number: num,
+          title: `EIP-${num}`,
+          summary: "No layman summary curated yet.",
+          benefits: [],
+          tradeoffs: [],
+        });
+        toast.info("No customized layman curation found; using default placeholders.");
+      }
+    } catch {
+      toast.error("Failed to query EIP curation details");
+    } finally {
+      setLoadingCuration(false);
+    }
+  };
+
+  // Compile Live Markdown whenever fields or selections change
+  useEffect(() => {
+    if (!data) return;
+
+    let md = `# ${title}\n\n`;
+    md += `Ethereum protocol upgrades, governance decisions, and EIP analysis — delivered to your inbox every week.\n\n---\n\n`;
+
+    // 1. STANDARDS IN MOTION
+    md += `## 1. Standards in Motion\n\n`;
+    
+    // New EIPs/ERCs
+    const selectedNew = data.newProposals.filter(p => selectedProposals[p.number]);
+    if (selectedNew.length > 0) {
+      md += `### 🆕 New Proposals Introduced\n`;
+      selectedNew.forEach(p => {
+        const typeStr = p.category ? `${p.category} ` : "";
+        md += `- **[${p.status}] [${typeStr}EIP-${p.number}](https://eipsinsight.com/${p.category?.toLowerCase() === "erc" ? "erc" : "eip"}s/${p.number})**: ${p.title}\n`;
+      });
+      md += `\n`;
+    }
+
+    // Status Transitions
+    const selectedTransition = data.statusChanges.filter(sc => selectedChanges[`${sc.number}-${sc.to}`]);
+    if (selectedTransition.length > 0) {
+      md += `### 🔄 Lifecycle & Status Changes\n`;
+      selectedTransition.forEach(sc => {
+        const typeStr = sc.category ? `${sc.category} ` : "";
+        md += `- **[${typeStr}EIP-${sc.number}](https://eipsinsight.com/${sc.category?.toLowerCase() === "erc" ? "erc" : "eip"}s/${sc.number})**: Transitioned from \`${sc.from}\` ➔ \`${sc.to}\`\n`;
+      });
+      md += `\n`;
+    }
+
+    // Merged PRs
+    const selectedMerged = data.mergedPRs.filter(pr => selectedPRs[pr.number]);
+    if (selectedMerged.length > 0) {
+      md += `### 🪵 Recently Merged Pull Requests\n`;
+      selectedMerged.forEach(pr => {
+        md += `- **PR #${pr.number}**: ${pr.title} (Merged by @${pr.author})\n`;
+      });
+      md += `\n`;
+    }
+
+    if (selectedNew.length === 0 && selectedTransition.length === 0 && selectedMerged.length === 0) {
+      md += `*No standards activity selected for this week.*\n\n`;
+    }
+
+    // 2. GOVERNANCE & UPGRADE WATCH
+    md += `## 2. Governance & Upgrade Watch\n\n`;
+    
+    // Call Decisions
+    const selectedCallData = data.recentCalls.filter(c => selectedCalls[`${c.series}-${c.number}`]);
+    if (selectedCallData.length > 0) {
+      md += `### 🗣️ Core Dev Calls Highlights\n`;
+      selectedCallData.forEach(c => {
+        md += `#### ${c.displayName || `${c.series} #${c.number}`}\n`;
+        if (c.tldr) {
+          md += `* **Summary:** ${c.tldr}\n`;
+        }
+        if (c.keyDecisions && Array.isArray(c.keyDecisions)) {
+          md += `* **Key Decisions:**\n`;
+          (c.keyDecisions as string[]).forEach(dec => {
+            md += `  - ${dec}\n`;
+          });
+        }
+        md += `\n`;
+      });
+    }
+
+    if (manualAcdHighlights.trim()) {
+      md += `### 💡 Governance Notes\n${manualAcdHighlights}\n\n`;
+    }
+
+    // Devnets
+    const selectedDevnetData = data.devnets.filter(d => selectedDevnets[d.id]);
+    if (selectedDevnetData.length > 0) {
+      md += `### 🧪 Devnets & Testnet Progression\n`;
+      selectedDevnetData.forEach(d => {
+        md += `- **[${d.active ? "Active" : "Closed"}] [${d.series.toUpperCase()} Devnet ${d.number}](https://eipsinsight.com/upgrade/devnets/${d.id})**: ${d.title}\n`;
+      });
+      md += `\n`;
+    }
+
+    // 3. FEATURED PROPOSAL
+    if (featuredDetails) {
+      md += `## 3. Featured Proposal: EIP-${featuredDetails.number}\n\n`;
+      md += `### 🔍 ${featuredDetails.title}\n\n`;
+      if (featuredDetails.summary) {
+        md += `**Problem and Technical Approach:**\n${featuredDetails.summary}\n\n`;
+      }
+      if (featuredDetails.benefits.length > 0) {
+        md += `**Ecosystem Benefits:**\n`;
+        featuredDetails.benefits.forEach(b => md += `- ${b}\n`);
+        md += `\n`;
+      }
+      if (featuredDetails.tradeoffs.length > 0) {
+        md += `**Design Tradeoffs:**\n`;
+        featuredDetails.tradeoffs.forEach(t => md += `- ${t}\n`);
+        md += `\n`;
+      }
+      md += `*Learn more on the detail page: [Read EIP-${featuredDetails.number} Observability Details](https://eipsinsight.com/eips/${featuredDetails.number})*\n\n`;
+    }
+
+    // 4. CONTRIBUTOR CORNER
+    md += `## 4. Contributor Corner\n\n`;
+    
+    // Last Calls seeking review
+    const selectedLast = data.lastCallEIPs.filter(lc => selectedLastCalls[lc.number]);
+    if (selectedLast.length > 0) {
+      md += `### 📢 EIPs in Last Call (Seeking final community review)\n`;
+      selectedLast.forEach(lc => {
+        md += `- **[EIP-${lc.number}](https://eipsinsight.com/eips/${lc.number})**: ${lc.title} (Review Deadline: \`${lc.deadline || "Immediate"}\`)\n`;
+      });
+      md += `\n`;
+    }
+
+    md += `* Check editor activities and contributions on the [Editors Leaderboard](https://eipsinsight.com/analytics/editors).\n\n`;
+
+    // 5. WHAT TO WATCH NEXT WEEK
+    md += `## 5. What to Watch Next Week\n\n`;
+    const selectedUpcomingData = data.upcomingCalls.filter(c => selectedUpcoming[`${c.series}-${c.callNumber || c.issueNumber}`]);
+    if (selectedUpcomingData.length > 0) {
+      md += `### 🗓️ Scheduled Core Meetings & Office Hours\n`;
+      selectedUpcomingData.forEach(c => {
+        const timeStr = c.occursOn ? ` on \`${c.occursOn}\`` : "";
+        md += `- **${c.title}**${timeStr} (Agenda issue: [#${c.issueNumber}](${c.issueUrl}))\n`;
+      });
+      md += `\n`;
+    }
+
+    if (watchNextWeek.trim()) {
+      md += `${watchNextWeek}\n\n`;
+    }
+
+    // ROTATING SECTIONS
+    if (spotlightInfo.trim()) {
+      md += `## 🎙️ Standards Spotlight\n\n${spotlightInfo}\n\n`;
+    }
+    if (enterpriseBrief.trim()) {
+      md += `## 🏢 Enterprise Brief: Why This Matters to Businesses\n\n${enterpriseBrief}\n\n`;
+    }
+    if (ecosystemAdoption.trim()) {
+      md += `## 🚀 Ecosystem Adoption & Implementations\n\n${ecosystemAdoption}\n\n`;
+    }
+
+    setMarkdown(md);
+  }, [
+    title, data, selectedProposals, selectedChanges, selectedPRs, selectedDevnets,
+    selectedCalls, selectedUpcoming, selectedLastCalls, featuredDetails,
+    manualAcdHighlights, enterpriseBrief, ecosystemAdoption, watchNextWeek, spotlightInfo
+  ]);
+
+  // Actions
+  const handleCopy = () => {
+    navigator.clipboard.writeText(markdown);
+    toast.success("Markdown copied to clipboard!");
+  };
+
+  const handleCreateDraft = async () => {
+    if (!title.trim() || !slug.trim()) {
+      toast.error("Please provide a Title and Slug for the draft");
+      return;
+    }
+    setSaving(true);
+    try {
+      await client.blog.create({
+        title,
+        slug,
+        content: markdown,
+        published: false,
+        categoryId: selectedCategory || null,
+        excerpt: `Weekly Ethereum Standards & Governance updates for ${new Date().toLocaleDateString("en", { month: "short", day: "numeric" })}.`,
+      });
+      toast.success("Blog draft created successfully!");
+      router.push("/admin/blogs");
+    } catch (err: any) {
+      toast.error(err.message || "Failed to create blog draft");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-background text-foreground">
+        <Loader2 className="h-10 w-10 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-950 p-6 text-slate-100 font-sans">
+      <div className="mx-auto max-w-[1600px] space-y-6">
+        
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-slate-800 pb-4">
+          <div>
+            <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-primary">
+              <Sparkles className="h-4 w-4" /> Admin Tools
+            </div>
+            <h1 className="text-3xl font-extrabold tracking-tight text-white mt-1">Weekly Recap Generator</h1>
+          </div>
+          <div className="flex items-center gap-3">
+            <Button variant="outline" onClick={loadData} className="border-slate-800 hover:bg-slate-900 text-slate-300">
+              <RefreshCw className="mr-2 h-4 w-4" /> Reload Data
+            </Button>
+            <Button onClick={handleCopy} className="bg-slate-800 hover:bg-slate-700 text-white">
+              <Copy className="mr-2 h-4 w-4" /> Copy Markdown
+            </Button>
+            <Button onClick={handleCreateDraft} disabled={saving} className="bg-primary hover:bg-primary/95 text-black font-semibold">
+              {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Send className="mr-2 h-4 w-4" />}
+              Publish Blog Draft
+            </Button>
+          </div>
+        </div>
+
+        {/* Two-Column Workspace */}
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          
+          {/* LEFT: Controls, Toggles, & Inputs */}
+          <div className="space-y-6 max-h-[85vh] overflow-y-auto pr-2 custom-scrollbar">
+            
+            {/* Metadata Card */}
+            <Card className="border-slate-800 bg-slate-900/60 backdrop-blur-md">
+              <CardHeader className="py-4">
+                <CardTitle className="text-sm font-semibold uppercase tracking-wider text-slate-300">Post Metadata</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div>
+                    <label className={labelClass}>Post Title</label>
+                    <input value={title} onChange={e => setTitle(e.target.value)} className={inputClass} />
+                  </div>
+                  <div>
+                    <label className={labelClass}>URL Slug</label>
+                    <input value={slug} onChange={e => setSlug(e.target.value)} className={inputClass} />
+                  </div>
+                </div>
+                <div>
+                  <label className={labelClass}>Blog Category</label>
+                  <select 
+                    value={selectedCategory} 
+                    onChange={e => setSelectedCategory(e.target.value)} 
+                    className="w-full rounded-md border border-border bg-slate-900 px-3 py-1.5 text-sm text-foreground focus:border-primary/50 outline-none"
+                  >
+                    <option value="">No Category</option>
+                    {categories.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+                  </select>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Standards in Motion Toggles */}
+            <Card className="border-slate-800 bg-slate-900/60 backdrop-blur-md">
+              <CardHeader className="py-4 flex flex-row items-center justify-between">
+                <CardTitle className="text-sm font-semibold uppercase tracking-wider text-slate-300 flex items-center gap-2">
+                  <Flame className="h-4 w-4 text-orange-500" /> 1. Standards in Motion
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {/* New proposals */}
+                <div>
+                  <h4 className="text-xs font-bold text-slate-400 mb-2">New Proposals (Last 7 Days)</h4>
+                  {data?.newProposals.length === 0 ? (
+                    <p className="text-xs text-slate-500 italic">No new proposals found.</p>
+                  ) : (
+                    <div className="space-y-2">
+                      {data?.newProposals.map(p => (
+                        <div key={p.number} className="flex items-start gap-2.5 text-sm">
+                          <button onClick={() => setSelectedProposals(prev => ({ ...prev, [p.number]: !prev[p.number] }))} className="text-slate-400 hover:text-white mt-0.5">
+                            {selectedProposals[p.number] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
+                          </button>
+                          <span className="text-slate-300">
+                            <Badge variant="outline" className="mr-1 bg-slate-950 text-[10px] py-0">{p.status}</Badge>
+                            EIP-{p.number}: {p.title}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Status Transitions */}
+                <div className="border-t border-slate-800 pt-4">
+                  <h4 className="text-xs font-bold text-slate-400 mb-2">Status Transitions (Last 7 Days)</h4>
+                  {data?.statusChanges.length === 0 ? (
+                    <p className="text-xs text-slate-500 italic">No status transitions found.</p>
+                  ) : (
+                    <div className="space-y-2">
+                      {data?.statusChanges.map(sc => {
+                        const key = `${sc.number}-${sc.to}`;
+                        return (
+                          <div key={key} className="flex items-start gap-2.5 text-sm">
+                            <button onClick={() => setSelectedChanges(prev => ({ ...prev, [key]: !prev[key] }))} className="text-slate-400 hover:text-white mt-0.5">
+                              {selectedChanges[key] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
+                            </button>
+                            <span className="text-slate-300">
+                              EIP-{sc.number} ➔ <span className="text-primary font-semibold">{sc.to}</span> ({sc.title})
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+
+                {/* Merged PRs */}
+                <div className="border-t border-slate-800 pt-4">
+                  <h4 className="text-xs font-bold text-slate-400 mb-2">Merged Pull Requests</h4>
+                  {data?.mergedPRs.length === 0 ? (
+                    <p className="text-xs text-slate-500 italic">No merged PRs found.</p>
+                  ) : (
+                    <div className="space-y-2">
+                      {data?.mergedPRs.map(pr => (
+                        <div key={pr.number} className="flex items-start gap-2.5 text-sm">
+                          <button onClick={() => setSelectedPRs(prev => ({ ...prev, [pr.number]: !prev[pr.number] }))} className="text-slate-400 hover:text-white mt-0.5">
+                            {selectedPRs[pr.number] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
+                          </button>
+                          <span className="text-slate-300">
+                            PR #{pr.number}: {pr.title} (by @{pr.author})
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Governance & Upgrade watch Toggles */}
+            <Card className="border-slate-800 bg-slate-900/60 backdrop-blur-md">
+              <CardHeader className="py-4">
+                <CardTitle className="text-sm font-semibold uppercase tracking-wider text-slate-300 flex items-center gap-2">
+                  <Layers className="h-4 w-4 text-indigo-500" /> 2. Governance & Upgrade Watch
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {/* Recent calls decisions */}
+                <div>
+                  <h4 className="text-xs font-bold text-slate-400 mb-2">Recent ACD Calls & Decisions</h4>
+                  {data?.recentCalls.length === 0 ? (
+                    <p className="text-xs text-slate-500 italic">No recent calls found.</p>
+                  ) : (
+                    <div className="space-y-3">
+                      {data?.recentCalls.map(c => {
+                        const key = `${c.series}-${c.number}`;
+                        return (
+                          <div key={key} className="flex items-start gap-2.5 text-sm">
+                            <button onClick={() => setSelectedCalls(prev => ({ ...prev, [key]: !prev[key] }))} className="text-slate-400 hover:text-white mt-0.5">
+                              {selectedCalls[key] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
+                            </button>
+                            <div className="text-slate-300 flex-1">
+                              <p className="font-semibold text-white">{c.displayName || `${c.series} #${c.number}`}</p>
+                              {c.tldr && <p className="text-xs text-slate-400 mt-0.5">{String(c.tldr)}</p>}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+
+                {/* Manual governance notes */}
+                <div className="border-t border-slate-800 pt-4">
+                  <label className={labelClass}>Manual Call Highlights & Governance Notes</label>
+                  <textarea 
+                    value={manualAcdHighlights} 
+                    onChange={e => setManualAcdHighlights(e.target.value)} 
+                    placeholder="Enter manual bullet points or decisions from Core Dev calls..." 
+                    className="w-full h-20 rounded-md border border-border bg-slate-900 px-3 py-1.5 text-sm text-foreground outline-none resize-y"
+                  />
+                </div>
+
+                {/* Active Devnets */}
+                <div className="border-t border-slate-800 pt-4">
+                  <h4 className="text-xs font-bold text-slate-400 mb-2">Devnets Progression</h4>
+                  {data?.devnets.length === 0 ? (
+                    <p className="text-xs text-slate-500 italic">No devnets specs found.</p>
+                  ) : (
+                    <div className="space-y-2">
+                      {data?.devnets.map(d => (
+                        <div key={d.id} className="flex items-start gap-2.5 text-sm">
+                          <button onClick={() => setSelectedDevnets(prev => ({ ...prev, [d.id]: !prev[d.id] }))} className="text-slate-400 hover:text-white mt-0.5">
+                            {selectedDevnets[d.id] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
+                          </button>
+                          <span className="text-slate-300">
+                            {d.series.toUpperCase()} Devnet {d.number}: {d.title} ({d.active ? "Active" : "Closed"})
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Featured Proposal Selector */}
+            <Card className="border-slate-800 bg-slate-900/60 backdrop-blur-md">
+              <CardHeader className="py-4">
+                <CardTitle className="text-sm font-semibold uppercase tracking-wider text-slate-300 flex items-center gap-2">
+                  <BookOpen className="h-4 w-4 text-emerald-500" /> 3. Featured Proposal
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex gap-2">
+                  <div className="relative flex-1">
+                    <input 
+                      placeholder="EIP or ERC Number (e.g. 7702)" 
+                      value={featuredEipNumber} 
+                      onChange={e => setFeaturedEipNumber(e.target.value)} 
+                      className="w-full rounded-md border border-border bg-muted/40 pl-8 pr-3 py-1.5 text-sm outline-none"
+                    />
+                    <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+                  </div>
+                  <Button onClick={handleLoadCuration} disabled={loadingCuration} className="bg-emerald-600 hover:bg-emerald-500 text-white font-medium">
+                    {loadingCuration ? <Loader2 className="h-4 w-4 animate-spin" /> : "Load Curation"}
+                  </Button>
+                </div>
+
+                {featuredDetails && (
+                  <div className="rounded-lg border border-emerald-950 bg-emerald-950/20 p-4 space-y-2">
+                    <p className="text-xs font-bold text-emerald-400 uppercase tracking-wider">Loaded Proposal</p>
+                    <p className="text-sm font-bold text-white">EIP-{featuredDetails.number}: {featuredDetails.title}</p>
+                    {featuredDetails.summary ? (
+                      <p className="text-xs text-slate-300 line-clamp-3 leading-relaxed">{featuredDetails.summary}</p>
+                    ) : (
+                      <p className="text-xs text-slate-500 italic">No summary found in database.</p>
+                    )}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            {/* Contributor corner & upcoming schedules */}
+            <Card className="border-slate-800 bg-slate-900/60 backdrop-blur-md">
+              <CardHeader className="py-4">
+                <CardTitle className="text-sm font-semibold uppercase tracking-wider text-slate-300 flex items-center gap-2">
+                  <Calendar className="h-4 w-4 text-yellow-500" /> 4 & 5. Corner & Next Week
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {/* Last Calls */}
+                <div>
+                  <h4 className="text-xs font-bold text-slate-400 mb-2">EIPs in Last Call</h4>
+                  {data?.lastCallEIPs.length === 0 ? (
+                    <p className="text-xs text-slate-500 italic">No EIPs currently in Last Call.</p>
+                  ) : (
+                    <div className="space-y-2">
+                      {data?.lastCallEIPs.map(lc => (
+                        <div key={lc.number} className="flex items-start gap-2.5 text-sm">
+                          <button onClick={() => setSelectedLastCalls(prev => ({ ...prev, [lc.number]: !prev[lc.number] }))} className="text-slate-400 hover:text-white mt-0.5">
+                            {selectedLastCalls[lc.number] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
+                          </button>
+                          <span className="text-slate-300">
+                            EIP-{lc.number}: {lc.title} (Deadline: {lc.deadline || "None"})
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Upcoming meetings */}
+                <div className="border-t border-slate-800 pt-4">
+                  <h4 className="text-xs font-bold text-slate-400 mb-2">Upcoming ACD & Coordination Calls</h4>
+                  {data?.upcomingCalls.length === 0 ? (
+                    <p className="text-xs text-slate-500 italic">No upcoming calls found.</p>
+                  ) : (
+                    <div className="space-y-2">
+                      {data?.upcomingCalls.map(c => {
+                        const key = `${c.series}-${c.callNumber || c.issueNumber}`;
+                        return (
+                          <div key={key} className="flex items-start gap-2.5 text-sm">
+                            <button onClick={() => setSelectedUpcoming(prev => ({ ...prev, [key]: !prev[key] }))} className="text-slate-400 hover:text-white mt-0.5">
+                              {selectedUpcoming[key] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
+                            </button>
+                            <span className="text-slate-300">
+                              {c.title} {c.occursOn ? `(${c.occursOn})` : ""}
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+
+                {/* Manual watchlist/schedules */}
+                <div className="border-t border-slate-800 pt-4">
+                  <label className={labelClass}>Manual Schedule / What to Watch Next Week</label>
+                  <textarea 
+                    value={watchNextWeek} 
+                    onChange={e => setWatchNextWeek(e.target.value)} 
+                    placeholder="Enter deadlines, office hours details, or specific PRs to watch next week..." 
+                    className="w-full h-20 rounded-md border border-border bg-slate-900 px-3 py-1.5 text-sm text-foreground outline-none resize-y"
+                  />
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Optional rotating sections */}
+            <Card className="border-slate-800 bg-slate-900/60 backdrop-blur-md">
+              <CardHeader className="py-4">
+                <CardTitle className="text-sm font-semibold uppercase tracking-wider text-slate-300">Rotating Editorial Sections</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div>
+                  <label className={labelClass}>Standards Spotlight (Author/Editor Feature)</label>
+                  <textarea 
+                    value={spotlightInfo} 
+                    onChange={e => setSpotlightInfo(e.target.value)} 
+                    placeholder="Feature a contributor, editor, or project this week..." 
+                    className="w-full h-20 rounded-md border border-border bg-slate-900 px-3 py-1.5 text-sm text-foreground outline-none resize-y"
+                  />
+                </div>
+                <div>
+                  <label className={labelClass}>Enterprise Brief</label>
+                  <textarea 
+                    value={enterpriseBrief} 
+                    onChange={e => setEnterpriseBrief(e.target.value)} 
+                    placeholder="Translate protocol changes into enterprise or business impacts..." 
+                    className="w-full h-20 rounded-md border border-border bg-slate-900 px-3 py-1.5 text-sm text-foreground outline-none resize-y"
+                  />
+                </div>
+                <div>
+                  <label className={labelClass}>Ecosystem Adoption</label>
+                  <textarea 
+                    value={ecosystemAdoption} 
+                    onChange={e => setEcosystemAdoption(e.target.value)} 
+                    placeholder="Highlight projects implementing recently finalized EIPs/ERCs..." 
+                    className="w-full h-20 rounded-md border border-border bg-slate-900 px-3 py-1.5 text-sm text-foreground outline-none resize-y"
+                  />
+                </div>
+              </CardContent>
+            </Card>
+
+          </div>
+
+          {/* RIGHT: Live Compiled Preview */}
+          <div className="space-y-6">
+            <Card className="border-slate-800 bg-slate-900/40 backdrop-blur-md h-full flex flex-col">
+              <CardHeader className="py-4 flex flex-row items-center justify-between border-b border-slate-800">
+                <CardTitle className="text-sm font-semibold uppercase tracking-wider text-slate-300 flex items-center gap-2">
+                  <FileText className="h-4 w-4 text-primary" /> Live Markdown Output
+                </CardTitle>
+                <div className="text-[10px] text-slate-500 font-mono">Real-time compilation</div>
+              </CardHeader>
+              <CardContent className="p-0 flex-1 flex flex-col min-h-[60vh]">
+                <textarea 
+                  value={markdown} 
+                  onChange={e => setMarkdown(e.target.value)} 
+                  className="w-full flex-1 bg-slate-950/60 p-6 text-sm text-slate-300 font-mono focus:outline-none resize-none leading-relaxed border-0"
+                />
+              </CardContent>
+            </Card>
+          </div>
+
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/weekly-recap/page.tsx
+++ b/src/app/admin/weekly-recap/page.tsx
@@ -30,6 +30,32 @@ type WeeklyData = Awaited<ReturnType<typeof client.dashboard.getWeeklyRecap>>;
 const labelClass = "mb-1.5 block text-[11px] font-semibold uppercase tracking-wider text-muted-foreground";
 const inputClass = "w-full rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm text-foreground focus:border-primary/50 focus:ring-1 focus:ring-primary/30 transition-all outline-none";
 
+// Helper Helpers
+const formatDate = (isoString?: string | null) => {
+  if (!isoString) return "";
+  const d = new Date(isoString);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+};
+
+const getProposalLink = (p: { category: string | null; number: number }) => {
+  const cat = p.category?.toLowerCase();
+  const folder = cat === "erc" ? "ercs" : cat === "rip" ? "rips" : "eips";
+  return `/${folder}/${p.number}`;
+};
+
+const getPRLink = (pr: { repoName: string; number: number }) => {
+  return `/pr/${pr.repoName}/${pr.number}`;
+};
+
+const getDevnetLink = (id: string) => {
+  return `/upgrade/devnets/${id}`;
+};
+
+const getCallLink = (c: { series: string; number: string }) => {
+  return `/upgrade/calls/${c.series.toLowerCase()}/${c.number}`;
+};
+
 export default function WeeklyRecapPage() {
   // App States
   const [loading, setLoading] = useState(true);
@@ -173,7 +199,7 @@ export default function WeeklyRecapPage() {
       md += `### 🆕 New Proposals Introduced\n`;
       selectedNew.forEach(p => {
         const typeStr = p.category ? `${p.category} ` : "";
-        md += `- **[${p.status}] [${typeStr}EIP-${p.number}](https://eipsinsight.com/${p.category?.toLowerCase() === "erc" ? "erc" : "eip"}s/${p.number})**: ${p.title}\n`;
+        md += `- **[${p.status}] [${typeStr}EIP-${p.number}](https://eipsinsight.com/${p.category?.toLowerCase() === "erc" ? "erc" : "eip"}s/${p.number})**: ${p.title} *(Created ${formatDate(p.createdAt)})*\n`;
       });
       md += `\n`;
     }
@@ -184,7 +210,7 @@ export default function WeeklyRecapPage() {
       md += `### 🔄 Lifecycle & Status Changes\n`;
       selectedTransition.forEach(sc => {
         const typeStr = sc.category ? `${sc.category} ` : "";
-        md += `- **[${typeStr}EIP-${sc.number}](https://eipsinsight.com/${sc.category?.toLowerCase() === "erc" ? "erc" : "eip"}s/${sc.number})**: Transitioned from \`${sc.from}\` ➔ \`${sc.to}\`\n`;
+        md += `- **[${typeStr}EIP-${sc.number}](https://eipsinsight.com/${sc.category?.toLowerCase() === "erc" ? "erc" : "eip"}s/${sc.number})**: Transitioned from \`${sc.from}\` ➔ \`${sc.to}\` *(Changed ${formatDate(sc.changedAt)})*\n`;
       });
       md += `\n`;
     }
@@ -194,7 +220,7 @@ export default function WeeklyRecapPage() {
     if (selectedMerged.length > 0) {
       md += `### 🪵 Recently Merged Pull Requests\n`;
       selectedMerged.forEach(pr => {
-        md += `- **PR #${pr.number}**: ${pr.title} (Merged by @${pr.author})\n`;
+        md += `- **[PR #${pr.number}](https://eipsinsight.com/pr/${pr.repoName}/${pr.number})**: ${pr.title} *(Merged ${formatDate(pr.mergedAt)} by @${pr.author})*\n`;
       });
       md += `\n`;
     }
@@ -211,7 +237,7 @@ export default function WeeklyRecapPage() {
     if (selectedCallData.length > 0) {
       md += `### 🗣️ Core Dev Calls Highlights\n`;
       selectedCallData.forEach(c => {
-        md += `#### ${c.displayName || `${c.series} #${c.number}`}\n`;
+        md += `#### ${c.displayName || `${c.series} #${c.number}`} *(Occurred ${formatDate(c.occurredOn)})*\n`;
         if (c.tldr) {
           md += `* **Summary:** ${c.tldr}\n`;
         }
@@ -234,7 +260,7 @@ export default function WeeklyRecapPage() {
     if (selectedDevnetData.length > 0) {
       md += `### 🧪 Devnets & Testnet Progression\n`;
       selectedDevnetData.forEach(d => {
-        md += `- **[${d.active ? "Active" : "Closed"}] [${d.series.toUpperCase()} Devnet ${d.number}](https://eipsinsight.com/upgrade/devnets/${d.id})**: ${d.title}\n`;
+        md += `- **[${d.active ? "Active" : "Closed"}] [${d.series.toUpperCase()} Devnet ${d.number}](https://eipsinsight.com/upgrade/devnets/${d.id})**: ${d.title} *(Scraped ${formatDate(d.scrapedAt)})*\n`;
       });
       md += `\n`;
     }
@@ -397,7 +423,7 @@ export default function WeeklyRecapPage() {
               ) : (
                 <div className="grid gap-2">
                   {data?.newProposals.map(p => (
-                    <label key={p.number} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors cursor-pointer">
+                    <div key={p.number} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors">
                       <button 
                         type="button"
                         onClick={() => setSelectedProposals(prev => ({ ...prev, [p.number]: !prev[p.number] }))} 
@@ -405,11 +431,15 @@ export default function WeeklyRecapPage() {
                       >
                         {selectedProposals[p.number] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
                       </button>
-                      <div className="text-sm">
-                        <Badge variant="outline" className="mr-2 bg-background/80 text-[10px] py-0">{p.status}</Badge>
-                        <span className="font-semibold text-foreground">EIP-{p.number}:</span> {p.title}
+                      <div className="text-sm flex-1 flex items-center justify-between">
+                        <div>
+                          <Badge variant="outline" className="mr-2 bg-background/80 text-[10px] py-0">{p.status}</Badge>
+                          <span className="font-semibold text-foreground">EIP-{p.number}:</span> {p.title}
+                          <span className="text-xs text-muted-foreground ml-2">({formatDate(p.createdAt)})</span>
+                        </div>
+                        <a href={getProposalLink(p)} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline font-semibold">[Check]</a>
                       </div>
-                    </label>
+                    </div>
                   ))}
                 </div>
               )}
@@ -425,7 +455,7 @@ export default function WeeklyRecapPage() {
                   {data?.statusChanges.map(sc => {
                     const key = `${sc.number}-${sc.to}`;
                     return (
-                      <label key={key} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors cursor-pointer">
+                      <div key={key} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors">
                         <button 
                           type="button"
                           onClick={() => setSelectedChanges(prev => ({ ...prev, [key]: !prev[key] }))} 
@@ -433,10 +463,14 @@ export default function WeeklyRecapPage() {
                         >
                           {selectedChanges[key] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
                         </button>
-                        <div className="text-sm">
-                          <span className="font-semibold text-foreground">EIP-{sc.number}</span> transitioned from <Badge variant="outline" className="bg-background">{sc.from}</Badge> ➔ <Badge className="bg-primary/25 text-primary">{sc.to}</Badge> ({sc.title})
+                        <div className="text-sm flex-1 flex items-center justify-between">
+                          <div>
+                            <span className="font-semibold text-foreground">EIP-{sc.number}</span> transitioned from <Badge variant="outline" className="bg-background">{sc.from}</Badge> ➔ <Badge className="bg-primary/25 text-primary">{sc.to}</Badge> ({sc.title})
+                            <span className="text-xs text-muted-foreground ml-2">({formatDate(sc.changedAt)})</span>
+                          </div>
+                          <a href={getProposalLink(sc)} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline font-semibold">[Check]</a>
                         </div>
-                      </label>
+                      </div>
                     );
                   })}
                 </div>
@@ -451,7 +485,7 @@ export default function WeeklyRecapPage() {
               ) : (
                 <div className="grid gap-2">
                   {data?.mergedPRs.map(pr => (
-                    <label key={pr.number} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors cursor-pointer">
+                    <div key={pr.number} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors">
                       <button 
                         type="button"
                         onClick={() => setSelectedPRs(prev => ({ ...prev, [pr.number]: !prev[pr.number] }))} 
@@ -459,10 +493,14 @@ export default function WeeklyRecapPage() {
                       >
                         {selectedPRs[pr.number] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
                       </button>
-                      <div className="text-sm">
-                        <span className="font-semibold text-foreground">PR #{pr.number}:</span> {pr.title} <span className="text-xs text-muted-foreground">by @{pr.author}</span>
+                      <div className="text-sm flex-1 flex items-center justify-between">
+                        <div>
+                          <span className="font-semibold text-foreground">PR #{pr.number}:</span> {pr.title} <span className="text-xs text-muted-foreground">by @{pr.author}</span>
+                          <span className="text-xs text-muted-foreground ml-2">({formatDate(pr.mergedAt)})</span>
+                        </div>
+                        <a href={getPRLink(pr)} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline font-semibold">[Check]</a>
                       </div>
-                    </label>
+                    </div>
                   ))}
                 </div>
               )}
@@ -485,7 +523,7 @@ export default function WeeklyRecapPage() {
                   {data?.recentCalls.map(c => {
                     const key = `${c.series}-${c.number}`;
                     return (
-                      <label key={key} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors cursor-pointer">
+                      <div key={key} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors">
                         <button 
                           type="button"
                           onClick={() => setSelectedCalls(prev => ({ ...prev, [key]: !prev[key] }))} 
@@ -493,11 +531,15 @@ export default function WeeklyRecapPage() {
                         >
                           {selectedCalls[key] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
                         </button>
-                        <div className="text-sm flex-1">
-                          <p className="font-semibold text-foreground">{c.displayName || `${c.series} #${c.number}`}</p>
-                          {c.tldr && <p className="text-xs text-muted-foreground mt-0.5">{String(c.tldr)}</p>}
+                        <div className="text-sm flex-1 flex items-start justify-between">
+                          <div className="flex-1">
+                            <p className="font-semibold text-foreground">{c.displayName || `${c.series} #${c.number}`}</p>
+                            {c.tldr && <p className="text-xs text-muted-foreground mt-0.5">{String(c.tldr)}</p>}
+                            <p className="text-[10px] text-muted-foreground mt-1">Happened: {formatDate(c.occurredOn)}</p>
+                          </div>
+                          <a href={getCallLink({ series: c.series, number: c.number || "" })} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline font-semibold ml-2">[Check]</a>
                         </div>
-                      </label>
+                      </div>
                     );
                   })}
                 </div>
@@ -523,7 +565,7 @@ export default function WeeklyRecapPage() {
               ) : (
                 <div className="grid gap-2">
                   {data?.devnets.map(d => (
-                    <label key={d.id} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors cursor-pointer">
+                    <div key={d.id} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors">
                       <button 
                         type="button"
                         onClick={() => setSelectedDevnets(prev => ({ ...prev, [d.id]: !prev[d.id] }))} 
@@ -531,10 +573,14 @@ export default function WeeklyRecapPage() {
                       >
                         {selectedDevnets[d.id] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
                       </button>
-                      <div className="text-sm">
-                        <span className="font-semibold text-foreground">{d.series.toUpperCase()} Devnet {d.number}:</span> {d.title} <Badge className={d.active ? "bg-emerald-500/20 text-emerald-400" : "bg-slate-500/20 text-slate-400"}>{d.active ? "Active" : "Closed"}</Badge>
+                      <div className="text-sm flex-1 flex items-center justify-between">
+                        <div>
+                          <span className="font-semibold text-foreground">{d.series.toUpperCase()} Devnet {d.number}:</span> {d.title} <Badge className={d.active ? "bg-emerald-500/20 text-emerald-400" : "bg-slate-500/20 text-slate-400"}>{d.active ? "Active" : "Closed"}</Badge>
+                          <span className="text-xs text-muted-foreground ml-2">({formatDate(d.scrapedAt)})</span>
+                        </div>
+                        <a href={getDevnetLink(d.id)} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline font-semibold">[Check]</a>
                       </div>
-                    </label>
+                    </div>
                   ))}
                 </div>
               )}
@@ -564,7 +610,10 @@ export default function WeeklyRecapPage() {
 
             {featuredDetails && (
               <div className="rounded-lg border border-emerald-900 bg-emerald-950/20 p-4 space-y-2">
-                <p className="text-xs font-bold text-emerald-400 uppercase tracking-wider">Featured EIP details loaded</p>
+                <div className="flex items-center justify-between">
+                  <p className="text-xs font-bold text-emerald-400 uppercase tracking-wider">Featured EIP details loaded</p>
+                  <a href={getProposalLink({ category: "EIP", number: featuredDetails.number })} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline font-semibold">[Check]</a>
+                </div>
                 <h4 className="text-sm font-bold text-white">EIP-{featuredDetails.number}: {featuredDetails.title}</h4>
                 {featuredDetails.summary ? (
                   <p className="text-xs text-slate-300 leading-relaxed mt-1">{featuredDetails.summary}</p>
@@ -589,7 +638,7 @@ export default function WeeklyRecapPage() {
               ) : (
                 <div className="grid gap-2">
                   {data?.lastCallEIPs.map(lc => (
-                    <label key={lc.number} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors cursor-pointer">
+                    <div key={lc.number} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors">
                       <button 
                         type="button"
                         onClick={() => setSelectedLastCalls(prev => ({ ...prev, [lc.number]: !prev[lc.number] }))} 
@@ -597,10 +646,13 @@ export default function WeeklyRecapPage() {
                       >
                         {selectedLastCalls[lc.number] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
                       </button>
-                      <div className="text-sm">
-                        <span className="font-semibold text-foreground">EIP-{lc.number}:</span> {lc.title} <span className="text-xs text-orange-400">(Deadline: {lc.deadline || "Immediate"})</span>
+                      <div className="text-sm flex-1 flex items-center justify-between">
+                        <div>
+                          <span className="font-semibold text-foreground">EIP-{lc.number}:</span> {lc.title} <span className="text-xs text-orange-400">(Deadline: {lc.deadline || "Immediate"})</span>
+                        </div>
+                        <a href={getProposalLink({ category: "EIP", number: lc.number })} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline font-semibold">[Check]</a>
                       </div>
-                    </label>
+                    </div>
                   ))}
                 </div>
               )}
@@ -616,7 +668,7 @@ export default function WeeklyRecapPage() {
                   {data?.upcomingCalls.map(c => {
                     const key = `${c.series}-${c.callNumber || c.issueNumber}`;
                     return (
-                      <label key={key} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors cursor-pointer">
+                      <div key={key} className="flex items-start gap-3 rounded-lg border border-border bg-muted/20 p-3 hover:bg-muted/40 transition-colors">
                         <button 
                           type="button"
                           onClick={() => setSelectedUpcoming(prev => ({ ...prev, [key]: !prev[key] }))} 
@@ -624,10 +676,15 @@ export default function WeeklyRecapPage() {
                         >
                           {selectedUpcoming[key] ? <CheckSquare className="h-4 w-4 text-primary" /> : <Square className="h-4 w-4" />}
                         </button>
-                        <div className="text-sm">
-                          <span className="font-semibold text-foreground">{c.title}</span> {c.occursOn ? `on ${c.occursOn}` : ""}
+                        <div className="text-sm flex-1 flex items-center justify-between">
+                          <div>
+                            <span className="font-semibold text-foreground">{c.title}</span> {c.occursOn ? `on ${c.occursOn}` : ""}
+                          </div>
+                          {c.issueUrl && (
+                            <a href={c.issueUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline font-semibold">[Agenda]</a>
+                          )}
                         </div>
-                      </label>
+                      </div>
                     );
                   })}
                 </div>

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -14,7 +14,6 @@ import {
   Settings,
   ChevronRight,
   Sparkles,
-  Crown,
   PanelLeft,
   PanelLeftOpen,
   Compass,
@@ -43,7 +42,6 @@ import {
   SidebarMenuSubButton,
   SidebarMenuSubItem,
   SidebarHeader,
-  SidebarFooter,
   useSidebar,
 } from "@/components/ui/sidebar";
 import {
@@ -1100,33 +1098,6 @@ function AppSidebarContent() {
           </SidebarGroup>
         ))}
       </SidebarContent>
-
-      {/* Footer */}
-      <SidebarFooter className="border-t border-border bg-card/50 p-3">
-        {membershipTier === "free" && (
-          state === "expanded" ? (
-            <Link href="/pricing">
-              <div className="flex items-center gap-2 rounded-lg border border-primary/30 bg-primary/10 p-3 transition hover:bg-primary/15">
-                <Sparkles className="h-4 w-4 text-primary dark:drop-shadow-[0_0_6px_rgb(var(--persona-accent-rgb)/0.6)]" />
-                <div className="flex-1">
-                  <p className="text-xs font-semibold text-foreground">Premium Coming Soon</p>
-                  <p className="text-[10px] text-muted-foreground">
-                    Early access for everyone
-                  </p>
-                </div>
-              </div>
-            </Link>
-          ) : (
-            <Link
-              href="/pricing"
-              className="flex items-center justify-center rounded-lg p-2 transition-colors hover:bg-muted"
-              title="Premium rolling out soon"
-            >
-              <Crown className="h-5 w-5 text-primary" />
-            </Link>
-          )
-        )}
-      </SidebarFooter>
     </Sidebar>
   );
 }

--- a/src/server/orpc/procedures/dashboard.ts
+++ b/src/server/orpc/procedures/dashboard.ts
@@ -498,4 +498,165 @@ export const dashboardProcedures = {
         throw err;
       }
     }),
+
+  getWeeklyRecap: os
+    .$context<Ctx>()
+    .input(z.object({}))
+    .handler(async ({ context }) => {
+      await checkAPIToken(context.headers);
+
+      const sevenDaysAgo = new Date();
+      sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+      const [newProposals, statusChanges, mergedPRs, devnets, recentCalls, upcomingCalls, lastCallEIPs] = await Promise.all([
+        prisma.eips.findMany({
+          where: {
+            created_at: { gte: sevenDaysAgo },
+          },
+          select: {
+            eip_number: true,
+            title: true,
+            created_at: true,
+            eip_snapshots: {
+              select: {
+                status: true,
+                category: true,
+              }
+            }
+          },
+          orderBy: { created_at: "desc" },
+        }),
+
+        prisma.$queryRawUnsafe<Array<{ eip_number: number; title: string; from_status: string; to_status: string; changed_at: Date; category: string | null }>>(
+          `SELECT e.eip_number, e.title, se.from_status, se.to_status, se.changed_at, s.category
+           FROM eip_status_events se
+           JOIN eips e ON se.eip_id = e.id
+           LEFT JOIN eip_snapshots s ON s.eip_id = e.id
+           WHERE se.changed_at >= $1
+           ORDER BY se.changed_at DESC`,
+          sevenDaysAgo
+        ),
+
+        prisma.pull_requests.findMany({
+          where: {
+            merged_at: { gte: sevenDaysAgo },
+          },
+          select: {
+            pr_number: true,
+            title: true,
+            author: true,
+            merged_at: true,
+          },
+          orderBy: { merged_at: "desc" },
+        }),
+
+        prisma.devnet_specs.findMany({
+          orderBy: [{ series: "asc" }, { devnet_number: "desc" }],
+          take: 6,
+          select: {
+            id: true,
+            series: true,
+            devnet_number: true,
+            title: true,
+            active: true,
+            genesis_time: true,
+            scraped_at: true,
+          }
+        }),
+
+        prisma.protocol_calls.findMany({
+          orderBy: { occurred_on: "desc" },
+          take: 3,
+          select: {
+            series: true,
+            call_number: true,
+            occurred_on: true,
+            display_name: true,
+            tldr: true,
+            key_decisions: true,
+          }
+        }),
+
+        prisma.protocol_calls_upcoming.findMany({
+          where: {
+            OR: [
+              { occurs_on: null },
+              { occurs_on: { gte: new Date() } },
+            ]
+          },
+          orderBy: [{ occurs_on: "asc" }, { occurs_at: "asc" }],
+          take: 5,
+        }),
+
+        prisma.eip_snapshots.findMany({
+          where: {
+            status: "Last Call",
+          },
+          select: {
+            deadline: true,
+            eips: {
+              select: {
+                eip_number: true,
+                title: true,
+              }
+            }
+          },
+          orderBy: { deadline: "asc" },
+        }),
+      ]);
+
+      return {
+        newProposals: newProposals.map(p => ({
+          number: p.eip_number,
+          title: p.title || "",
+          category: p.eip_snapshots?.category || null,
+          status: p.eip_snapshots?.status || "Draft",
+          createdAt: p.created_at?.toISOString() || null,
+        })),
+        statusChanges: statusChanges.map(sc => ({
+          number: sc.eip_number,
+          title: sc.title || "",
+          from: sc.from_status,
+          to: sc.to_status,
+          changedAt: sc.changed_at.toISOString(),
+          category: sc.category,
+        })),
+        mergedPRs: mergedPRs.map(pr => ({
+          number: pr.pr_number,
+          title: pr.title || "",
+          author: pr.author || "",
+          mergedAt: pr.merged_at ? pr.merged_at.toISOString() : null,
+        })),
+        devnets: devnets.map(d => ({
+          id: d.id,
+          series: d.series,
+          number: d.devnet_number,
+          title: d.title || "",
+          active: d.active,
+          genesisTime: d.genesis_time ? Number(d.genesis_time) : null,
+          scrapedAt: d.scraped_at ? d.scraped_at.toISOString() : null,
+        })),
+        recentCalls: recentCalls.map(c => ({
+          series: c.series,
+          number: c.call_number,
+          occurredOn: c.occurred_on.toISOString().slice(0, 10),
+          displayName: c.display_name,
+          tldr: c.tldr || null,
+          keyDecisions: c.key_decisions || null,
+        })),
+        upcomingCalls: upcomingCalls.map(c => ({
+          series: c.series,
+          title: c.title || "",
+          occursOn: c.occurs_on ? c.occurs_on.toISOString().slice(0, 10) : null,
+          callNumber: c.call_number,
+          issueNumber: c.issue_number,
+          issueUrl: c.issue_url,
+        })),
+        lastCallEIPs: lastCallEIPs.map(lc => ({
+          number: lc.eips?.eip_number || 0,
+          title: lc.eips?.title || "",
+          deadline: lc.deadline ? lc.deadline.toISOString().slice(0, 10) : null,
+        })),
+      };
+    }),
 }

--- a/src/server/orpc/procedures/dashboard.ts
+++ b/src/server/orpc/procedures/dashboard.ts
@@ -546,6 +546,11 @@ export const dashboardProcedures = {
             title: true,
             author: true,
             merged_at: true,
+            repositories: {
+              select: {
+                name: true,
+              }
+            }
           },
           orderBy: { merged_at: "desc" },
         }),
@@ -626,6 +631,7 @@ export const dashboardProcedures = {
           title: pr.title || "",
           author: pr.author || "",
           mergedAt: pr.merged_at ? pr.merged_at.toISOString() : null,
+          repoName: pr.repositories?.name || "",
         })),
         devnets: devnets.map(d => ({
           id: d.id,


### PR DESCRIPTION
This pull request introduces a new "Weekly Recap" feature to the admin dashboard and refactors the sidebar component to simplify the UI. The main highlights are the addition of a backend API endpoint to aggregate weekly activity data and corresponding frontend navigation, as well as cleanup of sidebar code related to premium features.

**New Weekly Recap Feature:**

* Added a new `getWeeklyRecap` procedure to `dashboardProcedures` in `dashboard.ts`, which aggregates recent proposals, status changes, merged PRs, devnets, protocol calls, and EIPs in Last Call for the past week. This provides a single API endpoint for generating a weekly summary.
* Added a "Weekly Recap" link to the admin dashboard navigation in `admin/page.tsx`, making the new feature accessible from the UI.

**Sidebar Refactoring and Cleanup:**

* Removed the premium upsell footer and related logic from the sidebar in `app-sidebar.tsx`, streamlining the sidebar for all users.
* Removed unused imports (`Crown`, `SidebarFooter`) from `app-sidebar.tsx` to reflect the sidebar cleanup. [[1]](diffhunk://#diff-167140c3830943094d6b84a9cdb9155e4c4762762d1d8245330b48be404758a6L17) [[2]](diffhunk://#diff-167140c3830943094d6b84a9cdb9155e4c4762762d1d8245330b48be404758a6L46)