### PR TITLE
Refactor navigation, charts, and upgrade page for consistency and usability

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -56,6 +56,11 @@ const nextConfig: NextConfig = {
         permanent: false,
       },
       {
+        source: '/upgrade-hub',
+        destination: '/upgrade',
+        permanent: false,
+      },
+      {
         source: '/upgrades',
         destination: '/upgrade',
         permanent: false,

--- a/src/app/(public)/_components/WeeklyRecapSection.tsx
+++ b/src/app/(public)/_components/WeeklyRecapSection.tsx
@@ -296,7 +296,7 @@ export function WeeklyRecapSection({ sectionTitleClass, sectionSubtitleClass }: 
   const totalCalls = (data?.recentCalls.length ?? 0) + (data?.devnets.length ?? 0);
 
   return (
-    <section className="mb-8 w-full" id="weekly-recap-digest">
+    <section className="mb-8 w-full" id="weekly-recap">
       {/* Section Header */}
       <div className="mb-4 flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
@@ -312,7 +312,7 @@ export function WeeklyRecapSection({ sectionTitleClass, sectionSubtitleClass }: 
               Weekly Standards Recap & Audit Feed
               <ArrowUpRight className="h-4 w-4 shrink-0 text-muted-foreground/40 transition-all group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:text-primary" />
             </Link>
-            <CopyLinkButton sectionId="weekly-recap-digest" tooltipLabel="Copy link" />
+            <CopyLinkButton sectionId="weekly-recap" tooltipLabel="Copy link" />
           </div>
           <p className={sectionSubtitleClass || 'mt-1 text-sm text-muted-foreground'}>
             Verifiable, real-time audit feed of new EIP proposals, status transitions, merged PRs, editor reviews, devnets, and ACD call decisions.

--- a/src/app/(public)/_components/persona-home/DeveloperUpgradeWatchSection.tsx
+++ b/src/app/(public)/_components/persona-home/DeveloperUpgradeWatchSection.tsx
@@ -8,6 +8,7 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { CopyLinkButton } from '@/components/header';
 import { ChartFooter } from '@/components/chart-footer';
+import { ChartWatermark } from '@/components/chart-watermark';
 import { UpgradeTimelineChart } from '@/components/upgrade/upgrade-timeline-chart';
 
 type UpgradeOption = {
@@ -152,12 +153,14 @@ export default function DeveloperUpgradeWatchSection({
             No timeline data available for this upgrade.
           </div>
         ) : chartView === 'composition' ? (
-          <div>
+          <div className="relative">
             <UpgradeTimelineChart data={upgradeTimelineRows} upgradeName={upgradeName} />
+            <ChartWatermark position="center" />
           </div>
         ) : (
-          <div>
+          <div className="relative">
             <ReactECharts option={upgradeWatchChartOption as object} style={{ height: '220px', width: '100%' }} opts={{ renderer: 'svg' }} />
+            <ChartWatermark position="center" />
           </div>
         )}
         {chartView === 'compact' && (

--- a/src/app/(public)/_components/persona-home/DeveloperUpgradeWatchSection.tsx
+++ b/src/app/(public)/_components/persona-home/DeveloperUpgradeWatchSection.tsx
@@ -7,7 +7,7 @@ import { ArrowUpRight, Download, Package } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { CopyLinkButton } from '@/components/header';
-import { ChartWatermark } from '@/components/chart-watermark';
+import { ChartFooter } from '@/components/chart-footer';
 import { UpgradeTimelineChart } from '@/components/upgrade/upgrade-timeline-chart';
 
 type UpgradeOption = {
@@ -152,14 +152,12 @@ export default function DeveloperUpgradeWatchSection({
             No timeline data available for this upgrade.
           </div>
         ) : chartView === 'composition' ? (
-          <div className="relative">
+          <div>
             <UpgradeTimelineChart data={upgradeTimelineRows} upgradeName={upgradeName} />
-            <ChartWatermark position="one-third" />
           </div>
         ) : (
-          <div className="relative">
+          <div>
             <ReactECharts option={upgradeWatchChartOption as object} style={{ height: '220px', width: '100%' }} opts={{ renderer: 'svg' }} />
-            <ChartWatermark position="one-third" />
           </div>
         )}
         {chartView === 'compact' && (
@@ -177,6 +175,7 @@ export default function DeveloperUpgradeWatchSection({
           ))}
         </div>
         )}
+        <ChartFooter />
         {showTable && (
           <div className="mt-3 overflow-x-auto rounded-lg border border-border/70">
             <table className="min-w-full text-xs">

--- a/src/app/(public)/_components/persona-home/DeveloperUpgradeWatchSection.tsx
+++ b/src/app/(public)/_components/persona-home/DeveloperUpgradeWatchSection.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import ReactECharts from 'echarts-for-react';
 import { ArrowUpRight, Download, Package } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
 import { CopyLinkButton } from '@/components/header';
 import { ChartWatermark } from '@/components/chart-watermark';
 import { UpgradeTimelineChart } from '@/components/upgrade/upgrade-timeline-chart';
@@ -90,6 +91,11 @@ export default function DeveloperUpgradeWatchSection({
           <p className={sectionSubtitleClass}>EIP composition timeline by upgrade — proposed through included.</p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          <Link href="/upgrade/eips">
+            <Button variant="outline" size="sm" className="h-8 border-border bg-card/60 hover:bg-muted text-xs gap-1">
+              EIP Upgrade Directory <ArrowUpRight className="h-3.5 w-3.5 text-primary" />
+            </Button>
+          </Link>
           {/* View toggle: compact bar vs the full hub composition chart. */}
           <div className="inline-flex rounded-md border border-border bg-muted/40 p-0.5">
             {(['compact', 'composition'] as const).map((view) => (

--- a/src/app/(public)/_components/persona-home/DeveloperUpgradeWatchSection.tsx
+++ b/src/app/(public)/_components/persona-home/DeveloperUpgradeWatchSection.tsx
@@ -81,7 +81,7 @@ export default function DeveloperUpgradeWatchSection({
       <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
         <div>
           <div className="inline-flex items-center gap-2">
-            <Package className="h-5 w-5 text-sky-400 shrink-0" />
+            <Package className="h-5 w-5 text-primary shrink-0" />
             {/* Title links straight to the hub. */}
             <Link href="/upgrade" className={cn(sectionTitleClass, 'group inline-flex items-center gap-1 transition-colors hover:text-primary')}>
               Upgrade Hub

--- a/src/app/(public)/_components/persona-home/DeveloperUpgradeWatchSection.tsx
+++ b/src/app/(public)/_components/persona-home/DeveloperUpgradeWatchSection.tsx
@@ -76,7 +76,7 @@ export default function DeveloperUpgradeWatchSection({
   };
 
   return (
-    <section className="mb-6 border-t border-border/70 pt-6" id="developer-upgrade-watch">
+    <section className="mb-6 border-t border-border/70 pt-6" id="upgrade-watch">
       <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
         <div>
           <div className="inline-flex items-center gap-2">
@@ -86,7 +86,7 @@ export default function DeveloperUpgradeWatchSection({
               Upgrade Hub
               <ArrowUpRight className="h-4 w-4 text-muted-foreground/50 transition-all group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:text-primary" />
             </Link>
-            <CopyLinkButton sectionId="developer-upgrade-watch" className="h-8 w-8 rounded-md" />
+            <CopyLinkButton sectionId="upgrade-watch" className="h-8 w-8 rounded-md" />
           </div>
           <p className={sectionSubtitleClass}>EIP composition timeline by upgrade — proposed through included.</p>
         </div>
@@ -154,12 +154,12 @@ export default function DeveloperUpgradeWatchSection({
         ) : chartView === 'composition' ? (
           <div className="relative">
             <UpgradeTimelineChart data={upgradeTimelineRows} upgradeName={upgradeName} />
-            <ChartWatermark />
+            <ChartWatermark position="one-third" />
           </div>
         ) : (
           <div className="relative">
             <ReactECharts option={upgradeWatchChartOption as object} style={{ height: '220px', width: '100%' }} opts={{ renderer: 'svg' }} />
-            <ChartWatermark />
+            <ChartWatermark position="one-third" />
           </div>
         )}
         {chartView === 'compact' && (

--- a/src/app/(public)/_components/persona-home/DeveloperUpgradeWatchSection.tsx
+++ b/src/app/(public)/_components/persona-home/DeveloperUpgradeWatchSection.tsx
@@ -147,9 +147,9 @@ export default function DeveloperUpgradeWatchSection({
 
       <div className="rounded-xl border border-border bg-card/60 p-3">
         {upgradeTimelineLoading ? (
-          <div className="h-[220px] animate-pulse rounded-lg bg-muted" />
+          <div className="h-[280px] animate-pulse rounded-lg bg-muted" />
         ) : !upgradeWatchChartOption ? (
-          <div className="flex h-[220px] items-center justify-center rounded-lg border border-border/70 bg-muted/30 text-sm text-muted-foreground">
+          <div className="flex h-[280px] items-center justify-center rounded-lg border border-border/70 bg-muted/30 text-sm text-muted-foreground">
             No timeline data available for this upgrade.
           </div>
         ) : chartView === 'composition' ? (
@@ -159,7 +159,7 @@ export default function DeveloperUpgradeWatchSection({
           </div>
         ) : (
           <div className="relative">
-            <ReactECharts option={upgradeWatchChartOption as object} style={{ height: '220px', width: '100%' }} opts={{ renderer: 'svg' }} />
+            <ReactECharts option={upgradeWatchChartOption as object} style={{ height: '280px', width: '100%' }} opts={{ renderer: 'svg' }} />
             <ChartWatermark position="center" />
           </div>
         )}

--- a/src/app/(public)/_components/persona-home/EditorCategoryBreakdownSection.tsx
+++ b/src/app/(public)/_components/persona-home/EditorCategoryBreakdownSection.tsx
@@ -6,6 +6,8 @@ import ReactECharts from 'echarts-for-react';
 import { ArrowRight, CircleHelp, Layers } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { CopyLinkButton } from '@/components/header';
+import { ChartFooter } from '@/components/chart-footer';
+import { ChartWatermark } from '@/components/chart-watermark';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 type EditorRepoFilter = '' | 'eips' | 'ercs' | 'rips';
@@ -52,13 +54,13 @@ export default function EditorCategoryBreakdownSection({
     'Awaited means the PR is in Draft state.';
 
   return (
-    <section className="mb-6 border-t border-border/70 pt-6" id="editor-category-breakdown">
+    <section className="mb-6 border-t border-border/70 pt-6" id="categories">
       <div className="mb-3 flex flex-wrap items-start justify-between gap-2">
         <div>
           <div className="inline-flex items-center gap-2">
             <Layers className="h-5 w-5 text-violet-400 shrink-0" />
             <h2 className={sectionTitleClass}>Category Breakdown</h2>
-            <CopyLinkButton sectionId="editor-category-breakdown" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
+            <CopyLinkButton sectionId="categories" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
           </div>
           <p className={sectionSubtitleClass}>Participants × process stacked distribution for open PRs.</p>
           <p className="mt-1 text-[11px] text-muted-foreground">Month context: {monthLabelText}</p>
@@ -131,11 +133,14 @@ export default function EditorCategoryBreakdownSection({
         ) : !categoryBreakdownChartOption ? (
           <p className="py-8 text-center text-sm text-muted-foreground">No category data available.</p>
         ) : (
-          <ReactECharts
-            option={categoryBreakdownChartOption as object}
-            style={{ height: '300px', width: '100%' }}
-            opts={{ renderer: 'svg' }}
-          />
+          <div className="relative">
+            <ReactECharts
+              option={categoryBreakdownChartOption as object}
+              style={{ height: '300px', width: '100%' }}
+              opts={{ renderer: 'svg' }}
+            />
+            <ChartWatermark position="center" />
+          </div>
         )}
         <div className="mt-3 flex items-center justify-between gap-2 border-t border-border/70 pt-2 text-xs text-muted-foreground">
           <span>
@@ -161,6 +166,7 @@ export default function EditorCategoryBreakdownSection({
             </button>
           </div>
         </div>
+        <ChartFooter />
       </div>
     </section>
   );

--- a/src/app/(public)/_components/persona-home/EditorReviewQueueSection.tsx
+++ b/src/app/(public)/_components/persona-home/EditorReviewQueueSection.tsx
@@ -130,13 +130,13 @@ export default function EditorReviewQueueSection({
   }, [downloadingReport, editorRepoFilter, selectedBoardProcesses]);
 
   return (
-    <section className="mb-6 border-t border-border/70 pt-6" id="editor-review-queue">
+    <section className="mb-6 border-t border-border/70 pt-6" id="review-queue">
       <div className="mb-4 flex items-start justify-between gap-3">
         <div>
           <div className="inline-flex items-center gap-2">
             <GitPullRequest className="h-5 w-5 text-rose-400 shrink-0" />
             <h2 className={sectionTitleClass}>Editor Review Queue</h2>
-            <CopyLinkButton sectionId="editor-review-queue" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
+            <CopyLinkButton sectionId="review-queue" tooltipLabel="Copy link" className="h-8 w-8 rounded-md" />
           </div>
           <p className={sectionSubtitleClass}>
             Open PRs currently waiting on editor action in the{' '}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -3891,7 +3891,7 @@ export default function EIPsHomePage() {
       >
       {activePersona !== 'editor' && visibleSections.governance && <hr className="my-6 border-border" />}
 
-      <section className="mb-6 w-full" id="recent-governance-activity">
+      <section className="mb-6 w-full" id="weekly-recap-digest">
         <WeeklyRecapSection sectionTitleClass={sectionTitleClass} sectionSubtitleClass={sectionSubtitleClass} />
       </section>
 

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -2096,14 +2096,14 @@ export default function EIPsHomePage() {
         axisPointer: {
           type: 'line',
           lineStyle: {
-            color: isDark ? 'rgba(56, 189, 248, 0.6)' : 'rgba(2, 132, 199, 0.6)',
-            type: 'dotted',
+            color: isDark ? 'rgba(148, 163, 184, 0.4)' : 'rgba(100, 116, 139, 0.4)',
+            type: 'dashed',
             width: 1.5,
           },
         },
-        backgroundColor: isDark ? 'rgba(15, 23, 42, 0.94)' : 'rgba(255, 255, 255, 0.96)',
-        borderColor: isDark ? 'rgba(56, 189, 248, 0.45)' : 'rgba(2, 132, 199, 0.45)',
-        borderWidth: 1.5,
+        backgroundColor: isDark ? 'rgba(15, 23, 42, 0.95)' : 'rgba(255, 255, 255, 0.98)',
+        borderColor: isDark ? 'rgba(148, 163, 184, 0.3)' : 'rgba(148, 163, 184, 0.4)',
+        borderWidth: 1,
         padding: [10, 14],
         textStyle: { color: isDark ? '#f8fafc' : '#0f172a', fontSize: 12 },
         extraCssText:
@@ -2120,7 +2120,7 @@ export default function EIPsHomePage() {
             total += val;
             html += `<div style="display:flex;align-items:center;justify-content:space-between;gap:16px;font-size:11px;margin-top:4px"><span style="display:inline-flex;align-items:center;gap:6px"><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background-color:${item.color}"></span><span style="color:${isDark ? '#cbd5e1' : '#475569'}">${item.seriesName}</span></span><span style="font-weight:700;color:${isDark ? '#f8fafc' : '#0f172a'}">${val}</span></div>`;
           }
-          html += `<div style="margin-top:8px;padding-top:6px;border-top:1px dashed ${isDark ? 'rgba(148,163,184,0.25)' : 'rgba(148,163,184,0.35)'};display:flex;align-items:center;justify-content:space-between;font-size:11px"><span style="color:${isDark ? '#94a3b8' : '#64748b'};font-weight:600">Total EIPs</span><span style="font-weight:800;color:${isDark ? '#38bdf8' : '#0284c7'}">${total}</span></div>`;
+          html += `<div style="margin-top:8px;padding-top:6px;border-top:1px dashed ${isDark ? 'rgba(148,163,184,0.25)' : 'rgba(148,163,184,0.35)'};display:flex;align-items:center;justify-content:space-between;font-size:11px"><span style="color:${isDark ? '#94a3b8' : '#64748b'};font-weight:600">Total EIPs</span><span style="font-weight:800;color:${isDark ? '#f8fafc' : '#0f172a'}">${total}</span></div>`;
           return html;
         },
       },

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -413,7 +413,7 @@ const PERSONA_HOME_PLANS: Record<HomePersona, {
     tools: [
       { key: 'upgrade-hub', title: 'Upgrade Hub', href: '/upgrade', cta: 'Open the hub', icon: Network, blurb: 'Upgrade timelines, headliner EIPs, and what ships next.', image: '/quick-access/upgrade-hub.png' },
       { key: 'calls-decisions', title: 'Protocol Calls & Decisions', href: '/decisions', cta: 'See the decisions', icon: Gavel, blurb: 'Key outcomes from All Core Devs and breakout calls.', image: '/quick-access/calls-decisions.png' },
-      { key: 'editor-insights', title: 'Editor Insights', href: '/analytics/editors', cta: 'View insights', icon: Trophy, blurb: 'Editorial workload, coverage, and the leaderboard.', image: '/quick-access/editor-insights.png' },
+      { key: 'editor-insights', title: 'Editor Leadership Board', href: '/analytics/editors', cta: 'View leadership board', icon: Trophy, blurb: 'Editorial workload, coverage, and the leadership board.', image: '/quick-access/editor-insights.png' },
       { key: 'eip-analytics', title: 'EIP Analytics', href: '/analytics/eips', cta: 'Explore analytics', icon: FileText, blurb: 'Proposal activity and lifecycle, Draft to Final.', image: '/quick-access/eip-analytics.png' },
       { key: 'pr-board', title: 'Open PR Board', href: '/board', cta: 'Open the board', icon: GitPullRequest, blurb: "Open PRs, sorted by what's waiting on editors.", image: '/quick-access/pr-board.png' },
       { key: 'monthly-insights', title: 'Monthly Insights', href: '/insights', cta: 'Read the recap', icon: ArrowUpDown, blurb: 'A month-by-month standards & governance recap.', image: '/quick-access/monthly-insights.png' },
@@ -2358,7 +2358,7 @@ export default function EIPsHomePage() {
             <div>
               <div className="inline-flex items-center gap-2">
                 <Trophy className="h-5 w-5 text-amber-400 shrink-0" />
-                <SectionTitleLink href="/analytics/editors" className={sectionTitleClass}>Editors - {editorContributionWindowLabel}</SectionTitleLink>
+                <SectionTitleLink href="/analytics/editors" className={sectionTitleClass}>Editor Leadership Board - {editorContributionWindowLabel}</SectionTitleLink>
                 <CopyLinkButton sectionId="editor-contributions-overview" tooltipLabel="Copy link" />
               </div>
               <p className={sectionSubtitleClass}>
@@ -3613,7 +3613,7 @@ export default function EIPsHomePage() {
           <div>
             <div className="inline-flex items-center gap-2">
               <Trophy className="h-5 w-5 text-amber-400 shrink-0" />
-              <SectionTitleLink href="/insights" className={sectionTitleClass}>Monthly Insight & Editor Leaderboard</SectionTitleLink>
+              <SectionTitleLink href="/insights" className={sectionTitleClass}>Monthly Insight & Editor Leadership Board</SectionTitleLink>
               <CopyLinkButton sectionId="editor-monthly-insight" tooltipLabel="Copy link" />
             </div>
             <p className={sectionSubtitleClass}>Monthly status distribution and editor activity snapshot.</p>

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -66,6 +66,7 @@ import { cn } from '@/lib/utils';
 import { ASSOCIATE_EIP_EDITORS, CANONICAL_EIP_EDITORS } from '@/data/eip-contributor-roles';
 import { getUpgradeTimelineData } from '@/data/upgrade-timelines';
 import { useEffectivePersona, useIsHydrated } from '@/stores/personaStore';
+import { chartTooltip, chartTooltipRow, chartTooltipTitle, CHART_TOOLTIP_BORDER } from '@/lib/chart-theme';
 
 type Dimension = 'status' | 'category' | 'repo' | 'stages';
 type SortBy = 'github' | 'eip' | 'title' | 'author' | 'type' | 'category' | 'status' | 'updated_at';
@@ -845,7 +846,9 @@ export default function EIPsHomePage() {
   const [downloadingLeaderboard, setDownloadingLeaderboard] = useState(false);
   const [monthlyDeltaUpdatedAt, setMonthlyDeltaUpdatedAt] = useState<string | null>(null);
   const [monthlyLeaderboardUpdatedAt, setMonthlyLeaderboardUpdatedAt] = useState<string | null>(null);
-  const [showProposalTable, setShowProposalTable] = useState(true);
+  // RIPs are a separate track — opt-in so status/category counts are not skewed.
+  const [includeRips, setIncludeRips] = useState(false);
+  const [showProposalTable, setShowProposalTable] = useState(false);
   const [showPersonaWorkspace, setShowPersonaWorkspace] = useState(true);
   const [editorRepoFilter, setEditorRepoFilter] = useState<EditorRepoFilter>('');
   const [developerRepoFilter, setDeveloperRepoFilter] = useState<DeveloperRepoFilter>('');
@@ -902,8 +905,11 @@ export default function EIPsHomePage() {
     setPage(1);
   }, [dimension, activeBucket, sortBy, sortDir, columnSearch]);
 
+  // Collapse the proposal table whenever the persona changes. It stays hidden for
+  // every persona now (not just editor) — the distribution cards are the scannable
+  // summary, and the table is opt-in via "Show table".
   useEffect(() => {
-    setShowProposalTable(activePersona !== 'editor');
+    setShowProposalTable(false);
   }, [activePersona]);
 
   useEffect(() => {
@@ -1151,7 +1157,7 @@ export default function EIPsHomePage() {
       (async () => {
         setDistributionLoading(true);
         try {
-          const distRes = await client.standards.getUnifiedDistribution({ dimension: dimension as 'status' | 'category' | 'repo' });
+          const distRes = await client.standards.getUnifiedDistribution({ dimension: dimension as 'status' | 'category' | 'repo', includeRips });
           if (!cancelled) setDistribution(distRes);
         } catch (err) {
           console.error('Failed to load homepage distribution:', err);
@@ -1163,7 +1169,7 @@ export default function EIPsHomePage() {
     return () => {
       cancelled = true;
     };
-  }, [dimension]);
+  }, [dimension, includeRips]);
 
   // Fetch status sub-distribution when category/repo bucket is selected
   useEffect(() => {
@@ -1272,6 +1278,7 @@ export default function EIPsHomePage() {
             sortDir,
             dimension: dimension as 'status' | 'category' | 'repo',
             bucket: activeBucket ?? undefined,
+            includeRips,
             columnSearch: {
               github: debouncedColumnSearch.github || undefined,
               eip: debouncedColumnSearch.eip || undefined,
@@ -1296,7 +1303,7 @@ export default function EIPsHomePage() {
     return () => {
       cancelled = true;
     };
-  }, [dimension, page, sortBy, sortDir, activeBucket, debouncedColumnSearch]);
+  }, [dimension, page, sortBy, sortDir, activeBucket, debouncedColumnSearch, includeRips]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1450,14 +1457,11 @@ export default function EIPsHomePage() {
     [febInsightPieData]
   );
   const febInsightDonutOption = useMemo(() => ({
-    tooltip: {
+    tooltip: chartTooltip({
       trigger: 'item',
       formatter: (params: { name: string; value: number; percent: number }) =>
         `${params.name}<br/>${params.value} (${params.percent}%)`,
-      backgroundColor: isDark ? 'rgba(15,23,42,0.92)' : 'rgba(255,255,255,0.98)',
-      borderColor: isDark ? 'rgba(148,163,184,0.2)' : 'rgba(148,163,184,0.35)',
-      textStyle: { color: isDark ? '#e2e8f0' : '#0f172a', fontSize: 12 },
-    },
+    }),
     legend: {
       show: true,
       orient: 'vertical',
@@ -1564,12 +1568,9 @@ export default function EIPsHomePage() {
     });
 
     return {
-      tooltip: {
+      tooltip: chartTooltip({
         trigger: 'axis',
         axisPointer: { type: 'shadow' },
-        backgroundColor: isDark ? 'rgba(15,23,42,0.94)' : 'rgba(255,255,255,0.98)',
-        borderColor: isDark ? 'rgba(148,163,184,0.25)' : 'rgba(148,163,184,0.35)',
-        textStyle: { color: isDark ? '#e2e8f0' : '#0f172a', fontSize: 12 },
         formatter: (params: Array<{ seriesName: string; value: number; marker: string; axisValue: string }>) => {
           if (!params?.length) return '';
           const actor = params[0]?.axisValue ?? '';
@@ -1588,7 +1589,7 @@ export default function EIPsHomePage() {
           `;
           return [header, ...lines, `<strong>Total: ${total.toLocaleString()}</strong>`].join('<br/>');
         },
-      },
+      }),
       legend: {
         top: 0,
         textStyle: { color: isDark ? '#cbd5e1' : '#475569', fontSize: 11 },
@@ -1713,6 +1714,7 @@ export default function EIPsHomePage() {
       const res = await client.standards.exportUnifiedDetailedCSV({
         dimension: csvDimension,
         bucket: activeBucket ?? undefined,
+        includeRips,
         search: undefined,
         columnSearch: {
           github: columnSearch.github || undefined,
@@ -2031,10 +2033,36 @@ export default function EIPsHomePage() {
       backgroundColor: 'transparent',
       tooltip: {
         trigger: 'axis',
-        axisPointer: { type: 'shadow' },
-        backgroundColor: isDark ? '#020617' : '#ffffff',
-        borderColor: isDark ? '#1f2937' : '#e2e8f0',
-        textStyle: { color: isDark ? '#e5e7eb' : '#0f172a' },
+        axisPointer: {
+          type: 'line',
+          lineStyle: {
+            color: isDark ? 'rgba(148, 163, 184, 0.4)' : 'rgba(100, 116, 139, 0.4)',
+            type: 'dashed',
+            width: 1.5,
+          },
+        },
+        backgroundColor: isDark ? 'rgba(15, 23, 42, 0.95)' : 'rgba(255, 255, 255, 0.98)',
+        borderColor: isDark ? 'rgba(148, 163, 184, 0.3)' : 'rgba(148, 163, 184, 0.4)',
+        borderWidth: 1,
+        padding: [10, 14],
+        textStyle: { color: isDark ? '#f8fafc' : '#0f172a', fontSize: 12 },
+        extraCssText:
+          'border-style: dotted !important; box-shadow: 0 12px 32px rgba(0,0,0,0.35); border-radius: 12px; backdrop-filter: blur(16px); min-width: 170px;',
+        formatter: (params: unknown) => {
+          const items = Array.isArray(params) ? (params as any[]) : [];
+          if (!items.length) return '';
+          const name = items[0].axisValue;
+          let html = `<div style="font-weight:700;font-size:12px;margin-bottom:6px;color:${isDark ? '#f8fafc' : '#0f172a'}">${name}</div>`;
+          let total = 0;
+          for (const item of items) {
+            const val = item.value || 0;
+            if (val === 0) continue;
+            total += val;
+            html += `<div style="display:flex;align-items:center;justify-content:space-between;gap:16px;font-size:11px;margin-top:4px"><span style="display:inline-flex;align-items:center;gap:6px"><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background-color:${item.color}"></span><span style="color:${isDark ? '#cbd5e1' : '#475569'}">${item.seriesName}</span></span><span style="font-weight:700;color:${isDark ? '#f8fafc' : '#0f172a'}">${val}</span></div>`;
+          }
+          html += `<div style="margin-top:8px;padding-top:6px;border-top:1px dashed ${isDark ? 'rgba(148,163,184,0.25)' : 'rgba(148,163,184,0.35)'};display:flex;align-items:center;justify-content:space-between;font-size:11px"><span style="color:${isDark ? '#94a3b8' : '#64748b'};font-weight:600">Total PRs</span><span style="font-weight:800;color:${isDark ? '#f8fafc' : '#0f172a'}">${total}</span></div>`;
+          return html;
+        },
       },
       legend: {
         top: 0,
@@ -2091,39 +2119,31 @@ export default function EIPsHomePage() {
 
     return {
       grid: { left: 16, right: 16, top: 32, bottom: 44, containLabel: true },
-      tooltip: {
+      tooltip: chartTooltip({
         trigger: 'axis',
         axisPointer: {
           type: 'line',
-          lineStyle: {
-            color: isDark ? 'rgba(148, 163, 184, 0.4)' : 'rgba(100, 116, 139, 0.4)',
-            type: 'dashed',
-            width: 1.5,
-          },
+          lineStyle: { color: 'var(--border)', type: 'dashed', width: 1.5 },
         },
-        backgroundColor: isDark ? 'rgba(15, 23, 42, 0.95)' : 'rgba(255, 255, 255, 0.98)',
-        borderColor: isDark ? 'rgba(148, 163, 184, 0.3)' : 'rgba(148, 163, 184, 0.4)',
-        borderWidth: 1,
-        padding: [10, 14],
-        textStyle: { color: isDark ? '#f8fafc' : '#0f172a', fontSize: 12 },
-        extraCssText:
-          'border-style: dotted !important; box-shadow: 0 12px 32px rgba(0,0,0,0.35); border-radius: 12px; backdrop-filter: blur(16px); min-width: 170px;',
         formatter: (params: unknown) => {
           const items = Array.isArray(params) ? (params as any[]) : [];
           if (!items.length) return '';
-          const date = items[0].axisValue;
-          let html = `<div style="font-weight:700;font-size:12px;margin-bottom:6px;color:${isDark ? '#f8fafc' : '#0f172a'}">${date}</div>`;
+
+          let html = chartTooltipTitle(items[0].axisValue);
           let total = 0;
           for (const item of items) {
             const val = item.value || 0;
             if (val === 0) continue;
             total += val;
-            html += `<div style="display:flex;align-items:center;justify-content:space-between;gap:16px;font-size:11px;margin-top:4px"><span style="display:inline-flex;align-items:center;gap:6px"><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background-color:${item.color}"></span><span style="color:${isDark ? '#cbd5e1' : '#475569'}">${item.seriesName}</span></span><span style="font-weight:700;color:${isDark ? '#f8fafc' : '#0f172a'}">${val}</span></div>`;
+            html += chartTooltipRow(item.seriesName, val, item.color);
           }
-          html += `<div style="margin-top:8px;padding-top:6px;border-top:1px dashed ${isDark ? 'rgba(148,163,184,0.25)' : 'rgba(148,163,184,0.35)'};display:flex;align-items:center;justify-content:space-between;font-size:11px"><span style="color:${isDark ? '#94a3b8' : '#64748b'};font-weight:600">Total EIPs</span><span style="font-weight:800;color:${isDark ? '#f8fafc' : '#0f172a'}">${total}</span></div>`;
+          html +=
+            `<div style="margin-top:8px;padding-top:6px;border-top:1px solid ${CHART_TOOLTIP_BORDER}">` +
+            chartTooltipRow('Total EIPs', total) +
+            `</div>`;
           return html;
         },
-      },
+      }, { minWidth: 172 }),
       legend: {
         top: 0,
         right: 0,
@@ -3000,6 +3020,32 @@ export default function EIPsHomePage() {
             </div>
           </div>
           <div className="flex items-center gap-2">
+            {/* Repo view is the EIPs/ERCs/RIPs split itself, so the toggle is
+                meaningless there — hidden rather than shown as a no-op. */}
+            {dimension !== 'repo' && (
+              <label
+                className={cn(
+                  'inline-flex cursor-pointer select-none items-center gap-1.5 rounded-md border px-2.5 text-xs font-medium transition-colors',
+                  'h-8 focus-within:ring-2 focus-within:ring-ring/40',
+                  includeRips
+                    ? 'border-primary/50 bg-primary/10 text-foreground'
+                    : 'border-border bg-card/70 text-muted-foreground hover:border-primary/40'
+                )}
+                title="RIPs are a separate track — off by default so status and category counts reflect EIPs and ERCs only."
+              >
+                <input
+                  type="checkbox"
+                  checked={includeRips}
+                  onChange={(e) => {
+                    setActiveBucket(null);
+                    setPage(1);
+                    setIncludeRips(e.target.checked);
+                  }}
+                  className="h-3.5 w-3.5 accent-primary"
+                />
+                Include RIPs
+              </label>
+            )}
             {(() => {
               const BrowseIcon =
                 dimension === 'status'
@@ -3370,7 +3416,7 @@ export default function EIPsHomePage() {
 
       <div className="mb-2 flex items-center justify-between gap-2">
         <p className="text-xs font-medium text-muted-foreground">
-          Proposal table view{activePersona === 'editor' ? ' (hidden by default for editor workflow)' : ''}
+          Proposal table view
         </p>
         <button
           type="button"

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -2090,16 +2090,24 @@ export default function EIPsHomePage() {
     ] as const;
 
     return {
-      grid: { left: 36, right: 10, top: 24, bottom: 56 },
+      grid: { left: 16, right: 16, top: 32, bottom: 44, containLabel: true },
       tooltip: {
         trigger: 'axis',
-        axisPointer: { type: 'shadow' },
-        backgroundColor: isDark ? 'rgba(15,23,42,0.95)' : 'rgba(255,255,255,0.98)',
-        borderColor: isDark ? 'rgba(148,163,184,0.25)' : 'rgba(148,163,184,0.35)',
-        borderWidth: 1,
+        axisPointer: {
+          type: 'line',
+          lineStyle: {
+            color: isDark ? 'rgba(56, 189, 248, 0.6)' : 'rgba(2, 132, 199, 0.6)',
+            type: 'dotted',
+            width: 1.5,
+          },
+        },
+        backgroundColor: isDark ? 'rgba(15, 23, 42, 0.94)' : 'rgba(255, 255, 255, 0.96)',
+        borderColor: isDark ? 'rgba(56, 189, 248, 0.45)' : 'rgba(2, 132, 199, 0.45)',
+        borderWidth: 1.5,
         padding: [10, 14],
         textStyle: { color: isDark ? '#f8fafc' : '#0f172a', fontSize: 12 },
-        extraCssText: 'box-shadow: 0 10px 30px -5px rgba(0,0,0,0.3); border-radius: 12px; backdrop-filter: blur(12px);',
+        extraCssText:
+          'border-style: dotted !important; box-shadow: 0 12px 32px rgba(0,0,0,0.35); border-radius: 12px; backdrop-filter: blur(16px); min-width: 170px;',
         formatter: (params: unknown) => {
           const items = Array.isArray(params) ? (params as any[]) : [];
           if (!items.length) return '';
@@ -2112,7 +2120,7 @@ export default function EIPsHomePage() {
             total += val;
             html += `<div style="display:flex;align-items:center;justify-content:space-between;gap:16px;font-size:11px;margin-top:4px"><span style="display:inline-flex;align-items:center;gap:6px"><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background-color:${item.color}"></span><span style="color:${isDark ? '#cbd5e1' : '#475569'}">${item.seriesName}</span></span><span style="font-weight:700;color:${isDark ? '#f8fafc' : '#0f172a'}">${val}</span></div>`;
           }
-          html += `<div style="margin-top:8px;padding-top:6px;border-top:1px solid ${isDark ? 'rgba(148,163,184,0.2)' : 'rgba(148,163,184,0.3)'};display:flex;align-items:center;justify-content:space-between;font-size:11px"><span style="color:${isDark ? '#94a3b8' : '#64748b'};font-weight:600">Total EIPs</span><span style="font-weight:800;color:${isDark ? '#38bdf8' : '#0284c7'}">${total}</span></div>`;
+          html += `<div style="margin-top:8px;padding-top:6px;border-top:1px dashed ${isDark ? 'rgba(148,163,184,0.25)' : 'rgba(148,163,184,0.35)'};display:flex;align-items:center;justify-content:space-between;font-size:11px"><span style="color:${isDark ? '#94a3b8' : '#64748b'};font-weight:600">Total EIPs</span><span style="font-weight:800;color:${isDark ? '#38bdf8' : '#0284c7'}">${total}</span></div>`;
           return html;
         },
       },

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -2091,21 +2091,6 @@ export default function EIPsHomePage() {
 
     return {
       grid: { left: 36, right: 10, top: 24, bottom: 56 },
-      graphic: [
-        {
-          type: 'text',
-          left: '33%',
-          top: '33%',
-          style: {
-            text: 'EIPsInsight.com',
-            fill: isDark ? 'rgba(148, 163, 184, 0.25)' : 'rgba(100, 116, 139, 0.25)',
-            fontSize: 13,
-            fontWeight: 700,
-            letterSpacing: 2,
-          },
-          z: 0,
-        },
-      ],
       tooltip: {
         trigger: 'axis',
         backgroundColor: isDark ? 'rgba(15,23,42,0.95)' : 'rgba(255,255,255,0.98)',

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -469,12 +469,23 @@ const PERSONA_HOME_PLANS: Record<HomePersona, {
 
 /** Section title that links to its full page, with a hover arrow. Replaces the old
  *  "Explore X" footer buttons — the header itself is now the way in. */
+/**
+ * Section title that doubles as a link to the section's full page.
+ *
+ * Renders a real <h2> because the sidebar scroll spy labels each section from
+ * its first descendant h1/h2/h3 — without one, it reaches into nested
+ * components and mislabels the section with some inner card's heading.
+ * `display: contents` keeps the heading out of the layout, so the link renders
+ * exactly as it did when this was a bare <a>.
+ */
 function SectionTitleLink({ href, className, children }: { href: string; className: string; children: React.ReactNode }) {
   return (
-    <Link href={href} className={cn(className, 'group inline-flex items-center gap-1 transition-colors hover:text-primary')}>
-      {children}
-      <ArrowUpRight className="h-4 w-4 shrink-0 text-muted-foreground/40 transition-all group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:text-primary" />
-    </Link>
+    <h2 className="contents">
+      <Link href={href} className={cn(className, 'group inline-flex items-center gap-1 transition-colors hover:text-primary')}>
+        {children}
+        <ArrowUpRight className="h-4 w-4 shrink-0 text-muted-foreground/40 transition-all group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:text-primary" />
+      </Link>
+    </h2>
   );
 }
 
@@ -2080,6 +2091,21 @@ export default function EIPsHomePage() {
 
     return {
       grid: { left: 36, right: 10, top: 24, bottom: 56 },
+      graphic: [
+        {
+          type: 'text',
+          left: '33%',
+          top: '33%',
+          style: {
+            text: 'EIPsInsight.com',
+            fill: isDark ? 'rgba(148, 163, 184, 0.25)' : 'rgba(100, 116, 139, 0.25)',
+            fontSize: 13,
+            fontWeight: 700,
+            letterSpacing: 2,
+          },
+          z: 0,
+        },
+      ],
       tooltip: {
         trigger: 'axis',
         backgroundColor: isDark ? 'rgba(15,23,42,0.95)' : 'rgba(255,255,255,0.98)',
@@ -2276,7 +2302,7 @@ export default function EIPsHomePage() {
       )}
 
       {visibleSections.quickAccess && (
-        <section className="mb-6" id="persona-home-workspace">
+        <section className="mb-6" id="workspace">
           <div className="rounded-xl border border-border/70 bg-card/60 p-4 shadow-sm">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
@@ -2353,13 +2379,13 @@ export default function EIPsHomePage() {
       )}
       <PersonaDashboardComponent>
       {activePersona === 'editor' && (
-        <section className="mb-6 border-t border-border/70 pt-6" id="editor-contributions-overview">
+        <section className="mb-6 border-t border-border/70 pt-6" id="contributions">
           <div className="mb-4 flex flex-col items-start gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div>
               <div className="inline-flex items-center gap-2">
                 <Trophy className="h-5 w-5 text-amber-400 shrink-0" />
                 <SectionTitleLink href="/analytics/editors" className={sectionTitleClass}>Editor Leadership Board - {editorContributionWindowLabel}</SectionTitleLink>
-                <CopyLinkButton sectionId="editor-contributions-overview" tooltipLabel="Copy link" />
+                <CopyLinkButton sectionId="contributions" tooltipLabel="Copy link" />
               </div>
               <p className={sectionSubtitleClass}>
                 Contribution ranking with action coverage and repository breakdown.
@@ -2460,14 +2486,14 @@ export default function EIPsHomePage() {
         <section
           style={{ order: sectionOrder.learning }}
           className="mb-6"
-          id="newcomer-learning-resources"
+          id="learn"
         >
           <div className="mb-4 flex items-start justify-between gap-4">
             <div>
               <div className="inline-flex items-center gap-2">
                 <BookOpen className="h-5 w-5 text-emerald-400 shrink-0" />
                 <SectionTitleLink href="/resources" className={sectionTitleClass}>Learning Resources</SectionTitleLink>
-                <CopyLinkButton sectionId="newcomer-learning-resources" tooltipLabel="Copy link" />
+                <CopyLinkButton sectionId="learn" tooltipLabel="Copy link" />
               </div>
               <p className={sectionSubtitleClass}>Start here to understand Ethereum standards without the noise.</p>
             </div>
@@ -2500,14 +2526,14 @@ export default function EIPsHomePage() {
         <section
           style={{ order: sectionOrder.trending }}
           className="mb-6 border-t border-border/70 pt-6"
-          id={activePersona === 'builder' ? 'builder-trending-proposals' : 'developer-trending-proposals'}
+          id="trending"
         >
           <div className="mb-4 flex items-start justify-between gap-4">
             <div>
               <div className="inline-flex items-center gap-2">
                 <Flame className="h-5 w-5 text-rose-500 shrink-0" />
                 <SectionTitleLink href="/explore/trending" className={sectionTitleClass}>Trending Proposals</SectionTitleLink>
-                <CopyLinkButton sectionId={activePersona === 'builder' ? 'builder-trending-proposals' : 'developer-trending-proposals'} tooltipLabel="Copy link" />
+                <CopyLinkButton sectionId="trending" tooltipLabel="Copy link" />
               </div>
               <p className={sectionSubtitleClass}>Most discussed proposals shaping Ethereum today.</p>
             </div>
@@ -2523,14 +2549,14 @@ export default function EIPsHomePage() {
         <section
           style={{ order: sectionOrder.trending }}
           className="mb-6 border-t border-border/70 pt-6"
-          id="newcomer-trending-proposals"
+          id="trending"
         >
           <div className="mb-4 flex items-start justify-between gap-4">
             <div>
               <div className="inline-flex items-center gap-2">
                 <Flame className="h-5 w-5 text-rose-500 shrink-0" />
                 <SectionTitleLink href="/explore/trending" className={sectionTitleClass}>Trending Proposals</SectionTitleLink>
-                <CopyLinkButton sectionId="newcomer-trending-proposals" tooltipLabel="Copy link" />
+                <CopyLinkButton sectionId="trending" tooltipLabel="Copy link" />
               </div>
               <p className={sectionSubtitleClass}>A simple snapshot of proposals with active discussions.</p>
             </div>
@@ -2571,14 +2597,14 @@ export default function EIPsHomePage() {
         <section
           style={{ order: sectionOrder.upgradeWatch }}
           className="mb-6 border-t border-border/70 pt-6"
-          id="newcomer-upgrade-watch"
+          id="upgrade-watch"
         >
           <div className="mb-4 flex items-start justify-between gap-4">
             <div>
               <div className="inline-flex items-center gap-2">
                 <Package className="h-5 w-5 text-sky-400 shrink-0" />
                 <SectionTitleLink href="/upgrade" className={sectionTitleClass}>Upgrade Hub</SectionTitleLink>
-                <CopyLinkButton sectionId="newcomer-upgrade-watch" tooltipLabel="Copy link" />
+                <CopyLinkButton sectionId="upgrade-watch" tooltipLabel="Copy link" />
               </div>
               <p className={sectionSubtitleClass}>Simplified snapshot of where proposal discussions stand for upgrades.</p>
             </div>
@@ -2608,14 +2634,14 @@ export default function EIPsHomePage() {
         <section
           style={{ order: sectionOrder.governanceOverTime }}
           className="mb-6 border-t border-border/70 pt-6"
-          id="developer-governance-over-time"
+          id="over-time"
         >
           <div className="mb-4 flex items-start justify-between gap-4">
             <div>
               <div className="inline-flex items-center gap-2">
                 <Zap className="h-5 w-5 text-yellow-400 shrink-0" />
                 <SectionTitleLink href="/dashboard" className={sectionTitleClass}>Governance Over Time</SectionTitleLink>
-                <CopyLinkButton sectionId="developer-governance-over-time" tooltipLabel="Copy link" />
+                <CopyLinkButton sectionId="over-time" tooltipLabel="Copy link" />
               </div>
               <p className={sectionSubtitleClass}>Track proposal lifecycle movement across the network timeline.</p>
             </div>
@@ -2627,14 +2653,14 @@ export default function EIPsHomePage() {
         <section
           style={{ order: sectionOrder.governanceOverTime }}
           className="mb-6 border-t border-border/70 pt-6"
-          id="builder-eip-builder-focus"
+          id="eip-builder"
         >
           <div className="mb-4 flex items-start justify-between gap-4">
             <div>
               <div className="inline-flex items-center gap-2">
                 <Code className="h-5 w-5 text-purple-400 shrink-0" />
                 <SectionTitleLink href="/eip-builder" className={sectionTitleClass}>EIP Builder</SectionTitleLink>
-                <CopyLinkButton sectionId="builder-eip-builder-focus" tooltipLabel="Copy link" />
+                <CopyLinkButton sectionId="eip-builder" tooltipLabel="Copy link" />
               </div>
               <p className={sectionSubtitleClass}>Primary workspace to draft, validate, and structure standards.</p>
             </div>
@@ -2654,14 +2680,14 @@ export default function EIPsHomePage() {
         <section
           style={{ order: sectionOrder.board }}
           className="mb-6 border-t border-border/70 pt-6"
-          id="developer-board-snapshot"
+          id="board"
         >
           <div className="mb-4 flex items-start justify-between gap-4">
             <div>
               <div className="inline-flex items-center gap-2">
                 <Activity className="h-5 w-5 text-blue-400 shrink-0" />
                 <SectionTitleLink href="/board" className={sectionTitleClass}>Board</SectionTitleLink>
-                <CopyLinkButton sectionId="developer-board-snapshot" tooltipLabel="Copy link" />
+                <CopyLinkButton sectionId="board" tooltipLabel="Copy link" />
               </div>
               <p className={sectionSubtitleClass}>
                 Compact open PR snapshot from the{' '}
@@ -2810,7 +2836,7 @@ export default function EIPsHomePage() {
         <section
           style={{ order: sectionOrder.board }}
           className="mb-6 border-t border-border/70 pt-6"
-          id="builder-tool-shortcuts"
+          id="tools"
         >
           <div className="mb-4 flex items-start justify-between gap-4">
             <div>
@@ -2820,7 +2846,7 @@ export default function EIPsHomePage() {
               </div>
               <div className="mt-1 flex items-center gap-2">
                 <p className={sectionSubtitleClass}>Jump directly into core contribution tools.</p>
-                <CopyLinkButton sectionId="builder-tool-shortcuts" tooltipLabel="Copy link" />
+                <CopyLinkButton sectionId="tools" tooltipLabel="Copy link" />
               </div>
               <p className={sectionSubtitleClass}>Jump directly into core contribution tools.</p>
             </div>
@@ -2854,7 +2880,7 @@ export default function EIPsHomePage() {
         <section
           style={{ order: sectionOrder.board }}
           className="mb-6 border-t border-border/70 pt-6"
-          id="newcomer-tools-shortcuts"
+          id="tools"
         >
           <div className="mb-4 flex items-start justify-between gap-4">
             <div>
@@ -2864,7 +2890,7 @@ export default function EIPsHomePage() {
               </div>
               <div className="mt-1 flex items-center gap-2">
                 <p className={sectionSubtitleClass}>Start with the essential tools for exploration and contribution.</p>
-                <CopyLinkButton sectionId="newcomer-tools-shortcuts" tooltipLabel="Copy link" />
+                <CopyLinkButton sectionId="tools" tooltipLabel="Copy link" />
               </div>
               <p className={sectionSubtitleClass}>Start with the essential tools for exploration and contribution.</p>
             </div>
@@ -2936,7 +2962,7 @@ export default function EIPsHomePage() {
       <div
         style={activePersona === 'editor' ? undefined : { order: sectionOrder.browse }}
         className={cn('mb-6', activePersona === 'editor' && 'border-t border-border/70 pt-6')}
-        id={activePersona === 'builder' ? 'builder-browse-snapshot' : 'editor-browse-snapshot'}
+        id="browse"
       >
       <div className="mb-4 space-y-3">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -2948,7 +2974,7 @@ export default function EIPsHomePage() {
                   Browse by Status, Category, Repository &amp; Stages
                 </SectionTitleLink>
                 <CopyLinkButton
-                  sectionId={activePersona === 'builder' ? 'builder-browse-snapshot' : 'editor-browse-snapshot'}
+                  sectionId="browse"
                   tooltipLabel="Copy link"
                   className="h-8 w-8 rounded-md"
                 />
@@ -3583,7 +3609,7 @@ export default function EIPsHomePage() {
         <section
           className={cn('mb-6', activePersona === 'editor' && 'border-t border-border/70 pt-6')}
           style={activePersona === 'editor' ? { order: 99 } : { order: sectionOrder.learning }}
-          id="home-reference"
+          id="reference"
         >
           {activePersona === 'editor' && (
             <div className="mb-3 flex items-start justify-between gap-2">
@@ -3591,7 +3617,7 @@ export default function EIPsHomePage() {
                 <div className="inline-flex items-center gap-2">
                   <FileText className="h-5 w-5 text-cyan-400 shrink-0" />
                   <SectionTitleLink href="/resources/faq" className={sectionTitleClass}>Reference</SectionTitleLink>
-                  <CopyLinkButton sectionId="home-reference" tooltipLabel="Copy link" />
+                  <CopyLinkButton sectionId="reference" tooltipLabel="Copy link" />
                 </div>
                 <p className={sectionSubtitleClass}>Key FAQs and guidance for standards workflow.</p>
               </div>
@@ -3604,7 +3630,7 @@ export default function EIPsHomePage() {
       <div
         style={activePersona === 'editor' ? undefined : { order: sectionOrder.monthly }}
         className={cn(activePersona === 'editor' && 'mb-6 border-t border-border/70 pt-6')}
-        id="editor-monthly-insight"
+        id="monthly"
       >
       {activePersona !== 'editor' && visibleSections.monthly && <hr className="my-6 border-border" />}
 
@@ -3614,7 +3640,7 @@ export default function EIPsHomePage() {
             <div className="inline-flex items-center gap-2">
               <Trophy className="h-5 w-5 text-amber-400 shrink-0" />
               <SectionTitleLink href="/insights" className={sectionTitleClass}>Monthly Insight & Editor Leadership Board</SectionTitleLink>
-              <CopyLinkButton sectionId="editor-monthly-insight" tooltipLabel="Copy link" />
+              <CopyLinkButton sectionId="monthly" tooltipLabel="Copy link" />
             </div>
             <p className={sectionSubtitleClass}>Monthly status distribution and editor activity snapshot.</p>
           </div>
@@ -3891,9 +3917,9 @@ export default function EIPsHomePage() {
       >
       {activePersona !== 'editor' && visibleSections.governance && <hr className="my-6 border-border" />}
 
-      <section className="mb-6 w-full" id="weekly-recap-digest">
-        <WeeklyRecapSection sectionTitleClass={sectionTitleClass} sectionSubtitleClass={sectionSubtitleClass} />
-      </section>
+      {/* No wrapper <section id>: WeeklyRecapSection owns its own #weekly-recap
+          anchor. Wrapping it would put two ids in the scroll spy for one section. */}
+      <WeeklyRecapSection sectionTitleClass={sectionTitleClass} sectionSubtitleClass={sectionSubtitleClass} />
 
       </div>
       )}
@@ -3913,14 +3939,14 @@ export default function EIPsHomePage() {
         <section
           style={{ order: sectionOrder.social }}
           className="mb-2 border-t border-border/70 pt-6"
-          id="builder-practical-resources"
+          id="resources"
         >
           <div className="mb-3 flex items-start justify-between gap-3">
             <div>
               <div className="inline-flex items-center gap-2">
                 <Layers className="h-5 w-5 text-emerald-400 shrink-0" />
                 <SectionTitleLink href="/resources" className={sectionTitleClass}>Practical Resources</SectionTitleLink>
-                <CopyLinkButton sectionId="builder-practical-resources" tooltipLabel="Copy link" />
+                <CopyLinkButton sectionId="resources" tooltipLabel="Copy link" />
               </div>
               <p className={sectionSubtitleClass}>Documentation and references to contribute effectively.</p>
             </div>

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -2093,8 +2093,28 @@ export default function EIPsHomePage() {
       grid: { left: 36, right: 10, top: 24, bottom: 56 },
       tooltip: {
         trigger: 'axis',
+        axisPointer: { type: 'shadow' },
         backgroundColor: isDark ? 'rgba(15,23,42,0.95)' : 'rgba(255,255,255,0.98)',
-        borderColor: isDark ? 'rgba(148,163,184,0.2)' : 'rgba(148,163,184,0.35)',
+        borderColor: isDark ? 'rgba(148,163,184,0.25)' : 'rgba(148,163,184,0.35)',
+        borderWidth: 1,
+        padding: [10, 14],
+        textStyle: { color: isDark ? '#f8fafc' : '#0f172a', fontSize: 12 },
+        extraCssText: 'box-shadow: 0 10px 30px -5px rgba(0,0,0,0.3); border-radius: 12px; backdrop-filter: blur(12px);',
+        formatter: (params: unknown) => {
+          const items = Array.isArray(params) ? (params as any[]) : [];
+          if (!items.length) return '';
+          const date = items[0].axisValue;
+          let html = `<div style="font-weight:700;font-size:12px;margin-bottom:6px;color:${isDark ? '#f8fafc' : '#0f172a'}">${date}</div>`;
+          let total = 0;
+          for (const item of items) {
+            const val = item.value || 0;
+            if (val === 0) continue;
+            total += val;
+            html += `<div style="display:flex;align-items:center;justify-content:space-between;gap:16px;font-size:11px;margin-top:4px"><span style="display:inline-flex;align-items:center;gap:6px"><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background-color:${item.color}"></span><span style="color:${isDark ? '#cbd5e1' : '#475569'}">${item.seriesName}</span></span><span style="font-weight:700;color:${isDark ? '#f8fafc' : '#0f172a'}">${val}</span></div>`;
+          }
+          html += `<div style="margin-top:8px;padding-top:6px;border-top:1px solid ${isDark ? 'rgba(148,163,184,0.2)' : 'rgba(148,163,184,0.3)'};display:flex;align-items:center;justify-content:space-between;font-size:11px"><span style="color:${isDark ? '#94a3b8' : '#64748b'};font-weight:600">Total EIPs</span><span style="font-weight:800;color:${isDark ? '#38bdf8' : '#0284c7'}">${total}</span></div>`;
+          return html;
+        },
       },
       legend: {
         top: 0,

--- a/src/app/(tools)/dependencies/page.tsx
+++ b/src/app/(tools)/dependencies/page.tsx
@@ -16,6 +16,7 @@ import {
 import { upgradeDependencies } from "@/data/upgrade-dependencies";
 import { eipTitles } from "@/data/network-upgrades";
 import { cn } from "@/lib/utils";
+import { chartTooltip } from '@/lib/chart-theme';
 
 type UpgradeName = (typeof upgradeDependencies)[number]["name"];
 type UpgradeFilter = UpgradeName | "All";
@@ -266,11 +267,8 @@ export default function DependenciesPage() {
     return {
       animationDurationUpdate: 250,
       backgroundColor: "transparent",
-      tooltip: {
+      tooltip: chartTooltip({
         trigger: "item",
-        backgroundColor: "rgba(15,23,42,0.96)",
-        borderColor: "rgba(148,163,184,0.25)",
-        textStyle: { color: "#e2e8f0", fontSize: 12 },
         formatter: (params: { dataType: string; data: GraphNode | GraphLink }) => {
           if (params.dataType === "edge") {
             const link = params.data as GraphLink;
@@ -280,7 +278,7 @@ export default function DependenciesPage() {
           const node = params.data as GraphNode;
           return `${node.name}<br/>${node.title}<br/>${node.category}`;
         },
-      },
+      }),
       series: [
         {
           type: "graph",

--- a/src/app/calls/[series]/[number]/page.tsx
+++ b/src/app/calls/[series]/[number]/page.tsx
@@ -191,6 +191,10 @@ export default async function CallDetailPage({ params }: Props) {
       {/* Below: summary + decisions/eips/links */}
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
         <div className="space-y-8 lg:col-span-2">
+          {/* Meeting chat sits above the summary and is collapsed by default, so the
+              always-expanded summary below it stays close to the top of the column. */}
+          {chatMessages && chatMessages.length > 0 && <CallChat messages={chatMessages} />}
+
           <section className="space-y-3">
             <h2 className="flex items-center gap-2 text-lg font-semibold tracking-tight text-foreground">
               <FileText className="h-4 w-4 text-muted-foreground" />
@@ -204,9 +208,6 @@ export default async function CallDetailPage({ params }: Props) {
               </p>
             )}
           </section>
-
-          {/* Meeting chat */}
-          {chatMessages && chatMessages.length > 0 && <CallChat messages={chatMessages} />}
 
           {/* Transcript fallback when there's a transcript but no embeddable video */}
           {call.has_transcript && !youtubeId && (

--- a/src/app/insights/governance/page.tsx
+++ b/src/app/insights/governance/page.tsx
@@ -9,6 +9,7 @@ import { PageHeader, SectionSeparator } from "@/components/header";
 import { LastUpdated } from "@/components/analytics/LastUpdated";
 import { AnalyticsAnnotation } from "@/components/analytics/AnalyticsAnnotation";
 import { InlineBrandLoader } from "@/components/inline-brand-loader";
+import { chartTooltip } from '@/lib/chart-theme';
 
 const STATE_ORDER = ["STALLED", "WAITING_ON_EDITOR", "WAITING_ON_AUTHOR", "MERGED", "CLOSED"] as const;
 const STATE_COLORS: Record<string, string> = {
@@ -171,12 +172,7 @@ export default function GovernanceProcessPage() {
   }, [stateMap]);
 
   const governanceStateOption = useMemo(() => ({
-    tooltip: {
-      trigger: "item",
-      backgroundColor: "rgba(15,23,42,0.96)",
-      borderColor: "rgba(148,163,184,0.25)",
-      textStyle: { color: "#e2e8f0", fontSize: 12 },
-    },
+    tooltip: chartTooltip({ trigger: "item" }),
     grid: { left: 0, right: 8, top: 6, bottom: 6, containLabel: true },
     xAxis: {
       type: "value",

--- a/src/app/upgrade/page.tsx
+++ b/src/app/upgrade/page.tsx
@@ -3,6 +3,7 @@ import { ArrowRight, Archive, BarChart2, CalendarClock, GitCommit, Info, Package
 import { CopyLinkButton } from '@/components/header';
 import '@/lib/orpc.server';
 import { cn } from '@/lib/utils';
+import { statusBadgeClass } from '@/lib/proposal-status';
 import {
   getInProgressUpgrades,
   getLiveUpgrades,
@@ -234,21 +235,19 @@ export default async function UpgradeIndexPage() {
                       EIP-{event.eip_number}
                     </Link>
                   )}
-                  {event.status && (
-                    <span className="inline-flex items-center rounded-full border border-border bg-muted/40 px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
-                      {event.status}
-                    </span>
-                  )}
                   <span className="hidden max-w-72 truncate text-sm text-muted-foreground md:inline">
                     {event.title}
                   </span>
-                  <span className="text-sm text-muted-foreground">
-                    {event.event_type === 'removed' ? 'removed from' : `${event.event_type} to`}
-                  </span>
-                  <StageBadge bucket={event.bucket} abbreviated />
-                  {event.upgrade_slug && (
+
+                  {/* The verb's object is the UPGRADE, so the clause has to close on the
+                      upgrade name. Putting the badges inside it read as "added to Draft
+                      CFI" — but Draft is the proposal's lifecycle status, not something
+                      an EIP is added to. Badges follow as trailing metadata instead. */}
+                  {event.upgrade_slug ? (
                     <>
-                      <span className="text-sm text-muted-foreground">in</span>
+                      <span className="text-sm text-muted-foreground">
+                        {event.event_type === 'removed' ? 'removed from' : `${event.event_type} to`}
+                      </span>
                       <Link
                         href={`/upgrade/${event.upgrade_slug}`}
                         className="text-sm font-medium text-foreground hover:text-primary"
@@ -256,7 +255,24 @@ export default async function UpgradeIndexPage() {
                         {event.upgrade_name ?? event.upgrade_slug}
                       </Link>
                     </>
+                  ) : (
+                    <span className="text-sm text-muted-foreground">{event.event_type}</span>
                   )}
+
+                  <span className="inline-flex shrink-0 items-center gap-1.5">
+                    {event.status && (
+                      <span
+                        title={`Proposal status: ${event.status}`}
+                        className={cn(
+                          'inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium',
+                          statusBadgeClass(event.status, 'outline')
+                        )}
+                      >
+                        {event.status}
+                      </span>
+                    )}
+                    <StageBadge bucket={event.bucket} abbreviated />
+                  </span>
                   <span className="ml-auto shrink-0 text-xs text-muted-foreground">
                     {event.commit_date ? timeAgo(event.commit_date) : ''}
                   </span>

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -451,7 +451,7 @@ const SECTION_LABEL_OVERRIDES: Record<string, string> = {
   "newcomer-trending-proposals": "Trending",
   "newcomer-upgrade-watch": "Upgrade Watch",
   "newcomer-tools-shortcuts": "Tool Shortcuts",
-  "recent-governance-activity": "Recent Activity",
+  "weekly-recap-digest": "Weekly Standards Recap",
   "explore-detail-header": "Overview",
   "explore-detail-timeline": "Over Time",
   "explore-detail-editor-reviews-24h": "Reviews (24h)",

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -161,7 +161,7 @@ const sidebarSections: SidebarSection[] = [
         ],
       },
       {
-        title: "EIP Board",
+        title: "Open PR Board",
         icon: ClipboardList,
         href: "/board",
         items: [
@@ -206,7 +206,7 @@ const sidebarSections: SidebarSection[] = [
         items: [
           // Most-used first: PR and Editor analytics are the daily drivers.
           { title: "PRs", href: "/analytics/prs" },
-          { title: "Editors", href: "/analytics/editors" },
+          { title: "Editors Leadership Board", href: "/analytics/editors" },
           { title: "EIPs", href: "/analytics/eips" },
           { title: "Reviewers", href: "/analytics/reviewers" },
           { title: "Authors", href: "/analytics/authors" },
@@ -324,7 +324,7 @@ const PERSONA_VISIBLE_SUBITEMS: Partial<Record<Persona, Record<string, string[]>
   editor: {
     // Authors and Contributors are not part of the editorial workflow.
     // (Board moved out of Analytics to its own top-level "EIP Board" item.)
-    Analytics: ["PRs", "Editors", "EIPs", "Reviewers"],
+    Analytics: ["PRs", "Editor Leadership Board", "EIPs", "Reviewers"],
   },
 };
 

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -140,22 +140,22 @@ const sidebarSections: SidebarSection[] = [
           { title: "All Calls", href: "/calls" },
           {
             title: "ACD Calls",
-            href: "/calls?series=acd",
+            href: "/calls?series=acd#recent",
             items: [
-              { title: "ACDE — Execution", href: "/calls?series=acd&acd=acde" },
-              { title: "ACDC — Consensus", href: "/calls?series=acd&acd=acdc" },
-              { title: "ACDT — Testing", href: "/calls?series=acd&acd=acdt" },
-              { title: "ACDT-CL Breakout", href: "/calls?series=acd&acd=acdtcl" },
+              { title: "ACDE — Execution", href: "/calls?series=acd&acd=acde#recent" },
+              { title: "ACDC — Consensus", href: "/calls?series=acd&acd=acdc#recent" },
+              { title: "ACDT — Testing", href: "/calls?series=acd&acd=acdt#recent" },
+              { title: "ACDT-CL Breakout", href: "/calls?series=acd&acd=acdtcl#recent" },
             ],
           },
-          { title: "Breakout Calls", href: "/calls?series=breakouts" },
+          { title: "Breakout Calls", href: "/calls?series=breakouts#recent" },
           {
             title: "Decisions",
             href: "/decisions",
             items: [
               { title: "All Decisions", href: "/decisions" },
-              { title: "From ACD", href: "/decisions?series=acd" },
-              { title: "From Breakouts", href: "/decisions?series=breakouts" },
+              { title: "From ACD", href: "/decisions?series=acd#decisions" },
+              { title: "From Breakouts", href: "/decisions?series=breakouts#decisions" },
             ],
           },
         ],
@@ -435,23 +435,19 @@ function sortItemsByPersonaPriority(
   });
 }
 
+/**
+ * Display-label overrides for "On this page", keyed by section id.
+ *
+ * Only needed where `toTitle(id)` gets it wrong — section ids are short and
+ * persona-independent, so most auto-title correctly ("trending" → "Trending")
+ * and must NOT be listed here. This map is global across routes, so an entry
+ * here relabels that id on every page: keep keys specific enough not to collide
+ * (that's why home uses "upgrade-watch" while /upgrade uses "upgrades").
+ */
 const SECTION_LABEL_OVERRIDES: Record<string, string> = {
-  "persona-home-workspace": "Workspace",
-  "developer-upgrade-watch": "Upgrade Watch",
-  "developer-governance-over-time": "Over Time",
-  "developer-board-snapshot": "Board",
-  "editor-review-queue": "Review Queue",
-  "editor-category-breakdown": "Breakdown",
-  "editor-browse-snapshot": "Browse",
-  "editor-monthly-insight": "Monthly",
-  "builder-eip-builder-focus": "EIP Builder",
-  "builder-tool-shortcuts": "Tool Shortcuts",
-  "builder-practical-resources": "Resources",
-  "newcomer-learning-resources": "Learning",
-  "newcomer-trending-proposals": "Trending",
-  "newcomer-upgrade-watch": "Upgrade Watch",
-  "newcomer-tools-shortcuts": "Tool Shortcuts",
-  "weekly-recap-digest": "Weekly Standards Recap",
+  // Home — only the ones auto-titling can't produce.
+  "eip-builder": "EIP Builder",
+  "weekly-recap": "Weekly Standards Recap",
   "explore-detail-header": "Overview",
   "explore-detail-timeline": "Over Time",
   "explore-detail-editor-reviews-24h": "Reviews (24h)",
@@ -594,23 +590,49 @@ function AppSidebarContent() {
         .trim()
         .replace(/\b\w/g, (c) => c.toUpperCase());
 
+    const SECTION_SELECTOR = "section[id], [data-sidebar-section][id]";
+
+    /**
+     * Text of the first heading that belongs to THIS section.
+     *
+     * Headings inside a nested section[id] are ignored — otherwise an embedded
+     * component (a trending list, a chart card) donates one of its item titles
+     * as the section's label, which is how "On this page" ended up showing
+     * proposal names.
+     */
+    const ownHeadingText = (node: HTMLElement): string | null => {
+      const headings = Array.from(node.querySelectorAll<HTMLElement>("h1, h2, h3"));
+      for (const heading of headings) {
+        if (heading.closest(SECTION_SELECTOR) === node) {
+          return heading.textContent?.trim() || null;
+        }
+      }
+      return null;
+    };
+
     const build = () => {
       const query = currentSearchStr ? `?${currentSearchStr}` : "";
       const seen = new Set<string>();
       const seenTitles = new Set<string>();
       const collected: SidebarSubItem[] = [];
-      const nodes = Array.from(document.querySelectorAll<HTMLElement>("section[id], [data-sidebar-section][id]"));
+      const nodes = Array.from(document.querySelectorAll<HTMLElement>(SECTION_SELECTOR));
 
       for (const node of nodes) {
         const id = (node.id || "").trim();
         if (!id || seen.has(id)) continue;
+
+        // Only top-level sections are page sections. A section[id] nested inside
+        // another one belongs to an embedded component that happens to carry its
+        // own anchor (e.g. TrendingProposals inside the home page's #trending);
+        // listing it duplicates the entry the outer section already provides.
+        if (node.parentElement?.closest(SECTION_SELECTOR)) continue;
+
         seen.add(id);
         const fromData = node.getAttribute("data-sidebar-label")?.trim();
-        const heading = node.querySelector<HTMLElement>("h1, h2, h3");
         const title =
           SECTION_LABEL_OVERRIDES[id] ||
           fromData ||
-          heading?.textContent?.trim() ||
+          ownHeadingText(node) ||
           toTitle(id);
         const titleKey = title.toLowerCase().replace(/\s+/g, " ").trim();
         if (seenTitles.has(titleKey)) continue;

--- a/src/components/chart-footer.tsx
+++ b/src/components/chart-footer.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+function formatFooterDate(value: Date | null): string {
+  if (!value) return '—';
+  const dd = String(value.getDate()).padStart(2, '0');
+  const mm = String(value.getMonth() + 1).padStart(2, '0');
+  const yyyy = value.getFullYear();
+  const hh = value.toLocaleString('en-US', { hour: '2-digit', hour12: true }).slice(0, 2);
+  const min = value.toLocaleString('en-US', { minute: '2-digit' });
+  const ap = value.toLocaleString('en-US', { hour: '2-digit', hour12: true }).slice(-2).toUpperCase();
+  return `${dd}-${mm}-${yyyy} ${hh}:${min} ${ap}`;
+}
+
+export function ChartFooter({ nextUpdateAt }: { nextUpdateAt?: Date | null }) {
+  const effectiveNextUpdate = nextUpdateAt ?? new Date(Date.now() + 6 * 60 * 60 * 1000);
+
+  return (
+    <div className="mt-3 border-t border-border/70 pt-2.5">
+      <div className="flex items-center justify-between gap-3 rounded-md bg-muted/30 px-2.5 py-1.5 text-xs text-muted-foreground">
+        <span className="font-medium text-foreground/90">EIPsInsight.com</span>
+        <span className="inline-flex items-center gap-1.5">
+          <span className="h-1.5 w-1.5 rounded-full bg-primary/70" />
+          Next Update: {formatFooterDate(effectiveNextUpdate)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default ChartFooter;

--- a/src/components/chart-watermark.tsx
+++ b/src/components/chart-watermark.tsx
@@ -6,26 +6,30 @@ import { cn } from '@/lib/utils';
  */
 export function ChartWatermark({
   className,
-  position = 'bottom-right',
+  position = 'center',
 }: {
   className?: string;
   position?: 'bottom-right' | 'center' | 'one-third';
 }) {
+  if (position === 'center') {
+    return (
+      <div aria-hidden className={cn('pointer-events-none absolute inset-0 z-0 flex items-center justify-center select-none', className)}>
+        <span className="text-xs sm:text-sm font-bold tracking-[0.14em] uppercase text-foreground/12 dark:text-foreground/16">
+          EIPsInsight.com
+        </span>
+      </div>
+    );
+  }
+
   const positionClass =
     position === 'one-third'
-      ? 'top-[33%] left-[33%] -translate-x-1/2 -translate-y-1/2'
-      : position === 'center'
-      ? 'top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2'
-      : 'bottom-2 right-2';
+      ? 'top-[33%] left-[33%] -translate-x-1/2 -translate-y-1/2 z-10 rounded-md border border-border/60 bg-background/70 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/70 backdrop-blur-sm'
+      : 'bottom-2 right-2 z-10 rounded-md border border-border/60 bg-background/70 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/70 backdrop-blur-sm';
 
   return (
     <div
       aria-hidden
-      className={cn(
-        'pointer-events-none absolute z-10 select-none rounded-md border border-border/60 bg-background/70 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/70 backdrop-blur-sm',
-        positionClass,
-        className,
-      )}
+      className={cn('pointer-events-none absolute select-none', positionClass, className)}
     >
       EIPsInsight.com
     </div>

--- a/src/components/chart-watermark.tsx
+++ b/src/components/chart-watermark.tsx
@@ -4,12 +4,26 @@ import { cn } from '@/lib/utils';
  * Small "EIPsInsight.com" attribution watermark for charts.
  * Drop inside a `position: relative` chart container.
  */
-export function ChartWatermark({ className }: { className?: string }) {
+export function ChartWatermark({
+  className,
+  position = 'bottom-right',
+}: {
+  className?: string;
+  position?: 'bottom-right' | 'center' | 'one-third';
+}) {
+  const positionClass =
+    position === 'one-third'
+      ? 'top-[33%] left-[33%] -translate-x-1/2 -translate-y-1/2'
+      : position === 'center'
+      ? 'top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2'
+      : 'bottom-2 right-2';
+
   return (
     <div
       aria-hidden
       className={cn(
-        'pointer-events-none absolute bottom-2 right-2 z-10 select-none rounded-md border border-border/60 bg-background/70 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/70 backdrop-blur-sm',
+        'pointer-events-none absolute z-10 select-none rounded-md border border-border/60 bg-background/70 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/70 backdrop-blur-sm',
+        positionClass,
         className,
       )}
     >

--- a/src/components/governance-over-time-shared.tsx
+++ b/src/components/governance-over-time-shared.tsx
@@ -7,6 +7,7 @@ import { ChevronDown, ChevronUp, Download, Table } from 'lucide-react';
 import { client } from '@/lib/orpc';
 import { InlineBrandLoader } from '@/components/inline-brand-loader';
 import { cn } from '@/lib/utils';
+import { chartTooltip, CHART_TOOLTIP_BORDER } from '@/lib/chart-theme';
 
 type TimelinePoint = {
   year: number;
@@ -325,9 +326,6 @@ export function GovernanceOverTimeShared({
     const isLight = !isDarkMode;
     const axisLabelColor = isLight ? '#475569' : '#94A3B8';
     const gridLineColor = isLight ? 'rgba(100, 116, 139, 0.12)' : 'rgba(148, 163, 184, 0.08)';
-    const tooltipBg = isLight ? 'rgba(248, 250, 252, 0.95)' : 'rgba(15, 23, 42, 0.92)';
-    const tooltipBorder = isLight ? 'rgba(100, 116, 139, 0.25)' : 'rgba(148, 163, 184, 0.2)';
-
     const series: echarts.SeriesOption[] = allKeys.map((key) => {
       const baseColor = colors[key] || '#94a3b8';
       return {
@@ -362,12 +360,9 @@ export function GovernanceOverTimeShared({
 
     return {
       animationDuration: 350,
-      tooltip: {
+      tooltip: chartTooltip({
         trigger: 'axis',
         axisPointer: { type: 'shadow' },
-        backgroundColor: tooltipBg,
-        borderColor: tooltipBorder,
-        borderWidth: 1,
         formatter: (params: unknown) => {
           const entries = Array.isArray(params) ? (params as TooltipParam[]) : [];
           const bars = entries.filter((p) => p.seriesName !== 'Total');
@@ -378,10 +373,10 @@ export function GovernanceOverTimeShared({
             if (!p.value) continue;
             html += `<div style="display:flex;justify-content:space-between;gap:14px"><span>${p.seriesName}</span><span style="font-weight:600">${p.value}</span></div>`;
           }
-          html += `<div style="margin-top:8px;padding-top:8px;border-top:1px solid ${tooltipBorder};display:flex;justify-content:space-between"><span>Total</span><span style="font-weight:700">${total}</span></div>`;
+          html += `<div style="margin-top:8px;padding-top:8px;border-top:1px solid ${CHART_TOOLTIP_BORDER};display:flex;justify-content:space-between"><span>Total</span><span style="font-weight:700">${total}</span></div>`;
           return html;
         },
-      },
+      }),
       legend: { show: false },
       grid: { left: '4%', right: '4%', top: '10%', bottom: '14%', containLabel: true },
       xAxis: {

--- a/src/components/insights/MonthlyDrilldown.tsx
+++ b/src/components/insights/MonthlyDrilldown.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { LastUpdated } from "@/components/analytics/LastUpdated";
 import { InlineBrandLoader } from "@/components/inline-brand-loader";
+import { chartTooltip, CHART_TOOLTIP_FG, CHART_TOOLTIP_BORDER } from '@/lib/chart-theme';
 
 const STATUS_COLORS: Record<string, string> = {
   Draft: "#64748b",
@@ -338,14 +339,11 @@ export function MonthlyDrilldown({ initialMonth, basePath = "/insights" }: Month
     ].filter((d) => d.value > 0);
 
     return {
-      tooltip: {
+      tooltip: chartTooltip({
         trigger: "item",
-        backgroundColor: "rgba(15,23,42,0.96)",
-        borderColor: "rgba(148,163,184,0.28)",
-        textStyle: { color: "#e2e8f0", fontSize: 12 },
         formatter: (params: { name: string; value: number; percent: number }) =>
           `${params.name}<br/><b>${params.value}</b> (${params.percent}%)`,
-      },
+      }),
       legend: {
         bottom: 0,
         left: "center",
@@ -394,12 +392,9 @@ export function MonthlyDrilldown({ initialMonth, basePath = "/insights" }: Month
   const editorBarOption = useMemo(() => {
     const top = [...editors].slice(0, 10).reverse();
     return {
-      tooltip: {
+      tooltip: chartTooltip({
         trigger: "axis",
         axisPointer: { type: "shadow" },
-        backgroundColor: "rgba(15,23,42,0.96)",
-        borderColor: "rgba(148,163,184,0.28)",
-        textStyle: { color: "#e2e8f0", fontSize: 12 },
         formatter: (params: Array<{ seriesName: string; value: number; color: string; dataIndex: number }>) => {
           if (!params?.length) return "";
           const idx = params[0]?.dataIndex ?? 0;
@@ -410,13 +405,13 @@ export function MonthlyDrilldown({ initialMonth, basePath = "/insights" }: Month
           const total = row?.totalActions ?? (eips + ercs + rips);
 
           const lines = [
-            `<div style="margin-bottom:6px;font-weight:600;color:#f8fafc">${row?.editor ?? ""}</div>`,
+            `<div style="margin-bottom:6px;font-weight:600;color:${CHART_TOOLTIP_FG}">${row?.editor ?? ""}</div>`,
             ...params.map((p) => `<span style="display:inline-block;margin-right:8px;color:${p.color}">●</span>${p.seriesName}: <b>${Number(p.value || 0)}</b>`),
-            `<div style="margin-top:6px;padding-top:6px;border-top:1px solid rgba(148,163,184,0.25)">Total: <b>${total}</b></div>`,
+            `<div style="margin-top:6px;padding-top:6px;border-top:1px solid ${CHART_TOOLTIP_BORDER}">Total: <b>${total}</b></div>`,
           ];
           return lines.join("<br/>");
         },
-      },
+      }),
       grid: { left: 120, right: 18, top: 10, bottom: 24 },
       xAxis: {
         type: "value",
@@ -471,12 +466,7 @@ export function MonthlyDrilldown({ initialMonth, basePath = "/insights" }: Month
   const draftVsFinalOption = useMemo(() => {
     const months = draftFinalHistory.map((row) => monthLabel(row.month));
     return {
-      tooltip: {
-        trigger: "axis",
-        backgroundColor: "rgba(15,23,42,0.96)",
-        borderColor: "rgba(148,163,184,0.28)",
-        textStyle: { color: "#e2e8f0", fontSize: 12 },
-      },
+      tooltip: chartTooltip({ trigger: "axis" }),
       legend: {
         top: 0,
         right: 0,
@@ -540,12 +530,7 @@ export function MonthlyDrilldown({ initialMonth, basePath = "/insights" }: Month
     }));
 
     return {
-      tooltip: {
-        trigger: "axis",
-        backgroundColor: "rgba(15,23,42,0.96)",
-        borderColor: "rgba(148,163,184,0.28)",
-        textStyle: { color: "#e2e8f0", fontSize: 12 },
-      },
+      tooltip: chartTooltip({ trigger: "axis" }),
       legend: {
         top: 0,
         left: 0,

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -77,6 +77,7 @@ const mobileNavSections = [
     label: "Upgrades",
     items: [
       { title: "Overview", href: "/upgrade", icon: Package },
+      { title: "EIP Upgrade Directory", href: "/upgrade/eips", icon: Package },
       { title: "Archive", href: "/upgrade/archive", icon: Package },
       { title: "Pectra", href: "/upgrade/pectra", icon: Package },
       { title: "Fusaka", href: "/upgrade/fusaka", icon: Package },
@@ -90,7 +91,7 @@ const mobileNavSections = [
       { title: "Analytics Home", href: "/analytics", icon: LineChart },
       { title: "EIPs", href: "/analytics/eips", icon: LineChart },
       { title: "PRs", href: "/analytics/prs", icon: LineChart },
-      { title: "Editors", href: "/analytics/editors", icon: LineChart },
+      { title: "Editors Leadership Board", href: "/analytics/editors", icon: LineChart },
       { title: "Reviewers", href: "/analytics/reviewers", icon: LineChart },
       { title: "Authors", href: "/analytics/authors", icon: LineChart },
       { title: "Contributors", href: "/analytics/contributors", icon: LineChart },
@@ -104,7 +105,7 @@ const mobileNavSections = [
     label: "Tools",
     items: [
       { title: "Tools Home", href: "/tools", icon: Wrench },
-      { title: "Board", href: "/board", icon: Wrench },
+      { title: "Open PR Board", href: "/board", icon: Wrench },
       { title: "EIP Builder", href: "/eip-builder", icon: Wrench },
       { title: "Dependencies", href: "/dependencies", icon: Wrench },
       { title: "Timeline", href: "/timeline", icon: Wrench },

--- a/src/components/upgrade/call-chat.tsx
+++ b/src/components/upgrade/call-chat.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { MessagesSquare, Play, Search, X } from 'lucide-react';
+import { MessagesSquare, Play, Search, X, ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { ChatMessage } from '@/lib/call-artifacts';
 
@@ -58,6 +58,7 @@ function renderText(text: string) {
 }
 
 export function CallChat({ messages }: { messages: ChatMessage[] }) {
+  const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
   const query = search.trim().toLowerCase();
 
@@ -75,14 +76,34 @@ export function CallChat({ messages }: { messages: ChatMessage[] }) {
 
   return (
     <section className="space-y-3">
-      <h2 className="flex items-center gap-2 text-lg font-semibold tracking-tight text-foreground">
-        <MessagesSquare className="h-4 w-4 text-muted-foreground" />
-        Meeting chat
-        <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground">
-          {messages.length}
-        </span>
+      {/* Collapsed by default: the chat log is long and secondary to the summary,
+          which now sits below it and is always expanded. */}
+      <h2 className="text-lg font-semibold tracking-tight text-foreground">
+        <button
+          type="button"
+          onClick={() => setOpen((current) => !current)}
+          aria-expanded={open}
+          aria-controls="meeting-chat-panel"
+          className="group flex w-full items-center gap-2 text-left transition-colors hover:text-primary"
+        >
+          <MessagesSquare className="h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-primary" />
+          Meeting chat
+          <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground">
+            {messages.length}
+          </span>
+          <ChevronDown
+            className={cn(
+              'h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-300',
+              open && 'rotate-180'
+            )}
+          />
+        </button>
       </h2>
-      <div className="overflow-hidden rounded-xl border border-border bg-card/60">
+      <div
+        id="meeting-chat-panel"
+        hidden={!open}
+        className="overflow-hidden rounded-xl border border-border bg-card/60"
+      >
         <div className="border-b border-border/50 p-3">
           <div className="relative">
             <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />

--- a/src/components/upgrade/call-player.tsx
+++ b/src/components/upgrade/call-player.tsx
@@ -167,7 +167,9 @@ export function CallPlayer({
   const hasTranscript = cues.length > 0;
 
   return (
-    <div className={cn('grid gap-4', hasTranscript && 'lg:grid-cols-5')}>
+    // lg:pb-7 reserves room for the playhead caption, which is lifted out of flow
+    // below so the video box alone sets the row height (see the caption comment).
+    <div className={cn('grid gap-4', hasTranscript && 'lg:grid-cols-5 lg:pb-7')}>
       {/* Video */}
       <div className={cn(hasTranscript && 'lg:col-span-3')}>
         <div className="lg:sticky lg:top-20">
@@ -175,7 +177,10 @@ export function CallPlayer({
             <div ref={mountRef} className="absolute inset-0 h-full w-full" />
           </div>
           {ready && (
-            <div className="mt-2 flex items-center gap-2 px-0.5 text-xs text-muted-foreground">
+            // On lg this floats just under the video instead of adding to the column's
+            // height — otherwise the transcript (which fills the column) would always
+            // sit ~26px taller than the video box it is meant to line up with.
+            <div className="mt-2 flex items-center gap-2 px-0.5 text-xs text-muted-foreground lg:absolute lg:inset-x-0 lg:top-full">
               {playing ? <Pause className="h-3 w-3" /> : <Play className="h-3 w-3" />}
               <span className="font-mono">{fmt(currentTime)}</span>
               {hasTranscript && activeIdx >= 0 && (
@@ -186,10 +191,13 @@ export function CallPlayer({
         </div>
       </div>
 
-      {/* Transcript */}
+      {/* Transcript — on lg it is absolutely positioned inside its grid cell so it
+          matches the video column's height exactly. The video (aspect-video) is then
+          the only auto-height item, so it alone drives the row height and the
+          transcript fills it rather than running taller on its own max-height. */}
       {hasTranscript && (
-        <div className="lg:col-span-2">
-          <div className="flex h-full flex-col rounded-2xl border border-border/50 bg-card/60">
+        <div className="lg:relative lg:col-span-2">
+          <div className="flex h-full flex-col rounded-2xl border border-border/50 bg-card/60 lg:absolute lg:inset-0">
             <div className="border-b border-border/50 p-3">
               <div className="mb-2 flex items-center justify-between">
                 <h3 className="text-sm font-semibold text-foreground">Transcript</h3>
@@ -223,7 +231,9 @@ export function CallPlayer({
             </div>
             <div
               ref={listRef}
-              className="max-h-[62vh] min-h-64 overflow-y-auto p-1.5"
+              // Mobile keeps a viewport cap (the card is static there); on lg the card
+              // is height-bound by the grid cell, so the list just flexes to fill it.
+              className="max-h-[62vh] min-h-64 overflow-y-auto p-1.5 lg:max-h-none lg:min-h-0 lg:flex-1"
             >
               {visibleCues.length === 0 ? (
                 <p className="px-2 py-6 text-center text-xs text-muted-foreground">

--- a/src/components/upgrade/call-tldr.tsx
+++ b/src/components/upgrade/call-tldr.tsx
@@ -1,8 +1,5 @@
 'use client';
 
-import { useState } from 'react';
-import { ChevronDown } from 'lucide-react';
-import { cn } from '@/lib/utils';
 
 /**
  * Defensive renderer for ACDbot tldr.json payloads. The shape varies across
@@ -101,9 +98,12 @@ function TldrSection({ label, value }: { label: string; value: unknown }) {
   return null;
 }
 
+/**
+ * Always-expanded call summary. The summary is the primary reason to open a call
+ * page, so it is not collapsible — the meeting chat carries the collapse instead,
+ * since that is the long, skimmable artifact.
+ */
 export function CallTldr({ tldr }: { tldr: unknown }) {
-  const [expanded, setExpanded] = useState(false);
-
   if (!tldr || typeof tldr !== 'object') return null;
   const sections = Object.entries(tldr as Record<string, unknown>).filter(
     ([key, value]) => !SKIP_KEYS.has(key.toLowerCase()) && value != null
@@ -111,30 +111,10 @@ export function CallTldr({ tldr }: { tldr: unknown }) {
   if (sections.length === 0) return null;
 
   return (
-    <div className="mt-2">
-      <div
-        className={cn(
-          'grid transition-[grid-template-rows] duration-300 ease-in-out',
-          expanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
-        )}
-      >
-        <div className="overflow-hidden">
-          <div className="space-y-3 pb-2 pt-1">
-            {sections.map(([key, value]) => (
-              <TldrSection key={key} label={titleize(key)} value={value} />
-            ))}
-          </div>
-        </div>
-      </div>
-      <button
-        onClick={() => setExpanded((current) => !current)}
-        className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground transition-colors hover:text-primary"
-      >
-        <ChevronDown
-          className={cn('h-3.5 w-3.5 transition-transform duration-300', expanded && 'rotate-180')}
-        />
-        {expanded ? 'Hide summary' : 'Show summary'}
-      </button>
+    <div className="mt-2 space-y-3">
+      {sections.map(([key, value]) => (
+        <TldrSection key={key} label={titleize(key)} value={value} />
+      ))}
     </div>
   );
 }

--- a/src/components/upgrade/calls-browser.tsx
+++ b/src/components/upgrade/calls-browser.tsx
@@ -48,15 +48,27 @@ export function CallsBrowser({ calls }: { calls: RecentCall[] }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  // Initialise from the URL so sidebar deep links (?series=acd&acd=acde) and shared
-  // links restore the exact filter state.
-  const [series, setSeries] = useState<SeriesFilterValue>(() => {
+  // The URL is the source of truth for the series filter — NOT a useState initialiser.
+  // Sidebar deep links (?series=acd&acd=acde) are client-side navigations that
+  // re-render this component without remounting it, so an initialiser would only ever
+  // read the URL present on first mount and every later link would silently no-op.
+  const series = useMemo<SeriesFilterValue>(() => {
     const g = searchParams.get('series');
     if (g === 'acd') return { group: 'acd', acd: searchParams.get('acd') ?? 'all' };
     if (g === 'breakouts') return { group: 'breakouts', acd: 'all' };
     return DEFAULT_SERIES_FILTER;
-  });
-  const [search, setSearch] = useState(() => searchParams.get('q') ?? '');
+  }, [searchParams]);
+
+  // Search keeps local state so typing stays responsive, but adopts the URL when it
+  // changes externally (sidebar link, back button). Render-phase adjustment is React's
+  // documented pattern for this and avoids a setState-in-effect.
+  const urlSearch = searchParams.get('q') ?? '';
+  const [search, setSearch] = useState(urlSearch);
+  const [syncedSearch, setSyncedSearch] = useState(urlSearch);
+  if (urlSearch !== syncedSearch) {
+    setSyncedSearch(urlSearch);
+    setSearch(urlSearch);
+  }
 
   // Reflect the current filters back into the URL (shareable, back-button friendly).
   const syncUrl = (next: { series?: SeriesFilterValue; search?: string }) => {
@@ -70,8 +82,8 @@ export function CallsBrowser({ calls }: { calls: RecentCall[] }) {
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
   };
 
+  // No setSeries: the URL drives it, and syncUrl re-renders us with the new params.
   const changeSeries = (v: SeriesFilterValue) => {
-    setSeries(v);
     syncUrl({ series: v });
   };
   const changeSearch = (v: string) => {

--- a/src/components/upgrade/decisions-browser.tsx
+++ b/src/components/upgrade/decisions-browser.tsx
@@ -54,18 +54,28 @@ export function DecisionsBrowser({ calls }: { calls: DecisionCall[] }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  // Initialise from the URL so shared links restore the exact filter state.
-  const [series, setSeries] = useState<SeriesFilterValue>(() => {
+  // The URL is the source of truth — NOT a useState initialiser. Sidebar deep links
+  // (?series=acd) are client-side navigations that re-render without remounting, so an
+  // initialiser would only ever read the first URL and later links would silently no-op.
+  const series = useMemo<SeriesFilterValue>(() => {
     const g = searchParams.get('series');
     if (g === 'acd') return { group: 'acd', acd: searchParams.get('acd') ?? 'all' };
     if (g === 'breakouts') return { group: 'breakouts', acd: 'all' };
     return DEFAULT_SERIES_FILTER;
-  });
-  const [type, setType] = useState<DecisionType | 'all'>(() => {
+  }, [searchParams]);
+  const type = useMemo<DecisionType | 'all'>(() => {
     const t = searchParams.get('type');
     return (DECISION_TYPES as readonly string[]).includes(t ?? '') ? (t as DecisionType) : 'all';
-  });
-  const [search, setSearch] = useState(() => searchParams.get('q') ?? '');
+  }, [searchParams]);
+
+  // Search keeps local state for responsive typing but adopts external URL changes.
+  const urlSearch = searchParams.get('q') ?? '';
+  const [search, setSearch] = useState(urlSearch);
+  const [syncedSearch, setSyncedSearch] = useState(urlSearch);
+  if (urlSearch !== syncedSearch) {
+    setSyncedSearch(urlSearch);
+    setSearch(urlSearch);
+  }
 
   // Reflect the current filters into the URL (shareable, back-button friendly).
   const syncUrl = (next: {
@@ -85,12 +95,11 @@ export function DecisionsBrowser({ calls }: { calls: DecisionCall[] }) {
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
   };
 
+  // No setSeries/setType: the URL drives both, and syncUrl re-renders with new params.
   const changeSeries = (v: SeriesFilterValue) => {
-    setSeries(v);
     syncUrl({ series: v });
   };
   const changeType = (t: DecisionType | 'all') => {
-    setType(t);
     syncUrl({ type: t });
   };
   const changeSearch = (v: string) => {

--- a/src/lib/chart-theme.ts
+++ b/src/lib/chart-theme.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared ECharts theming wired to the app's CSS design tokens.
+ *
+ * Charts used to hardcode a Tailwind slate palette (`rgba(15,23,42,.96)` and
+ * friends). Slate carries a blue hue, so those tooltips read as navy against the
+ * app's neutral near-black surfaces — and the dark-only ones stayed dark in light
+ * mode. Driving the chrome from `var(--popover)` / `var(--border)` instead keeps
+ * tooltips identical to every other panel and makes them follow the theme toggle
+ * with no `isDark` branching at the call site.
+ */
+
+/** Token references for use inside `formatter` HTML strings. */
+export const CHART_TOOLTIP_FG = 'var(--popover-foreground)';
+export const CHART_TOOLTIP_MUTED = 'var(--muted-foreground)';
+export const CHART_TOOLTIP_BORDER = 'var(--border)';
+
+/**
+ * ECharts writes its own inline styles onto the tooltip element and appends
+ * `extraCssText` after them, so these declarations need `!important` to win the
+ * cascade. Verified against the live DOM — without it, ECharts' inline
+ * `background-color` and `color` take precedence.
+ */
+const TOOLTIP_CSS = [
+  'background: var(--popover) !important',
+  'color: var(--popover-foreground) !important',
+  'border: 1px solid var(--border) !important',
+  'border-radius: var(--radius) !important',
+  'box-shadow: 0 12px 32px rgb(0 0 0 / 0.28) !important',
+  'padding: 10px 12px !important',
+].join('; ');
+
+/**
+ * Themed tooltip config. Spread-merge friendly:
+ *
+ *   tooltip: chartTooltip({ trigger: 'item', formatter: … })
+ *
+ * Pass `minWidth` for tooltips that would otherwise jitter as values change.
+ */
+export function chartTooltip<T extends Record<string, unknown>>(
+  overrides?: T,
+  options?: { minWidth?: number }
+) {
+  const minWidth = options?.minWidth;
+  return {
+    // Zeroed so the CSS variables in extraCssText own the chrome entirely.
+    backgroundColor: 'transparent',
+    borderWidth: 0,
+    padding: 0,
+    textStyle: { fontSize: 12 },
+    extraCssText: minWidth ? `${TOOLTIP_CSS}; min-width: ${minWidth}px` : TOOLTIP_CSS,
+    ...overrides,
+  };
+}
+
+/**
+ * One `label — value` line for custom tooltip `formatter` output, with an optional
+ * colour dot. Keeps multi-series tooltips visually identical across charts.
+ */
+export function chartTooltipRow(
+  label: string,
+  value: string | number,
+  dotColor?: string
+): string {
+  const dot = dotColor
+    ? `<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background-color:${dotColor}"></span>`
+    : '';
+  return (
+    `<div style="display:flex;align-items:center;justify-content:space-between;gap:16px;font-size:11px;margin-top:4px">` +
+      `<span style="display:inline-flex;align-items:center;gap:6px">${dot}` +
+        `<span style="color:${CHART_TOOLTIP_MUTED}">${label}</span>` +
+      `</span>` +
+      `<span style="font-weight:700;color:${CHART_TOOLTIP_FG};font-variant-numeric:tabular-nums">${value}</span>` +
+    `</div>`
+  );
+}
+
+/** Muted eyebrow used as the first line of a custom tooltip (usually the axis value). */
+export function chartTooltipTitle(text: string): string {
+  return `<div style="font-weight:600;font-size:11px;letter-spacing:0.02em;color:${CHART_TOOLTIP_MUTED}">${text}</div>`;
+}

--- a/src/lib/proposal-status.ts
+++ b/src/lib/proposal-status.ts
@@ -1,0 +1,98 @@
+/**
+ * Canonical colours for EIP/ERC/RIP lifecycle status badges.
+ *
+ * Hues come from the "Status / Semantic Colors" table in `docs/ui-reference.md`.
+ * The border/background/text *shape* deliberately mirrors `stageBadgeClass` in
+ * `upgrade-stages.ts` — status and stage badges sit side by side (e.g. on
+ * /upgrade#latest-changes), so they must read as one badge family rather than two
+ * different styles.
+ */
+
+export type ProposalStatus =
+  | 'draft'
+  | 'review'
+  | 'last call'
+  | 'final'
+  | 'living'
+  | 'stagnant'
+  | 'withdrawn';
+
+const STATUS_BADGE_CLASSES: Record<ProposalStatus, string> = {
+  draft: 'border-slate-500/30 bg-slate-500/15 text-slate-700 dark:text-slate-300',
+  review: 'border-amber-500/30 bg-amber-500/15 text-amber-700 dark:text-amber-300',
+  'last call': 'border-orange-500/30 bg-orange-500/15 text-orange-700 dark:text-orange-300',
+  final: 'border-emerald-500/30 bg-emerald-500/15 text-emerald-700 dark:text-emerald-300',
+  living: 'border-cyan-500/30 bg-cyan-500/15 text-cyan-700 dark:text-cyan-300',
+  stagnant: 'border-gray-500/30 bg-gray-500/15 text-gray-700 dark:text-gray-400',
+  withdrawn: 'border-red-500/30 bg-red-500/15 text-red-700 dark:text-red-300',
+};
+
+/** Hex equivalents for charts — the "Hex (charts)" column of the same table. */
+export const STATUS_CHART_COLORS: Record<ProposalStatus, string> = {
+  draft: '#64748b',
+  review: '#f59e0b',
+  'last call': '#f97316',
+  final: '#10b981',
+  living: '#22d3ee',
+  stagnant: '#6b7280',
+  withdrawn: '#ef4444',
+};
+
+/**
+ * Normalise free-form status strings from the DB ("Last Call", "last-call",
+ * "LASTCALL") to a canonical key. Returns null when unrecognised so callers can
+ * fall back to neutral chrome rather than silently mis-colouring.
+ */
+export function normalizeProposalStatus(
+  status: string | null | undefined
+): ProposalStatus | null {
+  if (!status) return null;
+  const normalized = status
+    .toLowerCase()
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (normalized === 'lastcall' || normalized.includes('last call')) return 'last call';
+  if (normalized.includes('draft')) return 'draft';
+  if (normalized.includes('review')) return 'review';
+  if (normalized.includes('final')) return 'final';
+  if (normalized.includes('living')) return 'living';
+  if (normalized.includes('stagnant')) return 'stagnant';
+  if (normalized.includes('withdrawn')) return 'withdrawn';
+  return null;
+}
+
+/** Outline-only variant: same hue, no fill. */
+const STATUS_OUTLINE_CLASSES: Record<ProposalStatus, string> = {
+  draft: 'border-slate-500/40 bg-transparent text-slate-600 dark:text-slate-400',
+  review: 'border-amber-500/40 bg-transparent text-amber-600 dark:text-amber-400',
+  'last call': 'border-orange-500/40 bg-transparent text-orange-600 dark:text-orange-400',
+  final: 'border-emerald-500/40 bg-transparent text-emerald-600 dark:text-emerald-400',
+  living: 'border-cyan-500/40 bg-transparent text-cyan-600 dark:text-cyan-400',
+  stagnant: 'border-gray-500/40 bg-transparent text-gray-600 dark:text-gray-400',
+  withdrawn: 'border-red-500/40 bg-transparent text-red-600 dark:text-red-400',
+};
+
+/**
+ * Badge classes for a status string. Unknown statuses get neutral chrome.
+ *
+ * Use `variant: 'outline'` when the badge sits next to a filled StageBadge. The
+ * status palette and the stage palette both map to slate-500 (Draft / PFI), so two
+ * filled pills would be indistinguishable — and Draft+PFI is the most common pair.
+ * Outline keeps the documented hue while making the filled stage badge the
+ * primary element, which also matches the reading order ("… added to <stage>").
+ */
+export function statusBadgeClass(
+  status: string | null | undefined,
+  variant: 'solid' | 'outline' = 'solid'
+): string {
+  const normalized = normalizeProposalStatus(status);
+  if (!normalized) {
+    return variant === 'outline'
+      ? 'border-border bg-transparent text-muted-foreground'
+      : 'border-border bg-muted/40 text-muted-foreground';
+  }
+  return variant === 'outline'
+    ? STATUS_OUTLINE_CLASSES[normalized]
+    : STATUS_BADGE_CLASSES[normalized];
+}

--- a/src/server/orpc/procedures/standards.ts
+++ b/src/server/orpc/procedures/standards.ts
@@ -163,6 +163,12 @@ const tableInputSchema = z.object({
 
 const unifiedDistributionInputSchema = z.object({
   dimension: z.enum(['status', 'category', 'repo']).default('status'),
+  /**
+   * RIPs are a separate track from EIPs/ERCs, so they're opt-in — mixing them
+   * into a status or category breakdown by default skews the counts. Ignored for
+   * the `repo` dimension, where the whole point is the EIPs/ERCs/RIPs split.
+   */
+  includeRips: z.boolean().optional().default(false),
 })
 
 const unifiedTableInputSchema = z.object({
@@ -173,6 +179,8 @@ const unifiedTableInputSchema = z.object({
   search: z.string().optional(),
   dimension: z.enum(['status', 'category', 'repo']).optional(),
   bucket: z.string().optional(),
+  /** See unifiedDistributionInputSchema — kept in sync so cards and table agree. */
+  includeRips: z.boolean().optional().default(false),
   columnSearch: z.object({
     eip: z.string().optional(),
     github: z.string().optional(),
@@ -898,6 +906,23 @@ const results = await prisma.$queryRawUnsafe<Array<{
         : input.dimension === 'repo'
           ? 'repo_group'
           : 'status';
+      // The repo breakdown exists to show the EIPs/ERCs/RIPs split, so the toggle
+      // is ignored there — dropping RIPs would silently remove a whole bucket.
+      const includeRips = input.dimension === 'repo' || input.includeRips;
+      const ripsBranch = includeRips
+        ? `
+          UNION ALL
+          SELECT
+            COALESCE(NULLIF(r.status, ''), 'Unknown') AS status,
+            CASE
+              WHEN COALESCE(r.title, '') ~* '\\mRRC[-\\s]?[0-9]+' OR COALESCE(r.title, '') ~* '^RRC\\M'
+                THEN 'RRC'
+              ELSE 'RIP'
+            END AS category,
+            'RIPs'::text AS repo_group
+          FROM rips r
+          WHERE r.rip_number <> 0`
+        : '';
       const results = await prisma.$queryRawUnsafe<Array<{ bucket: string; count: bigint }>>(
         `
         WITH unified AS (
@@ -912,17 +937,7 @@ const results = await prisma.$queryRawUnsafe<Array<{
           JOIN eips e ON e.id = s.eip_id
           LEFT JOIN repositories r ON r.id = s.repository_id
           WHERE e.eip_number NOT IN ${HOMEPAGE_EXCLUDED_EIP_NUMBERS_SQL}
-          UNION ALL
-          SELECT
-            COALESCE(NULLIF(r.status, ''), 'Unknown') AS status,
-            CASE
-              WHEN COALESCE(r.title, '') ~* '\\mRRC[-\\s]?[0-9]+' OR COALESCE(r.title, '') ~* '^RRC\\M'
-                THEN 'RRC'
-              ELSE 'RIP'
-            END AS category,
-            'RIPs'::text AS repo_group
-          FROM rips r
-          WHERE r.rip_number <> 0
+          ${ripsBranch}
         )
         SELECT ${field} AS bucket, COUNT(*)::bigint AS count
         FROM unified
@@ -945,6 +960,10 @@ const results = await prisma.$queryRawUnsafe<Array<{
       const search = input.search?.trim() ?? '';
       const hasSearch = search.length > 0;
       const hasBucket = Boolean(input.dimension && input.bucket);
+      // Literal (not a bind param) because it's interpolated into the rip_rows CTE,
+      // which is gated to zero rows rather than removed so the UNION keeps its shape.
+      // Always TRUE for the repo dimension — see unifiedDistributionInputSchema.
+      const ripRowsEnabled = input.dimension === 'repo' || input.includeRips ? 'TRUE' : 'FALSE';
       const bucketField = input.dimension === 'category'
         ? 'category'
         : input.dimension === 'repo'
@@ -1001,7 +1020,7 @@ const results = await prisma.$queryRawUnsafe<Array<{
             COALESCE(MAX(rc.commit_date), r.created_at, NOW()) AS updated_at
           FROM rips r
           LEFT JOIN rip_commits rc ON rc.rip_id = r.id
-          WHERE r.rip_number <> 0
+          WHERE r.rip_number <> 0 AND ${ripRowsEnabled}
           GROUP BY r.rip_number, r.title, r.author, r.status, r.created_at
         ),
         eip_rows AS (
@@ -1109,7 +1128,7 @@ const results = await prisma.$queryRawUnsafe<Array<{
             COALESCE(MAX(rc.commit_date), r.created_at, NOW()) AS updated_at
           FROM rips r
           LEFT JOIN rip_commits rc ON rc.rip_id = r.id
-          WHERE r.rip_number <> 0
+          WHERE r.rip_number <> 0 AND ${ripRowsEnabled}
           GROUP BY r.rip_number, r.title, r.author, r.status, r.created_at
         ),
         eip_rows AS (
@@ -1214,6 +1233,8 @@ const results = await prisma.$queryRawUnsafe<Array<{
       dimension: z.enum(['status', 'category', 'repo']).default('status'),
       bucket: z.string().optional(),
       search: z.string().optional(),
+      /** Mirrors the table's toggle so an export matches what's on screen. */
+      includeRips: z.boolean().optional().default(false),
       columnSearch: z.object({
         eip: z.string().optional(),
         github: z.string().optional(),
@@ -1229,6 +1250,8 @@ const results = await prisma.$queryRawUnsafe<Array<{
       const search = input.search?.trim() ?? '';
       const hasSearch = search.length > 0;
       const hasBucket = Boolean(input.bucket);
+      // See getUnifiedProposals — same gating so the CSV matches the on-screen table.
+      const ripRowsEnabled = input.dimension === 'repo' || input.includeRips ? 'TRUE' : 'FALSE';
       const columnSearch = input.columnSearch ?? {};
       const eipSearch = columnSearch.eip?.trim() ?? '';
       const githubSearch = columnSearch.github?.trim() ?? '';
@@ -1289,7 +1312,7 @@ const results = await prisma.$queryRawUnsafe<Array<{
             COALESCE(MAX(rc.commit_date), r.created_at, NOW()) AS updated_at
           FROM rips r
           LEFT JOIN rip_commits rc ON rc.rip_id = r.id
-          WHERE r.rip_number <> 0
+          WHERE r.rip_number <> 0 AND ${ripRowsEnabled}
           GROUP BY r.rip_number, r.title, r.author, r.status, r.created_at
         )
         SELECT ${bucketField} AS bucket, COUNT(*)::bigint AS count
@@ -1367,7 +1390,7 @@ const results = await prisma.$queryRawUnsafe<Array<{
             COALESCE(MAX(rc.commit_date), r.created_at, NOW()) AS updated_at
           FROM rips r
           LEFT JOIN rip_commits rc ON rc.rip_id = r.id
-          WHERE r.rip_number <> 0
+          WHERE r.rip_number <> 0 AND ${ripRowsEnabled}
           GROUP BY r.rip_number, r.title, r.author, r.status, r.created_at
         ),
         eip_rows AS (


### PR DESCRIPTION
This pull request introduces several improvements to the EIPs homepage and related components, focusing on better UX, more consistent section anchors, enhanced chart visuals, and improved data filtering. The changes include new section IDs and copy-link targets, opt-in support for RIPs in proposal counts, improved chart tooltips and watermarking, and minor UI/wording tweaks.

**Homepage and Section Improvements:**

* Updated anchor IDs and `CopyLinkButton` targets for main sections to use simpler, more consistent IDs (`weekly-recap`, `upgrade-watch`, `categories`, `review-queue`) for improved navigation and sharing. [[1]](diffhunk://#diff-2f617c672fcdbcff5922e55c09de66d4fff739b7f36d83ee1468b6a57560725eL299-R299) [[2]](diffhunk://#diff-2f617c672fcdbcff5922e55c09de66d4fff739b7f36d83ee1468b6a57560725eL315-R315) [[3]](diffhunk://#diff-25f8cafc27df9e99a67a4c51f161edb4dd33ee03f2c881b36f649bcf599bd1deL78-R99) [[4]](diffhunk://#diff-f672a730f0286b42a8181c9fbb5c5fd0e9d98438d10ba1fe99ee4da81c658c44L55-R63) [[5]](diffhunk://#diff-c79cae646d8da699c595b18431c0be226913eea7f4eeee308cafdf5dd22d83a2L133-R139)
* Added a redirect for `/upgrade-hub` to `/upgrade` in `next.config.ts` for better URL management.
* Changed section titles to use real `<h2>` elements with `display: contents` for improved accessibility and correct sidebar scroll spy behavior.

**Chart and Analytics Enhancements:**

* Added `ChartFooter` and improved `ChartWatermark` positioning to analytics sections for clearer chart attribution and branding. [[1]](diffhunk://#diff-f672a730f0286b42a8181c9fbb5c5fd0e9d98438d10ba1fe99ee4da81c658c44R169) [[2]](diffhunk://#diff-25f8cafc27df9e99a67a4c51f161edb4dd33ee03f2c881b36f649bcf599bd1deR181) [[3]](diffhunk://#diff-f672a730f0286b42a8181c9fbb5c5fd0e9d98438d10ba1fe99ee4da81c658c44R136-R143) [[4]](diffhunk://#diff-25f8cafc27df9e99a67a4c51f161edb4dd33ee03f2c881b36f649bcf599bd1deL143-R163)
* Standardized chart tooltip appearance using a new `chartTooltip` helper, improving consistency and theme support. [[1]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfL1442-R1464) [[2]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfL1556-L1561) [[3]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfL1580-R1592) [[4]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfR69)

**Homepage Data and Table Behavior:**

* Added an "Include RIPs" toggle for proposal counts and analytics, making RIPs opt-in for more accurate EIP stats. This affects data fetching and display for distributions and tables. [[1]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfL837-R851) [[2]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfR908-R912) [[3]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfL1143-R1160) [[4]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfL1155-R1172) [[5]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfR1281) [[6]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfL1288-R1306)
* Changed proposal table to be collapsed by default for all personas; users must opt-in to view the full table, emphasizing summary cards instead. [[1]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfL837-R851) [[2]](diffhunk://#diff-dedff5c4497052ec633a8df025d691fda18bf5b73f9de4db34df47ad0cebc5cfR908-R912)

**UI and Wording Tweaks:**

* Updated the "Editor Insights" quick-access card to "Editor Leadership Board" for clarity and consistency.
* Minor style and color tweaks for icons and buttons for improved visual consistency. [[1]](diffhunk://#diff-25f8cafc27df9e99a67a4c51f161edb4dd33ee03f2c881b36f649bcf599bd1deL78-R99) [[2]](diffhunk://#diff-25f8cafc27df9e99a67a4c51f161edb4dd33ee03f2c881b36f649bcf599bd1deL143-R163) [[3]](diffhunk://#diff-25f8cafc27df9e99a67a4c51f161edb4dd33ee03f2c881b36f649bcf599bd1deR181) [[4]](diffhunk://#diff-25f8cafc27df9e99a67a4c51f161edb4dd33ee03f2c881b36f649bcf599bd1deR8-R10) [[5]](diffhunk://#diff-f672a730f0286b42a8181c9fbb5c5fd0e9d98438d10ba1fe99ee4da81c658c44R9-R10)

**Navigation and Actions:**

* Added a button linking to the "EIP Upgrade Directory" in the Developer Upgrade Watch section for easier navigation.

These changes collectively improve the homepage's usability, navigability, and analytics accuracy, while also enhancing visual consistency and accessibility.