### PR TITLE
Implement ACD agenda tracking with new panel and database schema

### DIFF
--- a/prisma/migrations/20260721000000_pm_agenda_eips/migration.sql
+++ b/prisma/migrations/20260721000000_pm_agenda_eips/migration.sql
@@ -1,0 +1,31 @@
+-- EIPs referenced in ethereum/pm ACD agenda issues (body + comments).
+-- Written by the scheduler, read by /board's ACD Agenda tab.
+CREATE TABLE IF NOT EXISTS "pm_agenda_eips" (
+    "id"           SERIAL PRIMARY KEY,
+    "issue_number" INTEGER NOT NULL,
+    "eip_number"   INTEGER NOT NULL,
+    "series"       TEXT,
+    "call_number"  TEXT,
+    "issue_title"  TEXT,
+    "issue_url"    TEXT,
+    "issue_state"  TEXT,
+    "occurs_on"    DATE,
+    "source"       TEXT NOT NULL,
+    "mentioned_by" TEXT NOT NULL DEFAULT '',
+    "snippet"      TEXT,
+    "source_url"   TEXT,
+    "mentioned_at" TIMESTAMPTZ(6),
+    "created_at"   TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"   TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- One row per (issue, eip, source, author): the same EIP can legitimately be
+-- raised by different people on the same agenda, and each mention carries its
+-- own quote. mentioned_by is NOT NULL DEFAULT '' so it participates in the key —
+-- NULLs never conflict in Postgres and would duplicate on every scheduler cycle.
+CREATE UNIQUE INDEX IF NOT EXISTS "pm_agenda_eips_unique"
+    ON "pm_agenda_eips" ("issue_number", "eip_number", "source", "mentioned_by");
+
+CREATE INDEX IF NOT EXISTS "pm_agenda_eips_eip_number_idx" ON "pm_agenda_eips" ("eip_number");
+CREATE INDEX IF NOT EXISTS "pm_agenda_eips_series_idx"     ON "pm_agenda_eips" ("series");
+CREATE INDEX IF NOT EXISTS "pm_agenda_eips_occurs_on_idx"  ON "pm_agenda_eips" ("occurs_on");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -437,6 +437,46 @@ model protocol_calls_upcoming {
   @@index([occurs_on])
 }
 
+/// EIPs referenced in ethereum/pm ACD agenda issues (body + comments).
+///
+/// Agenda issue bodies are near-empty templates ("- Glam / - Hegotá / - Misc"),
+/// so the useful signal lives in the comments, where people write things like
+/// "I'd like to PFI EIP-8115 ... for the EL side of Hegotá". We record each
+/// (issue, eip) pair with the quote and author so the board can show *why* an
+/// EIP is on an agenda, not just that it is.
+///
+/// Written by the scheduler, read by the app's /board ACD Agenda tab.
+model pm_agenda_eips {
+  id           Int       @id @default(autoincrement())
+  issue_number Int
+  eip_number   Int
+  /// Call series slug (acde/acdc/acdt/acdtcl); null when it can't be derived.
+  series       String?
+  call_number  String?
+  issue_title  String?
+  issue_url    String?
+  issue_state  String?
+  occurs_on    DateTime? @db.Date
+  /// 'body' | 'comment' — where the reference was found.
+  source       String
+  /// GitHub login of whoever wrote the body/comment. Empty string (not null) when
+  /// unknown, so it participates in the unique key — NULLs never conflict in
+  /// Postgres and would let every scheduler cycle insert a duplicate.
+  mentioned_by String    @default("")
+  /// Short surrounding quote, for context in the UI.
+  snippet      String?
+  /// Permalink to the specific comment (or the issue, for body matches).
+  source_url   String?
+  mentioned_at DateTime? @db.Timestamptz(6)
+  created_at   DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at   DateTime  @default(now()) @db.Timestamptz(6)
+
+  @@unique([issue_number, eip_number, source, mentioned_by])
+  @@index([eip_number])
+  @@index([series])
+  @@index([occurs_on])
+}
+
 /// Devnet specs scraped by the scheduler from ethpandaops HackMD notes
 /// (+ live status from cartographoor). Scheduler-owned; no app migrations.
 model devnet_specs {

--- a/src/app/(tools)/board/_components/agenda-prs-panel.tsx
+++ b/src/app/(tools)/board/_components/agenda-prs-panel.tsx
@@ -1,0 +1,396 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import {
+  CalendarClock,
+  ChevronDown,
+  ExternalLink,
+  Github,
+  MessageSquareQuote,
+  Search,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { client } from '@/lib/orpc';
+
+/**
+ * "On an ACD agenda" board tab.
+ *
+ * Agenda issues on ethereum/pm name EIPs, not PRs — and their bodies are mostly
+ * empty templates, so the real references come from the comments. The scheduler
+ * extracts those into pm_agenda_eips; this panel joins them to currently-open
+ * PRs so an editor can see which of their queue is about to be discussed.
+ *
+ * Mentions are shown verbatim with author and source link: "I'd like to PFI
+ * EIP-8115" is a request, not a decision, so the UI must not present it as one.
+ */
+
+type Mention = {
+  issueNumber: number;
+  issueTitle: string | null;
+  issueUrl: string | null;
+  series: string | null;
+  callNumber: string | null;
+  occursOn: string | Date | null;
+  mentionedBy: string | null;
+  snippet: string | null;
+  source: string;
+  sourceUrl: string | null;
+  eip: number;
+};
+
+type Row = {
+  prNumber: number;
+  title: string;
+  author: string | null;
+  repo: string;
+  createdAt: string;
+  eipNumbers: number[];
+  nextCallOn: string | Date | null;
+  mentions: Mention[];
+};
+
+const SERIES = [
+  { key: '', label: 'All ACD' },
+  { key: 'acde', label: 'ACDE' },
+  { key: 'acdc', label: 'ACDC' },
+  { key: 'acdt', label: 'ACDT' },
+  { key: 'acdtcl', label: 'ACDT-CL' },
+] as const;
+
+const SERIES_BADGE: Record<string, string> = {
+  acde: 'border-emerald-500/30 bg-emerald-500/15 text-emerald-700 dark:text-emerald-300',
+  acdc: 'border-blue-500/30 bg-blue-500/15 text-blue-700 dark:text-blue-300',
+  acdt: 'border-cyan-500/30 bg-cyan-500/15 text-cyan-700 dark:text-cyan-300',
+  acdtcl: 'border-violet-500/30 bg-violet-500/15 text-violet-700 dark:text-violet-300',
+};
+
+const REPO_PATH: Record<string, string> = { eips: 'EIPs', ercs: 'ERCs', rips: 'RIPs' };
+
+/**
+ * Format a call date. The API returns plain 'YYYY-MM-DD' strings, but this stays
+ * tolerant of Date objects too: node-postgres hydrates DATE columns into Dates,
+ * so any query that forgets TO_CHAR would otherwise crash on `.slice`.
+ */
+function formatDate(value: string | Date | null | undefined): string {
+  if (!value) return '—';
+  const iso = value instanceof Date ? value.toISOString() : String(value);
+  const day = iso.slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return '—';
+  // Parsed and rendered as UTC so the calendar day can't shift by timezone.
+  return new Date(`${day}T00:00:00Z`).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+export function AgendaPrsPanel() {
+  const [series, setSeries] = useState<string>('');
+  const [window, setWindow] = useState<'upcoming' | 'all'>('all');
+  const [search, setSearch] = useState('');
+  const [debounced, setDebounced] = useState('');
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<{
+    ready: boolean;
+    total: number;
+    totalPages: number;
+    rows: Row[];
+  } | null>(null);
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(search), 300);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  // Filter changes reset paging in the handlers rather than via an effect on
+  // [series, window, debounced] — that effect would setState synchronously on
+  // every filter change, which the React Compiler flags as cascading renders.
+  const changeSeries = (next: string) => {
+    setSeries(next);
+    setPage(1);
+  };
+  const changeWindow = (next: 'upcoming' | 'all') => {
+    setWindow(next);
+    setPage(1);
+  };
+  const changeSearch = (next: string) => {
+    setSearch(next);
+    setPage(1);
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async () => {
+      // Yield a microtask first so the setState calls below are not synchronous
+      // within the effect body (React Compiler rule); still lands in this frame.
+      await Promise.resolve();
+      if (cancelled) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await client.tools.getAgendaPRs({
+          series: (series || undefined) as 'acde' | 'acdc' | 'acdt' | 'acdtcl' | undefined,
+          window,
+          search: debounced || undefined,
+          page,
+          pageSize: 25,
+        });
+        if (!cancelled) setData(res as { ready: boolean; total: number; totalPages: number; rows: Row[] });
+      } catch (e) {
+        // Most likely cause before the migration is applied: pm_agenda_eips missing.
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load agenda PRs');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [series, window, debounced, page]);
+
+  const rows = useMemo(() => data?.rows ?? [], [data]);
+
+  return (
+    <div className="space-y-4">
+      {/* Filters */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap items-center gap-1.5">
+          {SERIES.map((s) => (
+            <button
+              key={s.key || 'all'}
+              type="button"
+              onClick={() => changeSeries(s.key)}
+              className={cn(
+                'inline-flex h-8 items-center rounded-md border px-2.5 text-xs font-medium transition-colors',
+                series === s.key
+                  ? 'border-primary/50 bg-primary/10 text-foreground'
+                  : 'border-border bg-card/70 text-muted-foreground hover:border-primary/40'
+              )}
+            >
+              {s.label}
+            </button>
+          ))}
+          <span className="mx-1 h-5 w-px bg-border" aria-hidden />
+          <button
+            type="button"
+            onClick={() => changeWindow(window === 'all' ? 'upcoming' : 'all')}
+            className={cn(
+              'inline-flex h-8 items-center gap-1.5 rounded-md border px-2.5 text-xs font-medium transition-colors',
+              window === 'upcoming'
+                ? 'border-primary/50 bg-primary/10 text-foreground'
+                : 'border-border bg-card/70 text-muted-foreground hover:border-primary/40'
+            )}
+            title="Only agendas for calls that haven't happened yet"
+          >
+            <CalendarClock className="h-3.5 w-3.5" />
+            Upcoming calls only
+          </button>
+        </div>
+
+        <div className="relative w-full sm:max-w-xs">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            value={search}
+            onChange={(e) => changeSearch(e.target.value)}
+            placeholder="Search PR, author, EIP…"
+            className="h-9 w-full rounded-lg border border-border bg-background pl-9 pr-3 text-sm outline-none transition-colors focus:border-primary/50 focus:ring-2 focus:ring-primary/20"
+          />
+        </div>
+      </div>
+
+      {error ? (
+        <div className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-6 text-sm">
+          <p className="font-medium text-foreground">Couldn&apos;t load agenda PRs.</p>
+          <p className="mt-2 font-mono text-xs text-muted-foreground">{error}</p>
+        </div>
+      ) : data && !data.ready ? (
+        // Distinct from an error: the table simply hasn't been created yet.
+        <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-6 text-sm">
+          <p className="font-medium text-foreground">Agenda tracking isn&apos;t set up yet.</p>
+          <p className="mt-1 text-muted-foreground">
+            The <code className="font-mono text-xs">pm_agenda_eips</code> table hasn&apos;t been
+            created. Run <code className="font-mono text-xs">bunx prisma migrate deploy</code>, then
+            let the scheduler run once to populate it.
+          </p>
+        </div>
+      ) : loading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="h-16 animate-pulse rounded-xl border border-border bg-card/60" />
+          ))}
+        </div>
+      ) : rows.length === 0 ? (
+        <p className="rounded-xl border border-border bg-card/60 px-4 py-8 text-center text-sm text-muted-foreground">
+          No open PRs are linked to an ACD agenda{series ? ` for ${series.toUpperCase()}` : ''}
+          {window === 'upcoming' ? ' in an upcoming call' : ''}.
+        </p>
+      ) : (
+        <>
+          <p className="text-xs text-muted-foreground">
+            <span className="font-semibold text-foreground">{data?.total ?? 0}</span> open{' '}
+            {data?.total === 1 ? 'PR is' : 'PRs are'} linked to an EIP mentioned on an ACD agenda.
+          </p>
+
+          <div className="overflow-hidden rounded-xl border border-border bg-card/60">
+            <ul className="divide-y divide-border/60">
+              {rows.map((row) => {
+                const isOpen = expanded === row.prNumber;
+                return (
+                  <li key={`${row.repo}-${row.prNumber}`} className="text-sm">
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-3">
+                      <a
+                        href={`https://github.com/ethereum/${REPO_PATH[row.repo] ?? 'EIPs'}/pull/${row.prNumber}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex shrink-0 items-center gap-1 font-mono text-xs font-semibold text-primary hover:underline"
+                      >
+                        <Github className="h-3.5 w-3.5" />#{row.prNumber}
+                      </a>
+
+                      <span className="min-w-0 flex-1 truncate text-foreground">{row.title}</span>
+
+                      <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
+                        @{row.author ?? 'unknown'}
+                      </span>
+
+                      <span className="inline-flex shrink-0 flex-wrap items-center gap-1">
+                        {row.eipNumbers.slice(0, 4).map((n) => (
+                          <Link
+                            key={n}
+                            href={`/eips/${n}`}
+                            className="rounded-full border border-border bg-muted/40 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground hover:border-primary/40 hover:text-primary"
+                          >
+                            {n}
+                          </Link>
+                        ))}
+                        {row.eipNumbers.length > 4 && (
+                          <span className="text-[10px] text-muted-foreground">
+                            +{row.eipNumbers.length - 4}
+                          </span>
+                        )}
+                      </span>
+
+                      {row.nextCallOn && (
+                        <span
+                          className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-foreground"
+                          title="Next call whose agenda mentions this EIP"
+                        >
+                          <CalendarClock className="h-3.5 w-3.5 text-primary" />
+                          {formatDate(row.nextCallOn)}
+                        </span>
+                      )}
+
+                      <button
+                        type="button"
+                        onClick={() => setExpanded(isOpen ? null : row.prNumber)}
+                        aria-expanded={isOpen}
+                        className="inline-flex shrink-0 items-center gap-1 rounded-md border border-border bg-muted/40 px-2 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary"
+                      >
+                        {row.mentions.length} mention{row.mentions.length === 1 ? '' : 's'}
+                        <ChevronDown
+                          className={cn('h-3 w-3 transition-transform', isOpen && 'rotate-180')}
+                        />
+                      </button>
+                    </div>
+
+                    {isOpen && (
+                      <div className="space-y-2 border-t border-border/50 bg-muted/20 px-4 py-3">
+                        {row.mentions.map((m, i) => (
+                          <div key={i} className="flex gap-2 text-xs">
+                            <MessageSquareQuote className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                            <div className="min-w-0">
+                              <div className="flex flex-wrap items-center gap-1.5">
+                                {m.series && (
+                                  <span
+                                    className={cn(
+                                      'rounded-full border px-1.5 py-0.5 text-[10px] font-semibold uppercase',
+                                      SERIES_BADGE[m.series] ??
+                                        'border-border bg-muted text-muted-foreground'
+                                    )}
+                                  >
+                                    {m.series}
+                                    {m.callNumber ? ` #${m.callNumber}` : ''}
+                                  </span>
+                                )}
+                                <span className="text-muted-foreground">
+                                  {formatDate(m.occursOn)}
+                                </span>
+                                {m.mentionedBy && (
+                                  <span className="text-muted-foreground">
+                                    · raised by{' '}
+                                    <span className="font-medium text-foreground">
+                                      @{m.mentionedBy}
+                                    </span>
+                                  </span>
+                                )}
+                                <span className="rounded bg-muted px-1 py-0.5 text-[10px] text-muted-foreground">
+                                  EIP-{m.eip} · {m.source}
+                                </span>
+                                {m.sourceUrl && (
+                                  <a
+                                    href={m.sourceUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="inline-flex items-center gap-0.5 text-primary hover:underline"
+                                  >
+                                    view
+                                    <ExternalLink className="h-3 w-3" />
+                                  </a>
+                                )}
+                              </div>
+                              {m.snippet && (
+                                <p className="mt-1 border-l-2 border-border pl-2 italic text-muted-foreground">
+                                  “{m.snippet}”
+                                </p>
+                              )}
+                            </div>
+                          </div>
+                        ))}
+                        <p className="pl-5 text-[10px] text-muted-foreground/70">
+                          Mentions are quoted from ethereum/pm agenda issues — a request to discuss,
+                          not a decision.
+                        </p>
+                      </div>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+
+          {(data?.totalPages ?? 1) > 1 && (
+            <div className="flex items-center justify-between text-xs">
+              <button
+                type="button"
+                disabled={page <= 1}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                className="rounded-md border border-border px-2.5 py-1 disabled:opacity-40"
+              >
+                Previous
+              </button>
+              <span className="text-muted-foreground">
+                Page {page} of {data?.totalPages}
+              </span>
+              <button
+                type="button"
+                disabled={page >= (data?.totalPages ?? 1)}
+                onClick={() => setPage((p) => p + 1)}
+                className="rounded-md border border-border px-2.5 py-1 disabled:opacity-40"
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/(tools)/board/page.tsx
+++ b/src/app/(tools)/board/page.tsx
@@ -3,6 +3,7 @@
 import React, { Suspense, useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { client } from "@/lib/orpc";
+import { AgendaPrsPanel } from "./_components/agenda-prs-panel";
 import {
   AlertTriangle,
   ArrowDown,
@@ -197,6 +198,9 @@ function BoardBrowser() {
     return s === "pr" || s === "created" || s === "wait" ? s : DEFAULT_SORT;
   });
   const [sortDir, setSortDir] = useState<SortDir>(() => (searchParams.get("dir") === "asc" ? "asc" : "desc"));
+  const [tab, setTab] = useState<"queue" | "agenda">(() =>
+    searchParams.get("tab") === "agenda" ? "agenda" : "queue",
+  );
   const [needsAttention, setNeedsAttention] = useState(() => searchParams.get("attn") === "1");
   const [hasConflicts, setHasConflicts] = useState(() => searchParams.get("conflict") === "1");
 
@@ -534,6 +538,40 @@ function BoardBrowser() {
       </div>
 
       <div className="mx-auto max-w-7xl space-y-4 px-4 py-5 sm:px-6">
+        {/* Tabs. The ACD panel owns its own filters/paging, so the whole board body
+            below is skipped when it's active rather than trying to share state. */}
+        <div
+          role="tablist"
+          aria-label="Board views"
+          className="flex items-center gap-1 border-b border-border"
+        >
+          {(
+            [
+              { key: "queue", label: "Editorial queue" },
+              { key: "agenda", label: "On an ACD agenda" },
+            ] as const
+          ).map((t) => (
+            <button
+              key={t.key}
+              role="tab"
+              aria-selected={tab === t.key}
+              onClick={() => setTab(t.key)}
+              className={cn(
+                "-mb-px border-b-2 px-3 py-2 text-sm font-medium transition-colors",
+                tab === t.key
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+
+        {tab === "agenda" ? (
+          <AgendaPrsPanel />
+        ) : (
+        <>
         <section className="rounded-xl border border-border bg-card/60 p-3 sm:p-4">
           <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-12">
             <div className="relative lg:col-span-5">
@@ -956,6 +994,8 @@ function BoardBrowser() {
               </PgBtn>
             </div>
           </div>
+        )}
+        </>
         )}
       </div>
     </div>

--- a/src/server/orpc/procedures/tools.ts
+++ b/src/server/orpc/procedures/tools.ts
@@ -694,4 +694,144 @@ const { repo, govState, search } = input;
         bucket: r.bucket as 'final' | 'lastcall' | 'review' | 'glamsterdam' | 'draft',
       }));
     }),
+
+  /**
+   * Open PRs whose EIPs were referenced on an ACD agenda (ethereum/pm).
+   *
+   * Agenda issues name EIPs, not PRs — so the join is
+   *   pm_agenda_eips.eip_number -> pull_request_eips -> pull_requests (open only).
+   * One row per PR, with every agenda that mentioned its EIP aggregated into
+   * `mentions` so an editor can see which call it is queued for and who raised it.
+   */
+  getAgendaPRs: optionalAuthProcedure
+    .input(
+      z.object({
+        /** Filter to one ACD series (acde/acdc/acdt/acdtcl). */
+        series: z.enum(['acde', 'acdc', 'acdt', 'acdtcl']).optional(),
+        /** 'upcoming' = agendas for calls not yet held; 'all' includes past calls. */
+        window: z.enum(['upcoming', 'all']).default('all'),
+        search: z.string().optional(),
+        page: z.number().min(1).default(1),
+        pageSize: z.number().min(1).max(100).default(25),
+      })
+    )
+    .handler(async ({ input }) => {
+      const { series, window, search, page, pageSize } = input;
+      const offset = (page - 1) * pageSize;
+      const q = search?.trim() ?? '';
+
+      // pm_agenda_eips is created by a migration and filled by the scheduler, so
+      // between deploying this code and running either one the table is simply
+      // absent. That's an expected setup state, not a server fault — report it as
+      // `ready: false` so the UI can explain it instead of surfacing a 500.
+      const [{ exists }] = await prisma.$queryRawUnsafe<Array<{ exists: boolean }>>(
+        `SELECT to_regclass('public.pm_agenda_eips') IS NOT NULL AS exists`
+      );
+      if (!exists) {
+        return { ready: false as const, total: 0, totalPages: 1, rows: [] };
+      }
+
+      const rows = await prisma.$queryRawUnsafe<Array<{
+        pr_number: number;
+        title: string;
+        author: string | null;
+        repo_short: string;
+        created_at: string;
+        eip_numbers: number[];
+        mentions: unknown;
+        next_call_on: string | null;
+        total_count: bigint;
+      }>>(
+        `
+        WITH agenda AS (
+          SELECT a.*
+          FROM pm_agenda_eips a
+          WHERE ($1::text IS NULL OR a.series = $1)
+            -- "upcoming" keys off the call date, not issue state: an agenda issue
+            -- can be closed while its call is still ahead, and vice versa.
+            AND ($2::text = 'all' OR a.occurs_on >= CURRENT_DATE)
+        ),
+        matched AS (
+          SELECT
+            p.pr_number,
+            p.title,
+            p.author,
+            LOWER(SPLIT_PART(r.name, '/', 2)) AS repo_short,
+            TO_CHAR(p.created_at, 'YYYY-MM-DD') AS created_at,
+            pe.eip_number,
+            a.issue_number, a.issue_title, a.issue_url, a.series, a.call_number,
+            a.occurs_on, a.mentioned_by, a.snippet, a.source, a.source_url
+          FROM agenda a
+          JOIN pull_request_eips pe ON pe.eip_number = a.eip_number
+          JOIN pull_requests p
+            ON p.pr_number = pe.pr_number AND p.repository_id = pe.repository_id
+          JOIN repositories r ON r.id = p.repository_id
+          WHERE p.state = 'open'
+            AND ($3::text = '' OR p.title ILIKE '%' || $3 || '%'
+                 OR p.author ILIKE '%' || $3 || '%'
+                 OR CAST(pe.eip_number AS text) ILIKE '%' || $3 || '%')
+        ),
+        grouped AS (
+          SELECT
+            pr_number, title, author, repo_short, created_at,
+            ARRAY_AGG(DISTINCT eip_number) AS eip_numbers,
+            -- TO_CHAR, not the bare DATE: node-postgres hydrates DATE columns into
+            -- JS Date objects at local midnight, so a 2025-03-13 call comes back as
+            -- 2025-03-12T18:30Z under a +05:30 offset and renders as the wrong day.
+            -- A plain YYYY-MM-DD string has no timezone to get wrong.
+            TO_CHAR(
+              MIN(occurs_on) FILTER (WHERE occurs_on >= CURRENT_DATE), 'YYYY-MM-DD'
+            ) AS next_call_on,
+            JSON_AGG(DISTINCT JSONB_BUILD_OBJECT(
+              'issueNumber', issue_number, 'issueTitle', issue_title,
+              'issueUrl', issue_url, 'series', series, 'callNumber', call_number,
+              'occursOn', TO_CHAR(occurs_on, 'YYYY-MM-DD'), 'mentionedBy', mentioned_by,
+              'snippet', snippet, 'source', source, 'sourceUrl', source_url,
+              'eip', eip_number
+            )) AS mentions
+          FROM matched
+          GROUP BY pr_number, title, author, repo_short, created_at
+        )
+        SELECT *, COUNT(*) OVER()::bigint AS total_count
+        FROM grouped
+        -- Calls happening soonest first; PRs with no upcoming call fall to the end.
+        ORDER BY next_call_on ASC NULLS LAST, pr_number DESC
+        LIMIT $4 OFFSET $5
+        `,
+        series ?? null,
+        window,
+        q,
+        pageSize,
+        offset
+      );
+
+      const total = rows.length > 0 ? Number(rows[0].total_count) : 0;
+      return {
+        ready: true as const,
+        total,
+        totalPages: Math.max(1, Math.ceil(total / pageSize)),
+        rows: rows.map((r) => ({
+          prNumber: r.pr_number,
+          title: r.title,
+          author: r.author,
+          repo: r.repo_short,
+          createdAt: r.created_at,
+          eipNumbers: r.eip_numbers ?? [],
+          nextCallOn: r.next_call_on,
+          mentions: (r.mentions ?? []) as Array<{
+            issueNumber: number;
+            issueTitle: string | null;
+            issueUrl: string | null;
+            series: string | null;
+            callNumber: string | null;
+            occursOn: string | null;
+            mentionedBy: string | null;
+            snippet: string | null;
+            source: string;
+            sourceUrl: string | null;
+            eip: number;
+          }>,
+        })),
+      };
+    }),
 };


### PR DESCRIPTION
This pull request introduces a new "On an ACD agenda" tab to the board tool, allowing editors to see which open PRs are linked to EIPs mentioned on Ethereum/pm All Core Devs (ACD) agendas. It adds a new database table and Prisma model to track these EIP mentions, and implements a fully-featured UI panel for filtering, searching, and viewing agenda-linked PRs.

**Database and Schema Changes:**

* Added a new table `pm_agenda_eips` to store references to EIPs mentioned in ACD agenda issues and comments, including fields for issue details, EIP number, call series, author, source, and a snippet for context. Created unique and supporting indexes for efficient querying.
* Added a corresponding Prisma model `pm_agenda_eips` with detailed documentation, ensuring the schema matches the new table and supports queries from the UI.

**Board UI and Functionality:**

* Implemented the `AgendaPrsPanel` React component, which displays open PRs linked to agenda EIPs, with filters for call series, upcoming/all calls, search, pagination, and expandable mention details. Handles loading, error, and empty states gracefully.
* Integrated the new panel into the board tool by adding a tabbed interface, allowing users to switch between the editorial queue and the new ACD agenda view. The agenda panel manages its own filters and paging. [[1]](diffhunk://#diff-84bdeb9a096a7b4f27519e6a7ed947edccdfae6f4059805f8d4e708af04218c9R201-R203) [[2]](diffhunk://#diff-84bdeb9a096a7b4f27519e6a7ed947edccdfae6f4059805f8d4e708af04218c9R541-R574) [[3]](diffhunk://#diff-84bdeb9a096a7b4f27519e6a7ed947edccdfae6f4059805f8d4e708af04218c9R998-R999)
* Registered the new panel component in the board page for rendering.