### PR TITLE
Sync agenda filters with URL parameters for shareable links

### DIFF
--- a/src/app/(tools)/board/_components/agenda-prs-panel.tsx
+++ b/src/app/(tools)/board/_components/agenda-prs-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import {
   CalendarClock,
   ChevronDown,
@@ -87,11 +88,20 @@ function formatDate(value: string | Date | null | undefined): string {
 }
 
 export function AgendaPrsPanel() {
-  const [series, setSeries] = useState<string>('');
-  const [window, setWindow] = useState<'upcoming' | 'all'>('all');
-  const [search, setSearch] = useState('');
-  const [debounced, setDebounced] = useState('');
-  const [page, setPage] = useState(1);
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const [series, setSeries] = useState<string>(() => {
+    const s = searchParams.get('series') || searchParams.get('acd_series');
+    return s && ['acde', 'acdc', 'acdt', 'acdtcl'].includes(s) ? s : '';
+  });
+  const [window, setWindow] = useState<'upcoming' | 'all'>(() => {
+    return searchParams.get('window') === 'upcoming' ? 'upcoming' : 'all';
+  });
+  const [search, setSearch] = useState(() => searchParams.get('acd_q') || '');
+  const [debounced, setDebounced] = useState(() => searchParams.get('acd_q') || '');
+  const [page, setPage] = useState(() => Math.max(1, Number(searchParams.get('acd_page')) || 1));
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [data, setData] = useState<{
@@ -106,6 +116,22 @@ export function AgendaPrsPanel() {
     const t = setTimeout(() => setDebounced(search), 300);
     return () => clearTimeout(t);
   }, [search]);
+
+  // Mirror agenda state to URL search parameters so sharing links retains tab + filters
+  useEffect(() => {
+    const p = new URLSearchParams(searchParams.toString());
+    p.set('tab', 'agenda');
+    if (series) p.set('series', series);
+    else p.delete('series');
+    if (window !== 'all') p.set('window', window);
+    else p.delete('window');
+    if (debounced) p.set('acd_q', debounced);
+    else p.delete('acd_q');
+    if (page > 1) p.set('acd_page', String(page));
+    else p.delete('acd_page');
+    const qs = p.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  }, [series, window, debounced, page, pathname, router, searchParams]);
 
   // Filter changes reset paging in the handlers rather than via an effect on
   // [series, window, debounced] — that effect would setState synchronously on

--- a/src/app/(tools)/board/page.tsx
+++ b/src/app/(tools)/board/page.tsx
@@ -231,6 +231,13 @@ function BoardBrowser() {
 
   // Mirror state into the URL so "Copy link" (and browser back/refresh) actually work.
   useEffect(() => {
+    if (tab === "agenda") {
+      const p = new URLSearchParams(searchParams.toString());
+      p.set("tab", "agenda");
+      const qs = p.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+      return;
+    }
     const p = new URLSearchParams();
     if (repo) p.set("repo", repo);
     if (selectedGovStates.length === 0) p.set("status", "none");
@@ -245,7 +252,7 @@ function BoardBrowser() {
     if (hasConflicts) p.set("conflict", "1");
     const qs = p.toString();
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
-  }, [repo, selectedGovStates, selectedProcessTypes, debouncedSearch, page, pageSize, sortBy, sortDir, needsAttention, hasConflicts, pathname, router]);
+  }, [tab, repo, selectedGovStates, selectedProcessTypes, debouncedSearch, page, pageSize, sortBy, sortDir, needsAttention, hasConflicts, pathname, router, searchParams]);
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
This pull request improves the way agenda panel state is synchronized with the URL in the board tool, enabling deep linking and better navigation. The changes ensure that filters, search, and pagination in the agenda view are reflected in the URL, so users can share links that retain their current view and use browser navigation as expected.

**Agenda panel state synchronization:**

* The `AgendaPrsPanel` component now initializes its state (`series`, `window`, `search`, `debounced`, and `page`) from URL search parameters, allowing direct linking to specific filter and search states.
* A new `useEffect` in `AgendaPrsPanel` mirrors the current agenda state to the URL search parameters, updating the browser history without scrolling, so sharing and navigation work seamlessly.
* Imports for `usePathname`, `useRouter`, and `useSearchParams` from `next/navigation` were added to support this synchronization.

**Board browser navigation consistency:**

* In the `BoardBrowser` component, the URL is updated with the `tab=agenda` parameter when the agenda tab is active, ensuring the correct tab is reflected in the URL for sharing and navigation.
* The dependency list for the effect updating the URL in `BoardBrowser` was expanded to include `tab` and `searchParams`, ensuring the effect runs when these values change.