### PR TITLE
Add EIP Directory search component with quick jump links

### DIFF
--- a/src/app/upgrade/page.tsx
+++ b/src/app/upgrade/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { ArrowRight, Archive, BarChart2, CalendarClock, GitCommit, Info, Package, Star, Zap } from 'lucide-react';
+import { ArrowRight, ArrowUpRight, Archive, BarChart2, CalendarClock, GitCommit, Info, Package, Search, Star, Zap } from 'lucide-react';
 import { CopyLinkButton } from '@/components/header';
 import { TOTAL_NETWORK_UPGRADES } from '@/data/upgrade-timeline-stats';
 import '@/lib/orpc.server';
@@ -21,18 +21,13 @@ import {
 import { getCurrentPhase } from '@/data/fork-schedule';
 import {
   getCachedRecentActivity,
-  getCachedRecentCalls,
-  getCachedUpcomingCalls,
   getCachedUpgradeComposition,
   getCachedUpgradeList,
   getCachedUpgradeStats,
 } from '@/lib/upgrade-data.server';
-import {
-  callDisplayName,
-  callSeriesBadgeClass,
-  callSeriesShort,
-} from '@/data/call-series';
 import { UpgradeTimelineStrip } from '@/components/upgrade/upgrade-timeline-strip';
+import { EipDirectorySearch } from '@/components/upgrade/eip-directory-search';
+import { ScheduleTimelinePreview } from '@/components/upgrade/schedule-timeline-preview';
 import { PhaseBadge, StageBadge, UpgradeStatusBadge } from '@/components/upgrade/stage-badge';
 import { EipInclusionProcessGraph } from '@/components/upgrade/eip-inclusion-process-graph';
 
@@ -150,12 +145,10 @@ export default async function UpgradeIndexPage() {
   // Featured cards: newest live fork + everything in progress.
   const featured = [live[0], ...inProgress].filter(Boolean);
 
-  const [list, stats, activity, recentCalls, upcomingCalls, ...compositions] = await Promise.all([
+  const [list, stats, activity, ...compositions] = await Promise.all([
     getCachedUpgradeList(),
     getCachedUpgradeStats(),
     getCachedRecentActivity(10),
-    getCachedRecentCalls(5),
-    getCachedUpcomingCalls(),
     ...featured.map((entry) => getCachedUpgradeComposition(entry.slug)),
   ]);
 
@@ -203,6 +196,56 @@ export default async function UpgradeIndexPage() {
             />
           ))}
         </div>
+      </section>
+
+      {/* EIP Directory search preview */}
+      <section id="eip-directory">
+        <div className="mb-4 flex flex-wrap items-end justify-between gap-2">
+          <div>
+            <div className="inline-flex items-center gap-2">
+              <Search className="h-5 w-5 text-primary" />
+              <Link
+                href="/upgrade/eips"
+                className="dec-title inline-flex items-center gap-1 text-xl font-semibold tracking-tight text-foreground transition-colors hover:text-primary sm:text-2xl"
+              >
+                Upgrade EIP Directory
+                <ArrowUpRight className="h-4 w-4 shrink-0 text-muted-foreground/50" />
+              </Link>
+              <CopyLinkButton sectionId="eip-directory" tooltipLabel="Copy link" />
+            </div>
+            <p className="mt-0.5 text-sm text-muted-foreground">
+              Search every EIP across all upgrades, or jump straight to a filtered view.
+            </p>
+          </div>
+        </div>
+        <EipDirectorySearch
+          upgradeChips={inProgress
+            .slice(0, 2)
+            .map((entry) => ({ label: entry.name, href: `/upgrade/eips?upgrade=${entry.slug}` }))}
+        />
+      </section>
+
+      {/* Timeline View — schedule preview */}
+      <section id="timeline-view">
+        <div className="mb-4 flex flex-wrap items-end justify-between gap-2">
+          <div>
+            <div className="inline-flex items-center gap-2">
+              <CalendarClock className="h-5 w-5 text-primary" />
+              <Link
+                href="/upgrade/schedule"
+                className="dec-title inline-flex items-center gap-1 text-xl font-semibold tracking-tight text-foreground transition-colors hover:text-primary sm:text-2xl"
+              >
+                Timeline View
+                <ArrowUpRight className="h-4 w-4 shrink-0 text-muted-foreground/50" />
+              </Link>
+              <CopyLinkButton sectionId="timeline-view" tooltipLabel="Copy link" />
+            </div>
+            <p className="mt-0.5 text-sm text-muted-foreground">
+              Upgrade phases and milestones across forks, on a shared calendar.
+            </p>
+          </div>
+        </div>
+        <ScheduleTimelinePreview today={today} />
       </section>
 
       {/* Latest changes */}
@@ -280,102 +323,6 @@ export default async function UpgradeIndexPage() {
                 </li>
               ))}
             </ul>
-          </div>
-        </section>
-      )}
-
-      {/* Protocol calls */}
-      {(recentCalls.length > 0 || upcomingCalls.length > 0) && (
-        <section id="protocol-calls">
-          <div className="mb-4 flex flex-wrap items-end justify-between gap-2">
-            <div>
-              <div className="inline-flex items-center gap-2">
-                <CalendarClock className="h-5 w-5 text-primary" />
-                <h2 className="dec-title text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
-                  Protocol calls
-                </h2>
-                <CopyLinkButton sectionId="protocol-calls" tooltipLabel="Copy link" />
-              </div>
-              <p className="mt-0.5 text-sm text-muted-foreground">
-                Where upgrade decisions happen - agendas, recordings, and summaries.
-              </p>
-            </div>
-            <Link
-              href="/calls"
-              className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
-            >
-              All calls
-              <ArrowRight className="h-3 w-3" />
-            </Link>
-          </div>
-          <div className="grid gap-4 lg:grid-cols-2">
-            {upcomingCalls.length > 0 && (
-              <div className="overflow-hidden rounded-xl border border-border bg-card/60">
-                <h3 className="border-b border-border/60 px-4 py-2.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                  Upcoming
-                </h3>
-                <ul className="divide-y divide-border/60">
-                  {upcomingCalls.slice(0, 4).map((call) => (
-                    <li key={call.issue_number} className="flex items-center gap-3 px-4 py-2.5">
-                      <span
-                        className={cn(
-                          'inline-flex w-14 shrink-0 items-center justify-center rounded-full border px-1.5 py-0.5 text-[10px] font-semibold',
-                          call.series
-                            ? callSeriesBadgeClass(call.series)
-                            : 'border-border bg-muted text-muted-foreground'
-                        )}
-                      >
-                        {call.series ? callSeriesShort(call.series) : '—'}
-                      </span>
-                      <a
-                        href={call.issue_url ?? '#'}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="min-w-0 flex-1 truncate text-sm text-foreground transition-colors hover:text-primary"
-                      >
-                        {call.title}
-                      </a>
-                      <span className="shrink-0 text-[11px] text-muted-foreground">
-                        {call.occurs_on ?? 'TBD'}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            {recentCalls.length > 0 && (
-              <div className="overflow-hidden rounded-xl border border-border bg-card/60">
-                <h3 className="border-b border-border/60 px-4 py-2.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                  Recent
-                </h3>
-                <ul className="divide-y divide-border/60">
-                  {recentCalls.slice(0, 4).map((call) => (
-                    <li
-                      key={`${call.series}-${call.call_id}`}
-                      className="flex items-center gap-3 px-4 py-2.5"
-                    >
-                      <span
-                        className={cn(
-                          'inline-flex w-14 shrink-0 items-center justify-center rounded-full border px-1.5 py-0.5 text-[10px] font-semibold',
-                          callSeriesBadgeClass(call.series)
-                        )}
-                      >
-                        {callSeriesShort(call.series)}
-                      </span>
-                      <Link
-                        href="/calls"
-                        className="min-w-0 flex-1 truncate text-sm text-foreground transition-colors hover:text-primary"
-                      >
-                        {callDisplayName(call)}
-                      </Link>
-                      <span className="shrink-0 text-[11px] text-muted-foreground">
-                        {call.occurred_on}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
           </div>
         </section>
       )}

--- a/src/components/upgrade/eip-directory-search.tsx
+++ b/src/components/upgrade/eip-directory-search.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { Search, ArrowRight } from 'lucide-react';
+
+/** A jump chip that deep-links into the directory with a filter pre-applied. */
+type QuickChip = { label: string; href: string };
+
+// Category shortcuts — the directory reads these exact params (headliner=true,
+// stage=<bucket>, layer=EL|CL). Upgrade chips are passed in from the server so
+// they always reflect the current in-progress forks.
+const CATEGORY_CHIPS: QuickChip[] = [
+  { label: 'Headliners', href: '/upgrade/eips?headliner=true' },
+  { label: 'Included', href: '/upgrade/eips?stage=included' },
+  { label: 'Execution', href: '/upgrade/eips?layer=EL' },
+  { label: 'Consensus', href: '/upgrade/eips?layer=CL' },
+];
+
+/**
+ * Compact search + jump entry point for the Upgrade EIP Directory, embedded on
+ * /upgrade. Typing and submitting sends the query to /upgrade/eips (which reads
+ * `?q=`), and the chips deep-link into the directory with a filter applied —
+ * a preview that hands off to the full tool rather than duplicating it.
+ */
+export function EipDirectorySearch({ upgradeChips = [] }: { upgradeChips?: QuickChip[] }) {
+  const router = useRouter();
+  const [value, setValue] = useState('');
+
+  const submit = (event: React.FormEvent) => {
+    event.preventDefault();
+    const q = value.trim();
+    router.push(q ? `/upgrade/eips?q=${encodeURIComponent(q)}` : '/upgrade/eips');
+  };
+
+  const chips = [...upgradeChips, ...CATEGORY_CHIPS];
+
+  return (
+    <div className="rounded-xl border border-border bg-card/60 p-4 sm:p-5">
+      <form onSubmit={submit} className="flex flex-col gap-2 sm:flex-row">
+        <label className="flex flex-1 items-center gap-3 rounded-lg border border-border bg-background/60 px-4 py-2.5 transition-colors focus-within:border-primary/40">
+          <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <input
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            placeholder="Search EIPs by number, title, author, or status…"
+            className="w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+            aria-label="Search the EIP directory"
+          />
+        </label>
+        <button
+          type="submit"
+          className="inline-flex h-10 items-center justify-center gap-2 rounded-lg persona-gradient px-5 text-sm font-semibold text-black shadow-sm transition-opacity hover:opacity-90"
+        >
+          <Search className="h-4 w-4" />
+          Search
+        </button>
+      </form>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Jump to</span>
+        {chips.map((chip) => (
+          <Link
+            key={chip.href}
+            href={chip.href}
+            className="inline-flex items-center rounded-full border border-border bg-background/60 px-3 py-1 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary"
+          >
+            {chip.label}
+          </Link>
+        ))}
+        <Link
+          href="/upgrade/eips"
+          className="ml-auto inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+        >
+          Browse all EIPs
+          <ArrowRight className="h-3 w-3" />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/upgrade/schedule-timeline-preview.tsx
+++ b/src/components/upgrade/schedule-timeline-preview.tsx
@@ -1,0 +1,87 @@
+import Link from 'next/link';
+import { Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { getUpgradeRegistryEntry } from '@/data/upgrade-registry';
+import {
+  FORK_SCHEDULE_CONFIGS,
+  calculateForkSchedule,
+  groupScheduleIntoPhases,
+} from '@/data/fork-schedule';
+
+/**
+ * Compact preview of the upgrade schedule for the /upgrade landing page: each
+ * in-progress fork's four phases (Scoping → Mainnet) as a status strip, plus its
+ * mainnet target. A read-only teaser that hands off to /upgrade/schedule for the
+ * full milestone-by-milestone view.
+ */
+
+function formatDate(iso: string): string {
+  return new Date(`${iso}T00:00:00Z`).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+export function ScheduleTimelinePreview({ today }: { today: string }) {
+  const forks = FORK_SCHEDULE_CONFIGS.map((config) => {
+    const milestones = calculateForkSchedule(config);
+    const phases = groupScheduleIntoPhases(milestones, today);
+    const name = getUpgradeRegistryEntry(config.slug)?.name ?? config.slug;
+    return { slug: config.slug, name, mainnetTarget: config.mainnetTarget, phases };
+  });
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {forks.map((fork) => (
+        <Link
+          key={fork.slug}
+          href="/upgrade/schedule"
+          className="group flex flex-col gap-3 rounded-xl border border-border bg-card/60 p-4 transition-colors hover:border-primary/40"
+        >
+          <div className="flex items-baseline justify-between gap-2">
+            <span className="dec-title text-base font-semibold text-foreground">{fork.name}</span>
+            <span className="text-xs text-muted-foreground">
+              Mainnet target · {formatDate(fork.mainnetTarget)}
+            </span>
+          </div>
+
+          {/* Phase strip: completed (check) · active (filled) · upcoming (faint). */}
+          <div className="flex items-center gap-1.5">
+            {fork.phases.map((phase, index) => (
+              <div key={phase.id} className="flex flex-1 items-center gap-1.5">
+                <div className="flex flex-1 flex-col gap-1">
+                  <div
+                    className={cn(
+                      'h-1.5 w-full rounded-full',
+                      phase.status === 'completed'
+                        ? 'bg-emerald-500/60'
+                        : phase.status === 'active'
+                          ? 'bg-primary'
+                          : 'bg-muted'
+                    )}
+                  />
+                  <span
+                    className={cn(
+                      'flex items-center gap-1 text-[10px] font-medium',
+                      phase.status === 'upcoming' ? 'text-muted-foreground/60' : 'text-muted-foreground'
+                    )}
+                  >
+                    {phase.status === 'completed' && <Check className="h-2.5 w-2.5 text-emerald-500" />}
+                    {phase.label}
+                  </span>
+                </div>
+                {index < fork.phases.length - 1 && (
+                  <span className="text-muted-foreground/30" aria-hidden>
+                    ·
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/src/data/network-upgrades.ts
+++ b/src/data/network-upgrades.ts
@@ -213,6 +213,10 @@ export const pairedUpgradeNames: Record<string, string> = {
 };
 
 export const rawData: UpgradeData[] = [
+  { date: "2025-12-03", upgrade: "Osaka", layer: "execution", type: "execution", blockNumber: 23935694, eips: ["EIP-7594", "EIP-7823", "EIP-7825", "EIP-7883", "EIP-7917", "EIP-7918", "EIP-7934", "EIP-7939", "EIP-7951"] },
+  { date: "2025-12-03", upgrade: "Fulu", layer: "consensus", type: "consensus", forkEpoch: 411392, eips: ["CONSENSUS"] },
+  { date: "2025-05-07", upgrade: "Prague", layer: "execution", type: "execution", blockNumber: 22431084, eips: ["EIP-2537", "EIP-2935", "EIP-6110", "EIP-7002", "EIP-7251", "EIP-7549", "EIP-7623", "EIP-7685", "EIP-7691", "EIP-7702"] },
+  { date: "2025-05-07", upgrade: "Electra", layer: "consensus", type: "consensus", forkEpoch: 364032, eips: ["CONSENSUS"] },
   { date: "2024-03-13", upgrade: "Cancun", layer: "execution", type: "execution", blockNumber: 19426587, eips: ["EIP-1153", "EIP-4788", "EIP-4844", "EIP-5656", "EIP-6780", "EIP-7516"] },
   { date: "2024-03-13", upgrade: "Deneb", layer: "consensus", type: "consensus", forkEpoch: 269568, eips: ["CONSENSUS", "EIP-7044", "EIP-7045", "EIP-7514"] },
   { date: "2023-04-12", upgrade: "Shanghai", layer: "execution", type: "execution", blockNumber: 17034870, eips: ["EIP-3651", "EIP-3855", "EIP-3860", "EIP-4895"] },
@@ -224,6 +228,7 @@ export const rawData: UpgradeData[] = [
   { date: "2021-10-27", upgrade: "Altair", layer: "consensus", type: "consensus", forkEpoch: 74240, eips: ["CONSENSUS"] },
   { date: "2021-08-05", upgrade: "London", layer: "execution", type: "execution", blockNumber: 12965000, eips: ["EIP-1559", "EIP-3198", "EIP-3529", "EIP-3541", "EIP-3554"] },
   { date: "2021-04-15", upgrade: "Berlin", layer: "execution", type: "execution", blockNumber: 12244000, eips: ["EIP-2565", "EIP-2929", "EIP-2718", "EIP-2930"] },
+  { date: "2020-12-01", upgrade: "Phase 0 (Genesis)", layer: "consensus", type: "beacon_genesis", forkEpoch: 0, eips: ["CONSENSUS"], sr_number: 0 },
   { date: "2020-01-02", upgrade: "Muir Glacier", layer: "execution", type: "execution", blockNumber: 9200000, eips: ["EIP-2384"] },
   { date: "2019-12-07", upgrade: "Istanbul", layer: "execution", type: "execution", blockNumber: 9069000, eips: ["EIP-152", "EIP-1108", "EIP-1344", "EIP-1884", "EIP-2028", "EIP-2200"] },
   { date: "2019-02-28", upgrade: "Petersburg", layer: "execution", type: "execution", blockNumber: 7280000, eips: ["EIP-1283-removed"] },


### PR DESCRIPTION
This pull request introduces two major new features to the `/upgrade` page: a compact EIP Directory search preview and a schedule timeline preview, both designed to improve navigation and provide quick insights into Ethereum network upgrades. Additionally, it cleans up legacy protocol call code and updates the network upgrade data with the latest and historical entries. Below are the most important changes:

**New features on the `/upgrade` page:**

* Added a preview section for the EIP Directory, including a search input and quick filter chips, allowing users to quickly search or jump to filtered EIP lists directly from the upgrade page. This is implemented via the new `EipDirectorySearch` component. [[1]](diffhunk://#diff-5b99c3b7c3f3aa5464f60b5e45188f9896da3e1d03b845fdbacdfe92c29d80d5R201-R250) [[2]](diffhunk://#diff-1e6dd7c6160153ac2121edc990276d8a16beec121b41ef54fdd54aee2e499192R1-R82)
* Introduced a schedule timeline preview section that summarizes the status of each in-progress fork and its mainnet target, using the new `ScheduleTimelinePreview` component. This provides a visual overview and links to the full schedule. [[1]](diffhunk://#diff-5b99c3b7c3f3aa5464f60b5e45188f9896da3e1d03b845fdbacdfe92c29d80d5R201-R250) [[2]](diffhunk://#diff-1ca41fc9fad01818687e494b13cf46d6709a304578d032101cc35f1decb347f6R1-R87)

**Code cleanup and removal:**

* Removed the protocol calls preview section and related data fetching from the `/upgrade` page, simplifying the UI and code by eliminating unused imports and state. [[1]](diffhunk://#diff-5b99c3b7c3f3aa5464f60b5e45188f9896da3e1d03b845fdbacdfe92c29d80d5L24-R30) [[2]](diffhunk://#diff-5b99c3b7c3f3aa5464f60b5e45188f9896da3e1d03b845fdbacdfe92c29d80d5L153-L158) [[3]](diffhunk://#diff-5b99c3b7c3f3aa5464f60b5e45188f9896da3e1d03b845fdbacdfe92c29d80d5L287-L382)

**Data updates:**

* Updated `rawData` in `network-upgrades.ts` to include upcoming (Osaka, Fulu, Prague, Electra) and historical (Phase 0/Genesis) network upgrades, ensuring the upgrade data is current and comprehensive. [[1]](diffhunk://#diff-8d7961e7dc2e21d9c4472feb9ad42cffab947ec555064c5ed4774f25a95328dcR216-R219) [[2]](diffhunk://#diff-8d7961e7dc2e21d9c4472feb9ad42cffab947ec555064c5ed4774f25a95328dcR231)

**Dependency and import adjustments:**

* Added necessary imports for new icons and components, and removed unused imports following the removal of the protocol calls section. [[1]](diffhunk://#diff-5b99c3b7c3f3aa5464f60b5e45188f9896da3e1d03b845fdbacdfe92c29d80d5L2-R2) [[2]](diffhunk://#diff-5b99c3b7c3f3aa5464f60b5e45188f9896da3e1d03b845fdbacdfe92c29d80d5L24-R30)

These changes collectively enhance the `/upgrade` landing page by making it more informative and easier to navigate, while also keeping the upgrade data up to date.