### PR TITLE
Enhance blog post layout with responsive width adjustments

### DIFF
--- a/src/app/(proposal)/[repo]/[number]/page.tsx
+++ b/src/app/(proposal)/[repo]/[number]/page.tsx
@@ -264,6 +264,27 @@ function getBucketBadgeClass(bucket: string | null): string {
   return stageBadgeClass(normalizeUpgradeBucket(bucket));
 }
 
+// Higher = more "active"/advanced. When an EIP sits in several upgrades (e.g.
+// declined in one, then re-proposed in a newer one), the headline inclusion
+// status should surface the live stage, not the dead-end DFI. Per-upgrade stages
+// are still listed separately so the DFI history is preserved.
+function bucketRank(bucket: string | null): number {
+  switch (normalizeUpgradeBucket(bucket)) {
+    case 'included':
+      return 5;
+    case 'scheduled':
+      return 4;
+    case 'considered':
+      return 3;
+    case 'proposed':
+      return 2;
+    case 'declined':
+      return 1;
+    default:
+      return 0;
+  }
+}
+
 function getStatusBadgeClass(status: string | null): string {
   if (!status) return 'border-slate-500/25 bg-slate-500/12 text-slate-700 dark:text-slate-300';
   const norm = status.toLowerCase();
@@ -383,7 +404,17 @@ export default function ProposalDetailPage() {
   const repoPath = normalizedRepo === 'eip' ? 'EIPs' : normalizedRepo === 'erc' ? 'ERCs' : 'RIPs';
   const filePath = normalizedRepo === 'eip' ? 'EIPS' : normalizedRepo === 'erc' ? 'ERCS' : 'RIPS';
   const fileName = `${normalizedRepo}-${number}.md`;
-  const latestUpgrade = upgrades.find((upgrade) => upgrade.bucket.toLowerCase() === 'included') ?? upgrades[0] ?? null;
+  // The "current" upgrade for headline fields: the most active/advanced stage
+  // across all upgrades this EIP appears in (newest as tiebreak), so a DFI in an
+  // older fork doesn't mask a live PFI/CFI/SFI in a newer one.
+  const latestUpgrade =
+    [...upgrades].sort((a, b) => {
+      const rankDiff = bucketRank(b.bucket) - bucketRank(a.bucket);
+      if (rankDiff !== 0) return rankDiff;
+      const at = a.commit_date ? new Date(a.commit_date).getTime() : 0;
+      const bt = b.commit_date ? new Date(b.commit_date).getTime() : 0;
+      return bt - at;
+    })[0] ?? null;
 
   useEffect(() => {
     const fetchData = async () => {
@@ -901,9 +932,20 @@ export default function ProposalDetailPage() {
                               <Link
                                 key={upgrade.upgrade_id}
                                 href={upgrade.slug ? `/upgrade/${upgrade.slug}` : '#'}
-                                className="inline-flex rounded-full border border-border bg-muted/60 px-2 py-0.5 text-[11px] font-medium text-primary hover:border-primary/40 hover:underline"
+                                title={`${upgrade.name}: ${formatInclusionBucket(upgrade.bucket)}`}
+                                className="inline-flex items-center overflow-hidden rounded-full border border-border text-[11px] font-medium transition-colors hover:border-primary/40"
                               >
-                                {upgrade.name || `Upgrade ${upgrade.upgrade_id}`}
+                                <span className="bg-muted/60 px-2 py-0.5 text-primary">
+                                  {upgrade.name || `Upgrade ${upgrade.upgrade_id}`}
+                                </span>
+                                <span
+                                  className={cn(
+                                    'border-l px-2 py-0.5',
+                                    getBucketBadgeClass(upgrade.bucket)
+                                  )}
+                                >
+                                  {formatInclusionBucket(upgrade.bucket)}
+                                </span>
                               </Link>
                             ))}
                           </div>

--- a/src/app/resources/blogs/[slug]/page.tsx
+++ b/src/app/resources/blogs/[slug]/page.tsx
@@ -246,7 +246,7 @@ export default function BlogPostPage() {
           Journal
         </Link>
 
-        <div className="max-w-3xl space-y-5">
+        <div className="max-w-4xl space-y-5">
           {/* Category */}
           {post.category && (
             <Link
@@ -264,7 +264,7 @@ export default function BlogPostPage() {
 
           {/* Excerpt */}
           {post.excerpt && (
-            <p className="max-w-2xl text-pretty text-base leading-relaxed text-muted-foreground sm:text-lg">
+            <p className="max-w-3xl text-pretty text-base leading-relaxed text-muted-foreground sm:text-lg">
               {post.excerpt}
             </p>
           )}
@@ -370,8 +370,9 @@ export default function BlogPostPage() {
       <div className="page-shell pt-12">
         <div className="flex flex-col gap-8 lg:flex-row lg:items-start">
 
-          {/* Article */}
-          <article className="min-w-0 flex-1 max-w-3xl">
+          {/* Article — fills the width left of / beside the sidebar (no max cap,
+              so there's no dead space next to it). */}
+          <article className="min-w-0 flex-1 lg:order-2">
             <div className="prose prose-sm sm:prose-base dark:prose-invert max-w-none
               prose-headings:dec-title prose-headings:font-semibold prose-headings:tracking-tight
               prose-p:text-foreground/90 prose-p:leading-relaxed
@@ -443,8 +444,9 @@ export default function BlogPostPage() {
             </section>
           </article>
 
-          {/* ── Sidebar ── */}
-          <aside className="hidden w-64 shrink-0 lg:sticky lg:top-28 lg:block">
+          {/* ── Sidebar (left of the article on desktop; stays after it in DOM
+              order so mobile shows the article first) ── */}
+          <aside className="hidden w-64 shrink-0 lg:sticky lg:top-28 lg:order-1 lg:block">
             <div className="space-y-8">
 
               {/* Table of contents — a distinct live rail: accent header + icon,


### PR DESCRIPTION
This pull request introduces improvements to the proposal detail page and blog post layout. The main focus is on enhancing how proposal upgrade stages are determined and displayed, as well as refining the blog layout for better content presentation.

**Proposal Detail Page Improvements:**

* Improved logic for determining the "current" upgrade stage of a proposal, ensuring the most active/advanced status is surfaced, even if older upgrades are declined. This prevents outdated statuses from masking live ones. (`bucketRank` function and `latestUpgrade` logic) ([src/app/(proposal)/[repo]/[number]/page.tsxR267-R287](diffhunk://#diff-d2778efaba6f980b03664c91301e04f196ccd05770066bdcd9ed46f04d8ef3a3R267-R287), [src/app/(proposal)/[repo]/[number]/page.tsxL386-R417](diffhunk://#diff-d2778efaba6f980b03664c91301e04f196ccd05770066bdcd9ed46f04d8ef3a3L386-R417))
* Enhanced the display of upgrade badges by splitting the upgrade name and status into separate, styled elements with tooltips for clarity. ([src/app/(proposal)/[repo]/[number]/page.tsxL904-R948](diffhunk://#diff-d2778efaba6f980b03664c91301e04f196ccd05770066bdcd9ed46f04d8ef3a3L904-R948))

**Blog Layout Refinements:**

* Increased the maximum width for blog post content and excerpts to improve readability (`max-w-4xl` and `max-w-3xl`). ([src/app/resources/blogs/[slug]/page.tsxL249-R249](diffhunk://#diff-75fd826776569a7a31dd21ae257c3053f5c8ec9cf3109b338cdf1c55f550406bL249-R249), [src/app/resources/blogs/[slug]/page.tsxL267-R267](diffhunk://#diff-75fd826776569a7a31dd21ae257c3053f5c8ec9cf3109b338cdf1c55f550406bL267-R267))
* Modified the article layout to remove the maximum width cap, allowing the article to fill available space next to the sidebar, and reordered the sidebar for better mobile experience. ([src/app/resources/blogs/[slug]/page.tsxL373-R375](diffhunk://#diff-75fd826776569a7a31dd21ae257c3053f5c8ec9cf3109b338cdf1c55f550406bL373-R375), [src/app/resources/blogs/[slug]/page.tsxL446-R449](diffhunk://#diff-75fd826776569a7a31dd21ae257c3053f5c8ec9cf3109b338cdf1c55f550406bL446-R449))