### PR TITLE
Enhance analytics time range and unify chart color handling

### DIFF
--- a/src/app/analytics/analytics-layout-client.tsx
+++ b/src/app/analytics/analytics-layout-client.tsx
@@ -46,7 +46,7 @@ function downloadFile(content: string, filename: string, mimeType: string) {
   URL.revokeObjectURL(url);
 }
 
-type TimeRange = "7d" | "30d" | "90d" | "1y" | "this_month" | "all" | "custom";
+type TimeRange = "7d" | "15d" | "30d" | "90d" | "1y" | "this_month" | "all" | "custom";
 type RepoFilter = "all" | "eips" | "ercs" | "rips";
 type SnapshotMode = "live" | "snapshot";
 
@@ -125,6 +125,7 @@ export function useAnalyticsExport(
 const timeRangeOptions: { value: TimeRange; label: string }[] = [
   { value: "this_month", label: "This month" },
   { value: "7d", label: "Last 7 days" },
+  { value: "15d", label: "Last 15 days" },
   { value: "30d", label: "Last 30 days" },
   { value: "90d", label: "Last 90 days" },
   { value: "1y", label: "Last year" },

--- a/src/app/analytics/authors/page.tsx
+++ b/src/app/analytics/authors/page.tsx
@@ -78,6 +78,9 @@ function getTimeWindow(
     case "7d":
       from = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
       break;
+    case "15d":
+      from = new Date(now.getTime() - 15 * 24 * 60 * 60 * 1000);
+      break;
     case "30d":
       from = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
       break;
@@ -138,7 +141,7 @@ export default function AuthorsAnalyticsPage() {
       setLoading(true);
       setError(null);
       try {
-        const months = timeRange === "all" ? undefined : timeRange === "7d" ? 3 : timeRange === "30d" ? 6 : timeRange === "90d" ? 12 : 24;
+        const months = timeRange === "all" ? undefined : (timeRange === "7d" || timeRange === "15d") ? 3 : timeRange === "30d" ? 6 : timeRange === "90d" ? 12 : 24;
 
         const [kpisData, cohortData, repoData, topData] = await Promise.all([
           client.analytics.getAuthorKPIs({

--- a/src/app/analytics/contributors/page.tsx
+++ b/src/app/analytics/contributors/page.tsx
@@ -96,6 +96,9 @@ function getTimeWindow(
     case "7d":
       from = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
       break;
+    case "15d":
+      from = new Date(now.getTime() - 15 * 24 * 60 * 60 * 1000);
+      break;
     case "30d":
       from = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
       break;

--- a/src/app/analytics/contributors/page.tsx
+++ b/src/app/analytics/contributors/page.tsx
@@ -371,9 +371,9 @@ export default function ContributorsAnalyticsPage() {
           >
             <ResponsiveContainer>
               <BarChart data={activityByType} layout="vertical">
-                <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
-                <XAxis type="number" stroke="#94a3b8" />
-                <YAxis dataKey="actionType" type="category" stroke="#94a3b8" width={100} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                <XAxis type="number" stroke="var(--muted-foreground)" />
+                <YAxis dataKey="actionType" type="category" stroke="var(--muted-foreground)" width={100} />
                 <ChartTooltip content={<ChartTooltipContent />} />
                 <Bar dataKey="count" radius={[0, 8, 8, 0]}>
                   {activityByType.map((entry, index) => (
@@ -401,9 +401,9 @@ export default function ContributorsAnalyticsPage() {
           >
             <ResponsiveContainer>
               <BarChart data={repoHeatmap}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
-                <XAxis dataKey="repo" stroke="#94a3b8" />
-                <YAxis stroke="#94a3b8" />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                <XAxis dataKey="repo" stroke="var(--muted-foreground)" />
+                <YAxis stroke="var(--muted-foreground)" />
                 <ChartTooltip content={<ChartTooltipContent />} />
                 <Bar dataKey="count" radius={[4, 4, 0, 0]}>
                   {repoHeatmap.map((entry, index) => (

--- a/src/app/analytics/editors/page.tsx
+++ b/src/app/analytics/editors/page.tsx
@@ -143,6 +143,9 @@ function getTimeWindow(
     case "7d":
       from = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
       break;
+    case "15d":
+      from = new Date(now.getTime() - 15 * 24 * 60 * 60 * 1000);
+      break;
     case "30d":
       from = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
       break;

--- a/src/app/analytics/editors/page.tsx
+++ b/src/app/analytics/editors/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState, useMemo, useCallback } from "react";
 import Link from "next/link";
 import { useAnalytics, useAnalyticsExport } from "../analytics-layout-client";
 import { client } from "@/lib/orpc";
+import { CHART_SERIES } from "@/lib/chart-colors";
 import { CANONICAL_EIP_EDITORS } from "@/data/eip-contributor-roles";
 import { 
   Loader2, 
@@ -1306,20 +1307,7 @@ export default function EditorsAnalyticsPage() {
 
   // ECharts Leaderboard Option that reflects active Metric filter
   const leaderboardHeroOption = useMemo(() => {
-    const palette = [
-      "#79d2e8",
-      "#8b7dff",
-      "#ff8a80",
-      "#7ea8ff",
-      "#6f9bff",
-      "#ffd166",
-      "#ff9f68",
-      "#b794f4",
-      "#4fd1c5",
-      "#f687b3",
-      "#90cdf4",
-      "#c6f6d5",
-    ];
+    const palette = CHART_SERIES;
     const ordered = [...leaderboardHeroRows].reverse();
     const maxValue = Math.max(1, ...ordered.map((row) => {
       if (selectedMetric === "reviews") return row.reviews;

--- a/src/app/analytics/eips/page.tsx
+++ b/src/app/analytics/eips/page.tsx
@@ -182,7 +182,7 @@ export default function EIPsAnalyticsPage() {
   const { resolvedTheme } = useTheme();
   const repoParam = repoFilter === "all" ? undefined : repoFilter;
   const throughputMonths =
-    timeRange === "7d"
+    timeRange === "7d" || timeRange === "15d"
       ? 3
       : timeRange === "30d"
         ? 6

--- a/src/app/analytics/prs/page.tsx
+++ b/src/app/analytics/prs/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import ReactECharts from "echarts-for-react";
 import { useAnalytics, useAnalyticsExport } from "../analytics-layout-client";
+import { rangeToMonthWindow, type TimeRange } from "@/lib/analytics-range";
 import { client } from "@/lib/orpc";
 import {
   Loader2,
@@ -126,7 +127,6 @@ interface OpenIssueRow {
   numComments: number;
 }
 
-type TimeRange = "7d" | "30d" | "90d" | "1y" | "this_month" | "all" | "custom";
 type CrossTabMode = "process_x_state" | "state_x_process";
 type OpenPRDistributionMode = "process" | "participants";
 
@@ -149,25 +149,7 @@ const GOVERNANCE_COLORS: Record<string, string> = {
   Uncategorized: "#64748B",
 };
 
-function getMonthWindow(
-  range: TimeRange,
-  customFromMonth?: string,
-  customToMonth?: string,
-): { from?: string; to?: string } {
-  const now = new Date();
-  const to = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
-  if (range === "all") return { from: undefined, to: undefined };
-  if (range === "custom") {
-    return {
-      from: customFromMonth || undefined,
-      to: customToMonth || undefined,
-    };
-  }
-  const monthsBack = range === "this_month" ? 1 : range === "7d" ? 1 : range === "30d" ? 3 : range === "90d" ? 6 : 12;
-  const fromDate = new Date(now.getFullYear(), now.getMonth() - (monthsBack - 1), 1);
-  const from = `${fromDate.getFullYear()}-${String(fromDate.getMonth() + 1).padStart(2, "0")}`;
-  return { from, to };
-}
+const getMonthWindow = rangeToMonthWindow;
 
 function Section({ title, icon, children, action, className, id }: {
   title: string;

--- a/src/app/analytics/reviewers/page.tsx
+++ b/src/app/analytics/reviewers/page.tsx
@@ -729,9 +729,9 @@ export default function ReviewersAnalyticsPage() {
             <div className="relative h-full w-full">
               <ResponsiveContainer>
                 <LineChart data={monthlyTrend}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
-                  <XAxis dataKey="month" stroke="#94a3b8" />
-                  <YAxis stroke="#94a3b8" />
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                  <XAxis dataKey="month" stroke="var(--muted-foreground)" />
+                  <YAxis stroke="var(--muted-foreground)" />
                   <ChartTooltip content={<ChartTooltipContent />} />
                   <Legend />
                   {trendActors.map((actor, idx) => (
@@ -776,9 +776,9 @@ export default function ReviewersAnalyticsPage() {
             <div className="relative h-full w-full">
               <ResponsiveContainer>
                 <BarChart data={cyclesData}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
-                  <XAxis dataKey="cycles" stroke="#94a3b8" label={{ value: "Number of Reviewers", position: "insideBottom", offset: -5 }} />
-                  <YAxis stroke="#94a3b8" />
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                  <XAxis dataKey="cycles" stroke="var(--muted-foreground)" label={{ value: "Number of Reviewers", position: "insideBottom", offset: -5 }} />
+                  <YAxis stroke="var(--muted-foreground)" />
                   <ChartTooltip content={<ChartTooltipContent />} />
                   <Bar dataKey="count" radius={[4, 4, 0, 0]} fill="#22c55e">
                     {cyclesData.map((entry, index) => (
@@ -828,9 +828,9 @@ export default function ReviewersAnalyticsPage() {
           <div className="relative h-full w-full">
             <ResponsiveContainer>
               <LineChart data={monthlyReviewedTrend}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
-                <XAxis dataKey="month" stroke="#94a3b8" />
-                <YAxis stroke="#94a3b8" />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                <XAxis dataKey="month" stroke="var(--muted-foreground)" />
+                <YAxis stroke="var(--muted-foreground)" />
                 <ChartTooltip content={<ChartTooltipContent />} />
                 <Legend />
                 {reviewedTrendActors.map((actor, idx) => (
@@ -881,9 +881,9 @@ export default function ReviewersAnalyticsPage() {
           <div className="relative h-full w-full">
             <ResponsiveContainer>
               <BarChart data={dailyStackedChartData.rows}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
-                <XAxis dataKey="date" stroke="#94a3b8" />
-                <YAxis stroke="#94a3b8" />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                <XAxis dataKey="date" stroke="var(--muted-foreground)" />
+                <YAxis stroke="var(--muted-foreground)" />
                 <ChartTooltip content={<ChartTooltipContent />} />
                 <Legend />
                 {dailyStackedChartData.actors.map((actor, idx) => (
@@ -1010,9 +1010,9 @@ export default function ReviewersAnalyticsPage() {
             <div className="relative h-full w-full">
               <ResponsiveContainer>
                 <BarChart data={reviewerRepoStackedData}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
-                  <XAxis dataKey="repo" stroke="#94a3b8" />
-                  <YAxis stroke="#94a3b8" />
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                  <XAxis dataKey="repo" stroke="var(--muted-foreground)" />
+                  <YAxis stroke="var(--muted-foreground)" />
                   <ChartTooltip content={<ChartTooltipContent />} />
                   <Legend />
                   {OFFICIAL_REVIEWERS.map((reviewer, idx) => (

--- a/src/app/analytics/reviewers/page.tsx
+++ b/src/app/analytics/reviewers/page.tsx
@@ -119,6 +119,9 @@ function getTimeWindow(
     case "7d":
       from = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
       break;
+    case "15d":
+      from = new Date(now.getTime() - 15 * 24 * 60 * 60 * 1000);
+      break;
     case "30d":
       from = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
       break;
@@ -131,7 +134,7 @@ function getTimeWindow(
     default:
       from = new Date(now.getFullYear(), now.getMonth(), 1);
   }
-  
+
   return { from: from.toISOString().split('T')[0], to };
 }
 
@@ -170,7 +173,7 @@ export default function ReviewersAnalyticsPage() {
       setLoading(true);
       setError(null);
       try {
-        const months = timeRange === "7d" ? 3 : timeRange === "30d" ? 6 : timeRange === "90d" ? 12 : 24;
+        const months = (timeRange === "7d" || timeRange === "15d") ? 3 : timeRange === "30d" ? 6 : timeRange === "90d" ? 12 : 24;
         
         const [leaderboardData, trendData, reviewedTrendData, cyclesDataRes, repoData, dailyData, actionDetails] = await Promise.all([
           client.analytics.getReviewersLeaderboard({

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,6 +48,9 @@ html.persona-theme-transition *::after {
   --color-sidebar-primary: var(--sidebar-primary);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar: var(--sidebar);
+  --color-chart-8: var(--chart-8);
+  --color-chart-7: var(--chart-7);
+  --color-chart-6: var(--chart-6);
   --color-chart-5: var(--chart-5);
   --color-chart-4: var(--chart-4);
   --color-chart-3: var(--chart-3);
@@ -113,6 +116,9 @@ html.persona-theme-transition *::after {
   --chart-3: oklch(0.65 0.15 195);
   --chart-4: oklch(0.7 0.12 85);
   --chart-5: oklch(0.6 0.2 330);
+  --chart-6: oklch(0.55 0.2 300);
+  --chart-7: oklch(0.6 0.2 25);
+  --chart-8: oklch(0.55 0.02 260);
   --sidebar: oklch(0.99 0.002 250);
   --sidebar-foreground: oklch(0.2 0.02 260);
   --sidebar-primary: var(--persona-primary);
@@ -159,6 +165,9 @@ html.persona-theme-transition *::after {
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
+  --chart-6: oklch(0.62 0.25 300);
+  --chart-7: oklch(0.65 0.24 25);
+  --chart-8: oklch(0.7 0.03 260);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: var(--persona-primary);

--- a/src/app/insights/review/[year]/client-page.tsx
+++ b/src/app/insights/review/[year]/client-page.tsx
@@ -10,10 +10,11 @@ import {
 import { client } from "@/lib/orpc";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { CHART_SERIES } from "@/lib/chart-colors";
 
 type YearInReviewData = Awaited<ReturnType<typeof client.insights.getYearInReview>>;
 
-const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899'];
+const COLORS = CHART_SERIES;
 
 export default function YearInReviewClient({ year }: { year: number }) {
   const [data, setData] = useState<YearInReviewData | null>(null);

--- a/src/app/insights/weekly/page.tsx
+++ b/src/app/insights/weekly/page.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  ArrowRight,
+  CalendarClock,
+  FileText,
+  GitMerge,
+  Loader2,
+  PhoneCall,
+  ShieldCheck,
+  Sparkles,
+  TrendingUp,
+} from "lucide-react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  LabelList,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { client } from "@/lib/orpc";
+import { cn } from "@/lib/utils";
+import { statusBadgeClass } from "@/lib/proposal-status";
+import { CHART_SERIES, CHART_AXIS, CHART_GRID } from "@/lib/chart-colors";
+import { InlineBrandLoader } from "@/components/inline-brand-loader";
+
+type WeeklyData = Awaited<ReturnType<typeof client.dashboard.getWeeklyRecap>>;
+
+const RANGE_OPTIONS = [
+  { days: 7, label: "7 days" },
+  { days: 15, label: "15 days" },
+  { days: 30, label: "30 days" },
+];
+
+function plural(n: number, one: string, many = `${one}s`): string {
+  return `${n} ${n === 1 ? one : many}`;
+}
+
+/** A short, human sentence summarising the period from the raw counts. */
+function buildNarrative(data: WeeklyData, days: number): string {
+  const parts: string[] = [];
+  if (data.newProposals.length) parts.push(plural(data.newProposals.length, "new proposal"));
+  if (data.statusChanges.length) parts.push(plural(data.statusChanges.length, "status change"));
+  if (data.mergedPRs.length) parts.push(`${plural(data.mergedPRs.length, "PR")} merged`);
+  if (data.editorActions.length) parts.push(plural(data.editorActions.length, "editor action"));
+  if (data.recentCalls.length) parts.push(plural(data.recentCalls.length, "protocol call"));
+
+  if (parts.length === 0) return `A quiet ${days} days — no recorded proposal, PR, or call activity.`;
+
+  const last = parts.pop();
+  const list = parts.length ? `${parts.join(", ")} and ${last}` : last;
+  return `Over the last ${days} days: ${list}.`;
+}
+
+export default function WeeklyStoryPage() {
+  const [days, setDays] = useState(7);
+  const [data, setData] = useState<WeeklyData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    client.dashboard
+      .getWeeklyRecap({ days })
+      .then((d) => {
+        if (!cancelled) setData(d);
+      })
+      .catch(() => {
+        if (!cancelled) setError("Could not load the weekly recap.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [days]);
+
+  const activity = useMemo(() => {
+    if (!data) return [];
+    return [
+      { label: "New proposals", value: data.newProposals.length },
+      { label: "Status changes", value: data.statusChanges.length },
+      { label: "PRs merged", value: data.mergedPRs.length },
+      { label: "Editor actions", value: data.editorActions.length },
+    ];
+  }, [data]);
+
+  const hasActivity = activity.some((a) => a.value > 0);
+
+  return (
+    <div className="page-shell space-y-8 py-8">
+      {/* Header */}
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="mb-2 inline-flex items-center gap-1.5 rounded-full border border-primary/30 bg-primary/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider text-primary">
+            <Sparkles className="h-3.5 w-3.5" />
+            Weekly recap
+          </div>
+          <h1 className="dec-title persona-title text-balance text-3xl font-semibold tracking-tight sm:text-4xl">
+            This week in EIPs
+          </h1>
+          <p className="mt-1.5 max-w-2xl text-pretty text-sm leading-relaxed text-muted-foreground sm:text-base">
+            {loading || !data
+              ? "A short, data-driven story of the latest movement across proposals, pull requests, and protocol calls."
+              : buildNarrative(data, days)}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-1.5 rounded-lg border border-border bg-card/60 p-1">
+          {RANGE_OPTIONS.map((opt) => (
+            <button
+              key={opt.days}
+              type="button"
+              onClick={() => setDays(opt.days)}
+              aria-pressed={days === opt.days}
+              className={cn(
+                "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                days === opt.days
+                  ? "bg-primary/15 text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      {loading ? (
+        <div className="rounded-xl border border-border bg-card/60 py-16">
+          <InlineBrandLoader size="sm" label="Assembling this week's story…" />
+        </div>
+      ) : error || !data ? (
+        <div className="rounded-xl border border-border bg-card/60 px-4 py-12 text-center text-sm text-muted-foreground">
+          {error ?? "No data."}
+        </div>
+      ) : (
+        <>
+          {/* KPI cards */}
+          <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+            <KpiCard icon={FileText} accent="text-blue-500" label="New proposals" value={data.newProposals.length} />
+            <KpiCard icon={TrendingUp} accent="text-emerald-500" label="Status changes" value={data.statusChanges.length} />
+            <KpiCard icon={GitMerge} accent="text-violet-500" label="PRs merged" value={data.mergedPRs.length} />
+            <KpiCard icon={ShieldCheck} accent="text-amber-500" label="Editor actions" value={data.editorActions.length} />
+          </div>
+
+          {/* Activity chart */}
+          {hasActivity && (
+            <Section title="Activity at a glance" icon={<TrendingUp className="h-5 w-5 text-primary" />}>
+              <div className="h-56 w-full">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={activity} layout="vertical" margin={{ left: 8, right: 32 }}>
+                    <CartesianGrid horizontal={false} stroke={CHART_GRID} strokeDasharray="3 3" />
+                    <XAxis type="number" stroke={CHART_AXIS} allowDecimals={false} tick={{ fontSize: 12 }} />
+                    <YAxis
+                      type="category"
+                      dataKey="label"
+                      stroke={CHART_AXIS}
+                      width={110}
+                      tick={{ fontSize: 12 }}
+                    />
+                    <Bar dataKey="value" radius={[0, 6, 6, 0]}>
+                      {activity.map((_, i) => (
+                        <Cell key={i} fill={CHART_SERIES[i % CHART_SERIES.length]} />
+                      ))}
+                      <LabelList dataKey="value" position="right" className="fill-foreground text-xs" />
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </Section>
+          )}
+
+          {/* Status movements */}
+          {data.statusChanges.length > 0 && (
+            <Section title="Proposals on the move" icon={<TrendingUp className="h-5 w-5 text-emerald-500" />}>
+              <ul className="divide-y divide-border/60">
+                {data.statusChanges.slice(0, 12).map((sc, i) => (
+                  <li key={`${sc.number}-${i}`} className="flex flex-wrap items-center gap-x-3 gap-y-1 py-2.5 text-sm">
+                    <Link href={`/eip/${sc.number}`} className="font-mono text-xs font-semibold text-primary hover:underline">
+                      EIP-{sc.number}
+                    </Link>
+                    <span className="hidden max-w-72 truncate text-muted-foreground md:inline">{sc.title}</span>
+                    <span className="ml-auto inline-flex items-center gap-1.5">
+                      {sc.from && <StatusPill status={sc.from} />}
+                      <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" />
+                      <StatusPill status={sc.to} />
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </Section>
+          )}
+
+          {/* New proposals */}
+          {data.newProposals.length > 0 && (
+            <Section title="Freshly proposed" icon={<FileText className="h-5 w-5 text-blue-500" />}>
+              <ul className="divide-y divide-border/60">
+                {data.newProposals.slice(0, 10).map((p) => (
+                  <li key={p.number} className="flex flex-wrap items-center gap-x-3 gap-y-1 py-2.5 text-sm">
+                    <Link href={`/eip/${p.number}`} className="font-mono text-xs font-semibold text-primary hover:underline">
+                      EIP-{p.number}
+                    </Link>
+                    <span className="min-w-0 flex-1 truncate text-foreground">{p.title}</span>
+                    {p.category && (
+                      <span className="rounded-full border border-border bg-muted/40 px-2 py-0.5 text-[11px] text-muted-foreground">
+                        {p.category}
+                      </span>
+                    )}
+                    <StatusPill status={p.status} />
+                  </li>
+                ))}
+              </ul>
+            </Section>
+          )}
+
+          {/* Merged PRs */}
+          {data.mergedPRs.length > 0 && (
+            <Section title="Merged this period" icon={<GitMerge className="h-5 w-5 text-violet-500" />}>
+              <ul className="divide-y divide-border/60">
+                {data.mergedPRs.slice(0, 10).map((pr, i) => (
+                  <li key={`${pr.number}-${i}`} className="flex flex-wrap items-center gap-x-3 gap-y-1 py-2.5 text-sm">
+                    <span className="font-mono text-xs font-semibold text-primary">#{pr.number}</span>
+                    <span className="min-w-0 flex-1 truncate text-foreground">{pr.title}</span>
+                    {pr.author && <span className="text-xs text-muted-foreground">@{pr.author}</span>}
+                  </li>
+                ))}
+              </ul>
+            </Section>
+          )}
+
+          {/* Protocol calls */}
+          {(data.recentCalls.length > 0 || data.upcomingCalls.length > 0) && (
+            <Section title="Protocol calls" icon={<PhoneCall className="h-5 w-5 text-cyan-500" />}>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {data.recentCalls.length > 0 && (
+                  <div>
+                    <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Recent</p>
+                    <ul className="space-y-1.5">
+                      {data.recentCalls.slice(0, 5).map((c) => (
+                        <li key={`${c.series}-${c.number}`} className="text-sm">
+                          <Link href={`/calls/${c.series}/${c.number}`} className="text-primary hover:underline">
+                            {c.displayName}
+                          </Link>
+                          <span className="ml-2 text-xs text-muted-foreground">{c.occurredOn}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {data.upcomingCalls.length > 0 && (
+                  <div>
+                    <p className="mb-2 inline-flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                      <CalendarClock className="h-3.5 w-3.5" />
+                      Upcoming
+                    </p>
+                    <ul className="space-y-1.5">
+                      {data.upcomingCalls.slice(0, 5).map((c, i) => (
+                        <li key={`${c.series}-${c.callNumber}-${i}`} className="text-sm text-foreground">
+                          {c.title || `${c.series} #${c.callNumber}`}
+                          {c.occursOn && <span className="ml-2 text-xs text-muted-foreground">{c.occursOn}</span>}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            </Section>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function KpiCard({
+  icon: Icon,
+  accent,
+  label,
+  value,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  accent: string;
+  label: string;
+  value: number;
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-card/60 p-4">
+      <Icon className={cn("h-4 w-4", accent)} />
+      <p className="mt-2 text-3xl font-bold tabular-nums text-foreground">{value}</p>
+      <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{label}</p>
+    </div>
+  );
+}
+
+function StatusPill({ status }: { status: string | null | undefined }) {
+  if (!status) return null;
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium",
+        statusBadgeClass(status, "outline")
+      )}
+    >
+      {status}
+    </span>
+  );
+}
+
+function Section({
+  title,
+  icon,
+  children,
+}: {
+  title: string;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <div className="mb-3 inline-flex items-center gap-2">
+        {icon}
+        <h2 className="dec-title text-xl font-semibold tracking-tight text-foreground">{title}</h2>
+      </div>
+      <div className="rounded-xl border border-border bg-card/60 px-4 py-3 sm:px-5">{children}</div>
+    </section>
+  );
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -219,6 +219,7 @@ const sidebarSections: SidebarSection[] = [
         icon: Lightbulb,
         href: "/insights",
         items: [
+          { title: "This Week in EIPs", href: "/insights/weekly" },
           { title: "Monthly Analysis", href: "/insights" },
           { title: "Governance & Process", href: "/insights/governance" },
           { title: "Editorial Commentary", href: "/insights/commentary" },

--- a/src/components/insights/MonthlyDrilldown.tsx
+++ b/src/components/insights/MonthlyDrilldown.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import ReactECharts from "echarts-for-react";
 import { client } from "@/lib/orpc";
+import { CHART_SERIES } from "@/lib/chart-colors";
 import { PageHeader, SectionSeparator } from "@/components/header";
 import {
   ArrowLeft,
@@ -42,16 +43,7 @@ function normalizeStatusLabel(raw: string | null | undefined): string {
   if (canonical) return canonical;
   return value;
 }
-const CATEGORY_LINE_COLORS = [
-  "#10b981",
-  "#60a5fa",
-  "#f59e0b",
-  "#f472b6",
-  "#a78bfa",
-  "#22d3ee",
-  "#fb923c",
-  "#94a3b8",
-];
+const CATEGORY_LINE_COLORS = CHART_SERIES;
 
 function csvEscape(v: string | number | null | undefined) {
   const s = String(v ?? "");

--- a/src/components/upgrade/upgrade-timeline-chart.tsx
+++ b/src/components/upgrade/upgrade-timeline-chart.tsx
@@ -354,7 +354,7 @@ export function UpgradeTimelineChart({ data, upgradeName }: UpgradeTimelineChart
                             height={blockHeight}
                             rx={3}
                             fill={COLOR_SCHEME[d.type]}
-                            stroke="#1e293b"
+                            stroke="var(--border)"
                             strokeWidth={0.8}
                             className="transition-opacity hover:opacity-90"
                           />

--- a/src/lib/analytics-range.ts
+++ b/src/lib/analytics-range.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared resolver for the analytics/insights time-range filter.
+ *
+ * The analytics data is monthly-granularity, so a "last N days" preset resolves
+ * to the calendar month(s) that window actually touches — never an arbitrary
+ * month count. Previously every page hardcoded its own mapping (7d→1mo on one
+ * page, 7d→3mo on another, none handling 15d), so the labels didn't match the
+ * data and the filters were inconsistent between sections. Route every page
+ * through here instead.
+ */
+
+export type TimeRange =
+  | '7d'
+  | '15d'
+  | '30d'
+  | '90d'
+  | '1y'
+  | 'this_month'
+  | 'all'
+  | 'custom';
+
+/** Number of days a preset covers, or null for non-day presets. */
+export function rangeDays(range: TimeRange): number | null {
+  switch (range) {
+    case '7d':
+      return 7;
+    case '15d':
+      return 15;
+    case '30d':
+      return 30;
+    case '90d':
+      return 90;
+    case '1y':
+      return 365;
+    default:
+      return null;
+  }
+}
+
+function ym(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function monthDiff(fromYm: string, toYm: string): number {
+  const [fy, fm] = fromYm.split('-').map(Number);
+  const [ty, tm] = toYm.split('-').map(Number);
+  return (ty - fy) * 12 + (tm - fm);
+}
+
+/**
+ * Resolve a preset to an inclusive `{ from, to }` month window (YYYY-MM).
+ * `all` → open window; `custom` → the provided months.
+ */
+export function rangeToMonthWindow(
+  range: TimeRange,
+  customFromMonth?: string,
+  customToMonth?: string,
+  now: Date = new Date()
+): { from?: string; to?: string } {
+  const to = ym(now);
+  if (range === 'all') return { from: undefined, to: undefined };
+  if (range === 'custom') {
+    return { from: customFromMonth || undefined, to: customToMonth || undefined };
+  }
+  if (range === 'this_month') return { from: to, to };
+
+  const days = rangeDays(range) ?? 365;
+  const fromDate = new Date(now);
+  fromDate.setDate(now.getDate() - days);
+  return { from: ym(fromDate), to };
+}
+
+/**
+ * Number of calendar months a preset touches (for consumers that take a
+ * "months back" count rather than a month window). `all`/`custom` → undefined.
+ */
+export function rangeToMonthsBack(
+  range: TimeRange,
+  now: Date = new Date()
+): number | undefined {
+  if (range === 'all' || range === 'custom') return undefined;
+  if (range === 'this_month') return 1;
+  const { from, to } = rangeToMonthWindow(range, undefined, undefined, now);
+  if (!from || !to) return undefined;
+  return monthDiff(from, to) + 1;
+}

--- a/src/lib/chart-colors.ts
+++ b/src/lib/chart-colors.ts
@@ -31,6 +31,29 @@ export function chartColor(index: number): string {
   return CHART_SERIES[((index % CHART_SERIES.length) + CHART_SERIES.length) % CHART_SERIES.length];
 }
 
+/**
+ * Resolve the categorical palette to concrete colour strings.
+ *
+ * SVG charts (Recharts) can use the `var(--chart-*)` values directly, but
+ * canvas charts (ECharts) can't read CSS variables — they need the computed
+ * colour. Call this in the browser and re-run it when the theme changes (e.g.
+ * keyed on `resolvedTheme` in a useMemo) so canvas charts use the same palette
+ * and stay theme-aware. Returns [] during SSR.
+ */
+export function resolveChartSeries(): string[] {
+  if (typeof window === 'undefined') return [];
+  const styles = getComputedStyle(document.documentElement);
+  return [1, 2, 3, 4, 5, 6, 7, 8]
+    .map((n) => styles.getPropertyValue(`--chart-${n}`).trim())
+    .filter(Boolean);
+}
+
+/** Resolve a single design token (e.g. '--muted-foreground') to its value. */
+export function resolveToken(token: string): string {
+  if (typeof window === 'undefined') return '';
+  return getComputedStyle(document.documentElement).getPropertyValue(token).trim();
+}
+
 /** Semantic colours for up/down/neutral and the brand accent. */
 export const CHART_SEMANTIC = {
   positive: 'var(--chart-2)', // green

--- a/src/lib/chart-colors.ts
+++ b/src/lib/chart-colors.ts
@@ -1,0 +1,49 @@
+/**
+ * The single source of truth for chart colours.
+ *
+ * Every colour here is a `var(--…)` reference to a design token defined in
+ * globals.css, so charts are automatically theme-aware (light/dark) and every
+ * section uses the exact same palette. Previously each chart hardcoded its own
+ * hex values (~43 distinct, with casing duplicates), so "series 1 blue" looked
+ * slightly different on every page and grids/axes didn't follow the theme.
+ *
+ * Recharts (and most chart libs) accept `var(--token)` anywhere a colour string
+ * is expected — `stroke`, `fill`, `color`, gradient stops, etc.
+ *
+ * For status/stage semantics (Draft/Final, PFI/DFI…) keep using the canonical
+ * helpers in `proposal-status.ts` / `upgrade-stages.ts` — don't reinvent them.
+ */
+
+/** Categorical series palette. Cycle through these for multi-series charts. */
+export const CHART_SERIES = [
+  'var(--chart-1)', // blue
+  'var(--chart-2)', // green
+  'var(--chart-3)', // cyan
+  'var(--chart-4)', // amber
+  'var(--chart-5)', // magenta
+  'var(--chart-6)', // violet
+  'var(--chart-7)', // red
+  'var(--chart-8)', // slate
+] as const;
+
+/** Nth categorical colour, wrapping around the palette. */
+export function chartColor(index: number): string {
+  return CHART_SERIES[((index % CHART_SERIES.length) + CHART_SERIES.length) % CHART_SERIES.length];
+}
+
+/** Semantic colours for up/down/neutral and the brand accent. */
+export const CHART_SEMANTIC = {
+  positive: 'var(--chart-2)', // green
+  negative: 'var(--chart-7)', // red
+  neutral: 'var(--chart-8)', // slate
+  accent: 'var(--primary)',
+} as const;
+
+/**
+ * Neutral chrome colours — axes, gridlines, tick labels. These map to the same
+ * foreground/border tokens the rest of the UI uses, so charts match the page in
+ * both themes instead of a fixed slate that only looked right in one.
+ */
+export const CHART_AXIS = 'var(--muted-foreground)';
+export const CHART_GRID = 'var(--border)';
+export const CHART_LABEL = 'var(--foreground)';


### PR DESCRIPTION
This pull request introduces a new "Last 15 days" (`15d`) time range option across all analytics pages, improves chart color theming by centralizing color definitions, and updates chart components to use CSS variables for better theme consistency. Additionally, some code cleanup and refactoring were performed to utilize shared utilities.

**New Time Range Support:**

- Added `"15d"` (last 15 days) as a selectable `TimeRange` value across all analytics pages, including logic to handle this range in time window calculations and relevant data queries. [[1]](diffhunk://#diff-de826d26953174dad8aff8172c1bb2a236c3bd708297701128a12137de198837L49-R49) [[2]](diffhunk://#diff-de826d26953174dad8aff8172c1bb2a236c3bd708297701128a12137de198837R128) [[3]](diffhunk://#diff-ffe9ee9c3863ddb2c4deae63f533487d1fb9fb1207600afdfa26e78ee379de61R81-R83) [[4]](diffhunk://#diff-ffe9ee9c3863ddb2c4deae63f533487d1fb9fb1207600afdfa26e78ee379de61L141-R144) [[5]](diffhunk://#diff-9bb64009dceca141115a78c960c8fb407dbc757e5640c2ce893c84fa9560c857R147-R149) [[6]](diffhunk://#diff-ec7d2df83555dc624fbdd5672cd6078c003fcb2356aec664b7c40a79c6aca95eL185-R185) [[7]](diffhunk://#diff-611b0e26821dda5f50156240fd174c4e99e174677f577287692bf48bbb5ce4deR122-R124) [[8]](diffhunk://#diff-611b0e26821dda5f50156240fd174c4e99e174677f577287692bf48bbb5ce4deL173-R176)

**Chart Color Theming Improvements:**

- Centralized chart color palettes by introducing and using the `CHART_SERIES` constant in place of hardcoded color arrays, and updated the EIP Editors and Year in Review pages to use this shared palette. [[1]](diffhunk://#diff-9bb64009dceca141115a78c960c8fb407dbc757e5640c2ce893c84fa9560c857R7) [[2]](diffhunk://#diff-9bb64009dceca141115a78c960c8fb407dbc757e5640c2ce893c84fa9560c857L1306-R1310) [src/app/insights/review/[year]/client-page.tsxR13-R17](diffhunk://#diff-5ee0f00828d95485fd6d9e626b567c8a25c14994490640fc978628d0d50da010R13-R17))
- Extended CSS variables in `globals.css` to define additional chart colors (`--chart-6`, `--chart-7`, `--chart-8`) and mapped them to theme-specific color values. [[1]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R51-R53) [[2]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R119-R121) [[3]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R168-R170)

**Chart Component Styling Updates:**

- Updated all chart components on the Contributors and Reviewers analytics pages to use CSS variables for grid and axis colors, ensuring charts adapt to theme changes and maintain visual consistency. [[1]](diffhunk://#diff-45a92fb91f224eb59ee70d34af91d9603ebd7bd5720d20e1d2b4225f96d6f865L371-R376) [[2]](diffhunk://#diff-45a92fb91f224eb59ee70d34af91d9603ebd7bd5720d20e1d2b4225f96d6f865L401-R406) [[3]](diffhunk://#diff-611b0e26821dda5f50156240fd174c4e99e174677f577287692bf48bbb5ce4deL729-R734) [[4]](diffhunk://#diff-611b0e26821dda5f50156240fd174c4e99e174677f577287692bf48bbb5ce4deL776-R781) [[5]](diffhunk://#diff-611b0e26821dda5f50156240fd174c4e99e174677f577287692bf48bbb5ce4deL828-R833) [[6]](diffhunk://#diff-611b0e26821dda5f50156240fd174c4e99e174677f577287692bf48bbb5ce4deL881-R886) [[7]](diffhunk://#diff-611b0e26821dda5f50156240fd174c4e99e174677f577287692bf48bbb5ce4deL1010-R1015)

**Code Cleanup and Refactoring:**

- Replaced the local `getMonthWindow` function in the PRs analytics page with the shared `rangeToMonthWindow` utility, and removed the duplicate `TimeRange` type definition in favor of the shared type. [[1]](diffhunk://#diff-9538e727ae560d5e5bb01d471e18d2c133b644d15c3af662e8ad6bb3be9b1cc7R8) [[2]](diffhunk://#diff-9538e727ae560d5e5bb01d471e18d2c133b644d15c3af662e8ad6bb3be9b1cc7L129) [[3]](diffhunk://#diff-9538e727ae560d5e5bb01d471e18d2c133b644d15c3af662e8ad6bb3be9b1cc7L152-R152)

These changes improve the flexibility of analytics time ranges, ensure consistent chart theming, and reduce code duplication.