### PR TITLE
Add waiting state filter for PRs in agenda panel

### DIFF
--- a/src/app/(tools)/board/_components/agenda-prs-panel.tsx
+++ b/src/app/(tools)/board/_components/agenda-prs-panel.tsx
@@ -48,8 +48,11 @@ type Row = {
   createdAt: string;
   eipNumbers: number[];
   nextCallOn: string | Date | null;
+  waitingOn: string | null;
   mentions: Mention[];
 };
+
+type WaitingFilter = '' | 'editor' | 'author';
 
 const SERIES = [
   { key: '', label: 'All ACD' },
@@ -99,6 +102,10 @@ export function AgendaPrsPanel() {
   const [window, setWindow] = useState<'upcoming' | 'all'>(() => {
     return searchParams.get('window') === 'upcoming' ? 'upcoming' : 'all';
   });
+  const [waitingOn, setWaitingOn] = useState<WaitingFilter>(() => {
+    const w = searchParams.get('waiting');
+    return w === 'editor' || w === 'author' ? w : '';
+  });
   const [search, setSearch] = useState(() => searchParams.get('acd_q') || '');
   const [debounced, setDebounced] = useState(() => searchParams.get('acd_q') || '');
   const [page, setPage] = useState(() => Math.max(1, Number(searchParams.get('acd_page')) || 1));
@@ -125,13 +132,15 @@ export function AgendaPrsPanel() {
     else p.delete('series');
     if (window !== 'all') p.set('window', window);
     else p.delete('window');
+    if (waitingOn) p.set('waiting', waitingOn);
+    else p.delete('waiting');
     if (debounced) p.set('acd_q', debounced);
     else p.delete('acd_q');
     if (page > 1) p.set('acd_page', String(page));
     else p.delete('acd_page');
     const qs = p.toString();
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
-  }, [series, window, debounced, page, pathname, router, searchParams]);
+  }, [series, window, waitingOn, debounced, page, pathname, router, searchParams]);
 
   // Filter changes reset paging in the handlers rather than via an effect on
   // [series, window, debounced] — that effect would setState synchronously on
@@ -142,6 +151,10 @@ export function AgendaPrsPanel() {
   };
   const changeWindow = (next: 'upcoming' | 'all') => {
     setWindow(next);
+    setPage(1);
+  };
+  const changeWaitingOn = (next: WaitingFilter) => {
+    setWaitingOn(next);
     setPage(1);
   };
   const changeSearch = (next: string) => {
@@ -163,6 +176,7 @@ export function AgendaPrsPanel() {
         const res = await client.tools.getAgendaPRs({
           series: (series || undefined) as 'acde' | 'acdc' | 'acdt' | 'acdtcl' | undefined,
           window,
+          waitingOn: (waitingOn || undefined) as 'editor' | 'author' | undefined,
           search: debounced || undefined,
           page,
           pageSize: 25,
@@ -180,7 +194,7 @@ export function AgendaPrsPanel() {
     return () => {
       cancelled = true;
     };
-  }, [series, window, debounced, page]);
+  }, [series, window, waitingOn, debounced, page]);
 
   const rows = useMemo(() => data?.rows ?? [], [data]);
 
@@ -219,6 +233,35 @@ export function AgendaPrsPanel() {
             <CalendarClock className="h-3.5 w-3.5" />
             Upcoming calls only
           </button>
+
+          <span className="mx-1 h-5 w-px bg-border" aria-hidden />
+          <span className="text-[11px] font-medium text-muted-foreground">Waiting on</span>
+          {([
+            ['', 'All'],
+            ['editor', 'Editors'],
+            ['author', 'Authors'],
+          ] as const).map(([value, label]) => (
+            <button
+              key={value || 'any'}
+              type="button"
+              onClick={() => changeWaitingOn(value)}
+              className={cn(
+                'inline-flex h-8 items-center rounded-md border px-2.5 text-xs font-medium transition-colors',
+                waitingOn === value
+                  ? 'border-primary/50 bg-primary/10 text-foreground'
+                  : 'border-border bg-card/70 text-muted-foreground hover:border-primary/40'
+              )}
+              title={
+                value === 'editor'
+                  ? 'Only PRs currently waiting on an editor'
+                  : value === 'author'
+                    ? 'Only PRs currently waiting on the author'
+                    : 'All PRs regardless of who they wait on'
+              }
+            >
+              {label}
+            </button>
+          ))}
         </div>
 
         <div className="relative w-full sm:max-w-xs">
@@ -266,6 +309,19 @@ export function AgendaPrsPanel() {
           </p>
 
           <div className="overflow-hidden rounded-xl border border-border bg-card/60">
+            {/* Column header (desktop) — the list is sorted by "Next call" ascending. */}
+            <div className="hidden items-center gap-x-3 border-b border-border bg-muted/50 px-4 py-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground sm:flex">
+              <span className="shrink-0">PR</span>
+              <span className="min-w-0 flex-1">Title</span>
+              <span className="shrink-0">Author</span>
+              <span className="shrink-0">Status</span>
+              <span className="shrink-0">EIPs</span>
+              <span className="inline-flex shrink-0 items-center gap-1">
+                Next call
+                <ChevronDown className="h-3 w-3" aria-label="sorted ascending" />
+              </span>
+              <span className="shrink-0">Mentions</span>
+            </div>
             <ul className="divide-y divide-border/60">
               {rows.map((row) => {
                 const isOpen = expanded === row.prNumber;
@@ -286,6 +342,26 @@ export function AgendaPrsPanel() {
                       <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
                         @{row.author ?? 'unknown'}
                       </span>
+
+                      {row.waitingOn && (
+                        <span
+                          className={cn(
+                            'shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] font-medium',
+                            row.waitingOn === 'WAITING_ON_EDITOR'
+                              ? 'border-amber-500/30 bg-amber-500/15 text-amber-700 dark:text-amber-300'
+                              : row.waitingOn === 'WAITING_ON_AUTHOR'
+                                ? 'border-sky-500/30 bg-sky-500/15 text-sky-700 dark:text-sky-300'
+                                : 'border-border bg-muted text-muted-foreground'
+                          )}
+                          title={`Governance: ${row.waitingOn.replace(/_/g, ' ').toLowerCase()}`}
+                        >
+                          {row.waitingOn === 'WAITING_ON_EDITOR'
+                            ? 'Waiting: editor'
+                            : row.waitingOn === 'WAITING_ON_AUTHOR'
+                              ? 'Waiting: author'
+                              : row.waitingOn.replace(/_/g, ' ').toLowerCase()}
+                        </span>
+                      )}
 
                       <span className="inline-flex shrink-0 flex-wrap items-center gap-1">
                         {row.eipNumbers.slice(0, 4).map((n) => (

--- a/src/server/orpc/procedures/tools.ts
+++ b/src/server/orpc/procedures/tools.ts
@@ -710,15 +710,19 @@ const { repo, govState, search } = input;
         series: z.enum(['acde', 'acdc', 'acdt', 'acdtcl']).optional(),
         /** 'upcoming' = agendas for calls not yet held; 'all' includes past calls. */
         window: z.enum(['upcoming', 'all']).default('all'),
+        /** Restrict to PRs whose governance state is waiting on the editor / author. */
+        waitingOn: z.enum(['editor', 'author']).optional(),
         search: z.string().optional(),
         page: z.number().min(1).default(1),
         pageSize: z.number().min(1).max(100).default(25),
       })
     )
     .handler(async ({ input }) => {
-      const { series, window, search, page, pageSize } = input;
+      const { series, window, waitingOn, search, page, pageSize } = input;
       const offset = (page - 1) * pageSize;
       const q = search?.trim() ?? '';
+      const waitingState =
+        waitingOn === 'editor' ? 'WAITING_ON_EDITOR' : waitingOn === 'author' ? 'WAITING_ON_AUTHOR' : null;
 
       // pm_agenda_eips is created by a migration and filled by the scheduler, so
       // between deploying this code and running either one the table is simply
@@ -740,6 +744,7 @@ const { repo, govState, search } = input;
         eip_numbers: number[];
         mentions: unknown;
         next_call_on: string | null;
+        waiting_state: string | null;
         total_count: bigint;
       }>>(
         `
@@ -758,6 +763,7 @@ const { repo, govState, search } = input;
             p.author,
             LOWER(SPLIT_PART(r.name, '/', 2)) AS repo_short,
             TO_CHAR(p.created_at, 'YYYY-MM-DD') AS created_at,
+            g.current_state AS waiting_state,
             pe.eip_number,
             a.issue_number, a.issue_title, a.issue_url, a.series, a.call_number,
             a.occurs_on, a.mentioned_by, a.snippet, a.source, a.source_url
@@ -766,14 +772,17 @@ const { repo, govState, search } = input;
           JOIN pull_requests p
             ON p.pr_number = pe.pr_number AND p.repository_id = pe.repository_id
           JOIN repositories r ON r.id = p.repository_id
+          LEFT JOIN pr_governance_state g
+            ON g.pr_number = p.pr_number AND g.repository_id = p.repository_id
           WHERE p.state = 'open'
+            AND ($6::text IS NULL OR g.current_state = $6)
             AND ($3::text = '' OR p.title ILIKE '%' || $3 || '%'
                  OR p.author ILIKE '%' || $3 || '%'
                  OR CAST(pe.eip_number AS text) ILIKE '%' || $3 || '%')
         ),
         grouped AS (
           SELECT
-            pr_number, title, author, repo_short, created_at,
+            pr_number, title, author, repo_short, created_at, waiting_state,
             ARRAY_AGG(DISTINCT eip_number) AS eip_numbers,
             -- TO_CHAR, not the bare DATE: node-postgres hydrates DATE columns into
             -- JS Date objects at local midnight, so a 2025-03-13 call comes back as
@@ -790,7 +799,7 @@ const { repo, govState, search } = input;
               'eip', eip_number
             )) AS mentions
           FROM matched
-          GROUP BY pr_number, title, author, repo_short, created_at
+          GROUP BY pr_number, title, author, repo_short, created_at, waiting_state
         )
         SELECT *, COUNT(*) OVER()::bigint AS total_count
         FROM grouped
@@ -802,7 +811,8 @@ const { repo, govState, search } = input;
         window,
         q,
         pageSize,
-        offset
+        offset,
+        waitingState
       );
 
       const total = rows.length > 0 ? Number(rows[0].total_count) : 0;
@@ -818,6 +828,7 @@ const { repo, govState, search } = input;
           createdAt: r.created_at,
           eipNumbers: r.eip_numbers ?? [],
           nextCallOn: r.next_call_on,
+          waitingOn: r.waiting_state,
           mentions: (r.mentions ?? []) as Array<{
             issueNumber: number;
             issueTitle: string | null;


### PR DESCRIPTION
This pull request adds a new "Waiting on" filter to the Agenda PRs panel, allowing users to filter PRs by whether they are waiting on an editor or an author. It also updates the backend and UI to support and display this new filter, including showing the waiting state in the PR list.

**Agenda PRs filtering and UI improvements:**
- Added a "Waiting on" filter to the Agenda PRs panel, allowing users to filter PRs by those waiting on an editor, author, or all. The filter state is synced with the URL and resets pagination on change. (`src/app/(tools)/board/_components/agenda-prs-panel.tsx`) [[1]](diffhunk://#diff-d52012045d1b7ba3019531dca3141d1ab40cecb3afd3b161a1565f9d93e7a2e5R51-R56) [[2]](diffhunk://#diff-d52012045d1b7ba3019531dca3141d1ab40cecb3afd3b161a1565f9d93e7a2e5R105-R108) [[3]](diffhunk://#diff-d52012045d1b7ba3019531dca3141d1ab40cecb3afd3b161a1565f9d93e7a2e5R135-R143) [[4]](diffhunk://#diff-d52012045d1b7ba3019531dca3141d1ab40cecb3afd3b161a1565f9d93e7a2e5R156-R159) [[5]](diffhunk://#diff-d52012045d1b7ba3019531dca3141d1ab40cecb3afd3b161a1565f9d93e7a2e5R179) [[6]](diffhunk://#diff-d52012045d1b7ba3019531dca3141d1ab40cecb3afd3b161a1565f9d93e7a2e5L183-R197) [[7]](diffhunk://#diff-d52012045d1b7ba3019531dca3141d1ab40cecb3afd3b161a1565f9d93e7a2e5R236-R264)
- Updated the PR list UI to display the waiting state (e.g., "Waiting: editor" or "Waiting: author") for each PR, with appropriate styling and tooltips. (`src/app/(tools)/board/_components/agenda-prs-panel.tsx`) [[1]](diffhunk://#diff-d52012045d1b7ba3019531dca3141d1ab40cecb3afd3b161a1565f9d93e7a2e5R346-R365) [[2]](diffhunk://#diff-d52012045d1b7ba3019531dca3141d1ab40cecb3afd3b161a1565f9d93e7a2e5R312-R324)

**Backend support for waiting state:**
- Extended the backend API and database query to accept and filter by a `waitingOn` parameter, mapping it to the correct governance state, and to include the waiting state in the returned data. (`src/server/orpc/procedures/tools.ts`) [[1]](diffhunk://#diff-fc05cff2abe8e6e1321f6b8b9ea2cb104c35afa365cf403014f14de3c9784e6cR713-R725) [[2]](diffhunk://#diff-fc05cff2abe8e6e1321f6b8b9ea2cb104c35afa365cf403014f14de3c9784e6cR747) [[3]](diffhunk://#diff-fc05cff2abe8e6e1321f6b8b9ea2cb104c35afa365cf403014f14de3c9784e6cR766) [[4]](diffhunk://#diff-fc05cff2abe8e6e1321f6b8b9ea2cb104c35afa365cf403014f14de3c9784e6cR775-R785) [[5]](diffhunk://#diff-fc05cff2abe8e6e1321f6b8b9ea2cb104c35afa365cf403014f14de3c9784e6cL793-R802) [[6]](diffhunk://#diff-fc05cff2abe8e6e1321f6b8b9ea2cb104c35afa365cf403014f14de3c9784e6cL805-R815) [[7]](diffhunk://#diff-fc05cff2abe8e6e1321f6b8b9ea2cb104c35afa365cf403014f14de3c9784e6cR831)

These changes make it easier for users to see and filter PRs based on their current governance state, improving the workflow for tracking agenda items.