### PR TITLE
Add Lucid page for encrypted mempool tracking and MEV metrics

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -38,6 +38,17 @@ const nextConfig: NextConfig = {
         destination: '/upgrade/schedule',
         permanent: false,
       },
+      // Aliases for the Lucid / encrypted-mempool project page.
+      {
+        source: '/mempool',
+        destination: '/lucid',
+        permanent: false,
+      },
+      {
+        source: '/encrypted-mempool',
+        destination: '/lucid',
+        permanent: false,
+      },
       // Analytics merged into the main /upgrade page (#analytics section).
       {
         source: '/upgrade/analytics',

--- a/src/app/lucid/layout.tsx
+++ b/src/app/lucid/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import { buildMetadata } from '@/lib/seo';
+
+export const metadata: Metadata = buildMetadata({
+  title: 'Lucid — Encrypted Mempool',
+  description:
+    'A dedicated tracker for Lucid (EIP-8184), Ethereum\'s encrypted mempool effort — working-group meeting summaries, key decisions, and research links, built with encryptedmempool.org.',
+  path: '/lucid',
+  keywords: ['Lucid', 'encrypted mempool', 'EIP-8184', 'Encrypt the Mempool', 'MEV', 'Ethereum'],
+});
+
+export default function LucidLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/lucid/page.tsx
+++ b/src/app/lucid/page.tsx
@@ -1,0 +1,602 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import {
+  ArrowUpRight,
+  CalendarClock,
+  CheckSquare,
+  Crosshair,
+  ExternalLink,
+  FileText,
+  Lock,
+  ListChecks,
+  Play,
+  ShieldAlert,
+  Sparkles,
+  Users,
+  Video,
+} from 'lucide-react';
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { client } from '@/lib/orpc';
+import type { MempoolMevStats } from '@/server/orpc/procedures/mev';
+import { CHART_AXIS, CHART_GRID, CHART_SERIES } from '@/lib/chart-colors';
+import { cn } from '@/lib/utils';
+import { InlineBrandLoader } from '@/components/inline-brand-loader';
+
+/**
+ * Dedicated tracker for Lucid (EIP-8184) — Ethereum's encrypted mempool effort,
+ * built with encryptedmempool.org. Pulls the "Encrypt The Mempool" (ETM) working
+ * group call summaries/decisions we already ingest, alongside the EIP and the
+ * research threads. Route aliases /mempool and /encrypted-mempool redirect here.
+ */
+
+type Tldr = {
+  meeting?: string;
+  targets?: unknown;
+  decisions?: Array<{ decision?: string; timestamp?: string }>;
+  highlights?: Record<string, unknown> | unknown[];
+  action_items?: unknown;
+} | null;
+
+type Call = {
+  call_id: string;
+  call_number: string | null;
+  occurred_on: string;
+  video_url: string | null;
+  has_transcript: boolean;
+  display_name: string | null;
+  tldr: Tldr;
+};
+
+const RESOURCES = [
+  {
+    label: 'encryptedmempool.org',
+    href: 'https://encryptedmempool.org/',
+    desc: 'Project hub — the partner site coordinating the encrypted-mempool effort.',
+  },
+  {
+    label: 'EIP-8184 — LUCID encrypted mempool',
+    href: 'https://eips.ethereum.org/EIPS/eip-8184',
+    desc: 'The specification (Draft, Core / Standards Track).',
+  },
+  {
+    label: 'Ethereum Magicians — EIP-8184: Lucid',
+    href: 'https://ethereum-magicians.org/t/eip-8184-lucid-encrypted-mempool/28017',
+    desc: 'Standards discussion thread.',
+  },
+  {
+    label: 'ethresear.ch — Lucid: encrypted mempool with distributed payload propagation',
+    href: 'https://ethresear.ch/t/lucid-encrypted-mempool-with-distributed-payload-propagation/24042',
+    desc: 'The design & research writeup.',
+  },
+];
+
+function humanize(key: string): string {
+  return key.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Pull the display text out of a string or an object, trying `fields` in order. */
+function textOf(item: unknown, fields: string[]): string {
+  if (typeof item === 'string') return item;
+  if (item && typeof item === 'object') {
+    const o = item as Record<string, unknown>;
+    for (const f of fields) if (typeof o[f] === 'string' && o[f]) return o[f] as string;
+  }
+  return '';
+}
+
+/**
+ * Highlights are an object of topic → array of {highlight, timestamp}. Group by
+ * topic and pull the highlight text so we render readable bullets, not raw JSON.
+ */
+function parseHighlights(value: unknown): Array<{ topic: string; items: string[] }> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const groups: Array<{ topic: string; items: string[] }> = [];
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      const arr = Array.isArray(v) ? v : [v];
+      const items = arr.map((it) => textOf(it, ['highlight', 'text', 'point', 'decision'])).filter(Boolean);
+      if (items.length) groups.push({ topic: humanize(k), items });
+    }
+    return groups;
+  }
+  if (Array.isArray(value)) {
+    const items = value.map((it) => textOf(it, ['highlight', 'text', 'point'])).filter(Boolean);
+    return items.length ? [{ topic: '', items }] : [];
+  }
+  return [];
+}
+
+/** Action items are [{owner, action, timestamp}] — render "action — owner". */
+function parseActionItems(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((it) => {
+      const action = textOf(it, ['action', 'item', 'text', 'decision']);
+      const owner = it && typeof it === 'object' ? String((it as Record<string, unknown>).owner ?? '') : '';
+      return action ? (owner ? `${action} — ${owner}` : action) : '';
+    })
+    .filter(Boolean);
+}
+
+export default function LucidPage() {
+  const [calls, setCalls] = useState<Call[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [mev, setMev] = useState<MempoolMevStats | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    client.calls
+      .listRecentCalls({ series: 'etm', limit: 50 })
+      .then((rows) => {
+        if (!cancelled) setCalls((rows as Call[]).slice().sort((a, b) => (a.occurred_on < b.occurred_on ? 1 : -1)));
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    client.mev
+      .getMempoolStats()
+      .then((s) => {
+        if (!cancelled && s?.available) setMev(s);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const stats = useMemo(() => {
+    const decisions = calls.reduce((n, c) => n + (c.tldr?.decisions?.length ?? 0), 0);
+    return {
+      meetings: calls.length,
+      latest: calls[0]?.occurred_on ?? null,
+      decisions,
+    };
+  }, [calls]);
+
+  return (
+    <div className="page-shell space-y-10 py-8">
+      {/* Hero */}
+      <header>
+        <div className="mb-3 inline-flex items-center gap-1.5 rounded-full border border-violet-500/30 bg-violet-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider text-violet-600 dark:text-violet-300">
+          <Lock className="h-3.5 w-3.5" />
+          Encrypted Mempool · Working Group
+        </div>
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="dec-title persona-title text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
+              Lucid
+            </h1>
+            <p className="mt-2 max-w-2xl text-pretty text-sm leading-relaxed text-muted-foreground sm:text-base">
+              An encrypted mempool for Ethereum — encrypting transactions until they&apos;re included
+              so builders and relays can&apos;t reorder or censor them, mitigating harmful MEV.
+              Tracked here with <strong className="text-foreground">encryptedmempool.org</strong>:
+              every working-group meeting, decision, and the live spec in one place.
+            </p>
+          </div>
+          <Link
+            href="/eip/8184"
+            className="inline-flex shrink-0 items-center gap-2 rounded-lg border border-primary/40 bg-primary/10 px-3 py-2 text-sm font-medium text-foreground transition-colors hover:border-primary/60"
+          >
+            <FileText className="h-4 w-4 text-primary" />
+            EIP-8184
+            <span className="rounded-full border border-border bg-muted/60 px-2 py-0.5 text-[11px] text-muted-foreground">
+              Draft · Core
+            </span>
+          </Link>
+        </div>
+      </header>
+
+      {/* Metrics */}
+      <section className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Metric icon={Video} accent="text-violet-500" label="WG meetings" value={loading ? '—' : String(stats.meetings)} />
+        <Metric icon={CheckSquare} accent="text-emerald-500" label="Decisions logged" value={loading ? '—' : String(stats.decisions)} />
+        <Metric icon={CalendarClock} accent="text-amber-500" label="Latest meeting" value={stats.latest ? formatDate(stats.latest) : '—'} />
+        <Metric icon={FileText} accent="text-blue-500" label="EIP status" value="Draft" sub="Core · Standards Track" />
+      </section>
+
+      {/* Resources */}
+      <section>
+        <SectionHeader icon={Sparkles} title="Resources" />
+        <div className="grid gap-3 sm:grid-cols-2">
+          {RESOURCES.map((r) => (
+            <a
+              key={r.href}
+              href={r.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group flex items-start gap-3 rounded-xl border border-border bg-card/60 p-4 transition-colors hover:border-primary/40"
+            >
+              <ExternalLink className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-primary" />
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-foreground">{r.label}</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">{r.desc}</p>
+              </div>
+            </a>
+          ))}
+        </div>
+      </section>
+
+      {/* The MEV problem Lucid targets — live data from BlobLens */}
+      {mev && <MevSection mev={mev} />}
+
+      {/* Meeting summaries */}
+      <section>
+        <SectionHeader
+          icon={ListChecks}
+          title="Meeting summaries & decisions"
+          action={
+            <Link
+              href="/calls?series=etm"
+              className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+            >
+              All ETM calls
+              <ArrowUpRight className="h-3.5 w-3.5" />
+            </Link>
+          }
+        />
+        {loading ? (
+          <div className="rounded-xl border border-border bg-card/60 py-14">
+            <InlineBrandLoader size="sm" label="Loading working-group meetings…" />
+          </div>
+        ) : calls.length === 0 ? (
+          <p className="rounded-xl border border-border bg-card/60 px-4 py-10 text-center text-sm text-muted-foreground">
+            No meetings synced yet.
+          </p>
+        ) : (
+          <ol className="relative space-y-4 border-l border-border/60 pl-5">
+            {calls.map((call) => (
+              <MeetingCard key={call.call_id} call={call} />
+            ))}
+          </ol>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function MeetingCard({ call }: { call: Call }) {
+  const tldr = call.tldr;
+  const title = tldr?.meeting || call.display_name || `Encrypt The Mempool #${call.call_number ?? ''}`;
+  const decisions = (tldr?.decisions ?? []).map((d) => d?.decision).filter(Boolean) as string[];
+  const highlightGroups = parseHighlights(tldr?.highlights);
+  const actions = parseActionItems(tldr?.action_items).slice(0, 8);
+  const callHref = `/calls/etm/${call.call_number ?? call.call_id}`;
+
+  return (
+    <li className="relative">
+      <span className="absolute -left-[23px] top-1.5 h-2.5 w-2.5 rounded-full bg-primary ring-4 ring-background" aria-hidden />
+      <div className="rounded-xl border border-border bg-card/60 p-4">
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div className="min-w-0">
+            <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+            <p className="mt-0.5 text-xs text-muted-foreground">{formatDate(call.occurred_on)}</p>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            {call.video_url && (
+              <a
+                href={call.video_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 rounded-md border border-border bg-muted/60 px-2 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary"
+              >
+                <Play className="h-3 w-3" />
+                Recording
+              </a>
+            )}
+            <Link
+              href={callHref}
+              className="inline-flex items-center gap-1 rounded-md border border-primary/40 bg-primary/10 px-2 py-1 text-[11px] font-medium text-foreground transition-colors hover:border-primary/60"
+            >
+              Full summary
+              <ArrowUpRight className="h-3 w-3" />
+            </Link>
+          </div>
+        </div>
+
+        {decisions.length > 0 && (
+          <div className="mt-3">
+            <p className="mb-1 inline-flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-emerald-600 dark:text-emerald-400">
+              <CheckSquare className="h-3 w-3" />
+              Decisions
+            </p>
+            <ul className="space-y-1">
+              {decisions.map((d, i) => (
+                <li key={i} className="flex gap-2 text-xs text-foreground/90">
+                  <span className="mt-1 h-1 w-1 shrink-0 rounded-full bg-emerald-500" />
+                  {d}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {highlightGroups.length > 0 && (
+          <div className="mt-3">
+            <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Highlights</p>
+            <div className="space-y-2">
+              {highlightGroups.map((g, gi) => (
+                <div key={gi}>
+                  {g.topic && (
+                    <p className="text-[11px] font-medium text-foreground/80">{g.topic}</p>
+                  )}
+                  <ul className="space-y-1">
+                    {g.items.map((h, i) => (
+                      <li key={i} className="flex gap-2 text-xs text-muted-foreground">
+                        <span className="mt-1 h-1 w-1 shrink-0 rounded-full bg-border" />
+                        {h}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {actions.length > 0 && (
+          <div className="mt-3">
+            <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400">
+              Action items
+            </p>
+            <ul className="space-y-1">
+              {actions.map((a, i) => (
+                <li key={i} className="flex gap-2 text-xs text-muted-foreground">
+                  <span className="mt-1 h-1 w-1 shrink-0 rounded-full bg-amber-500" />
+                  {a}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </li>
+  );
+}
+
+/**
+ * The live MEV picture that motivates the working group: how much harmful MEV is
+ * being extracted on mainnet today (sandwich attacks), which is exactly what an
+ * encrypted mempool is designed to neutralise. Data: BlobLens sandwich index.
+ */
+function MevSection({ mev }: { mev: MempoolMevStats }) {
+  const pct = mev.blocksSandwichedPct;
+  return (
+    <section>
+      <SectionHeader
+        icon={ShieldAlert}
+        title="The MEV Lucid is built to stop"
+        action={
+          <span className="text-[11px] text-muted-foreground">
+            Sandwich attacks on mainnet · source{' '}
+            <span className="font-medium text-foreground">BlobLens</span>
+          </span>
+        }
+      />
+      <p className="mb-4 max-w-3xl text-pretty text-sm leading-relaxed text-muted-foreground">
+        Because today&apos;s mempool is public, searchers can see pending swaps and{' '}
+        <strong className="text-foreground">sandwich</strong> them — front-running and back-running a
+        victim&apos;s trade to skim value. This is the harm an encrypted mempool removes at the source.
+        Measured since the Dencun upgrade (EIP-4844) across five major DEXs:
+      </p>
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Metric
+          icon={Crosshair}
+          accent="text-rose-500"
+          label="Sandwich attacks"
+          value={compactNum(mev.totalSandwiches)}
+          sub="detected since Dencun"
+        />
+        <Metric
+          icon={Users}
+          accent="text-orange-500"
+          label="Unique victims"
+          value={compactNum(mev.uniqueVictims)}
+          sub="distinct swaps sandwiched"
+        />
+        <Metric
+          icon={ShieldAlert}
+          accent="text-amber-500"
+          label="Value extracted"
+          value={compactUsd(mev.botProfitUsd)}
+          sub="bot gross profit (BlobLens est.)"
+        />
+        <Metric
+          icon={Crosshair}
+          accent="text-violet-500"
+          label="Blocks sandwiched"
+          value={pct != null ? `${pct}%` : '—'}
+          sub="of all blocks · last 30 days"
+        />
+      </div>
+
+      {mev.weekly.length > 1 && <MevWeeklyChart mev={mev} />}
+
+      <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground/70">
+        BlobLens indexes the post-EIP-4844 era across Uniswap v2/v3, SushiSwap, Curve and DODO, so these
+        are a conservative floor versus full-history sources. Dollar figures are gross, before gas.
+      </p>
+    </section>
+  );
+}
+
+type WeekPoint = MempoolMevStats['weekly'][number] & { label: string };
+
+/**
+ * The chart the working group actually reasons about: weekly sandwich frequency
+ * (bars, left axis) against the dollar value extracted (line, right axis). The
+ * two together show the "MEV payoff variance" the group debates — weeks where a
+ * few large extractions dwarf a normal week of activity, i.e. exactly the payoff
+ * distribution Lucid's key-reveal penalty has to deter.
+ */
+const CHART_TOOLTIP = {
+  borderRadius: '8px',
+  border: '1px solid var(--border)',
+  backgroundColor: 'var(--background)',
+  fontSize: '12px',
+} as const;
+
+function MevWeeklyChart({ mev }: { mev: MempoolMevStats }) {
+  const data: WeekPoint[] = mev.weekly.map((w) => ({ ...w, label: weekLabel(w.week) }));
+  // Prefer bot profit; fall back to victim volume when the profit series is flat.
+  const hasProfit = data.some((d) => d.botProfitUsd > 0);
+  const valueKey: 'botProfitUsd' | 'victimUsd' = hasProfit ? 'botProfitUsd' : 'victimUsd';
+  const valueLabel = hasProfit ? 'Value extracted (bot profit)' : 'Victim volume';
+
+  return (
+    <div className="mt-3 grid gap-3 lg:grid-cols-2">
+      {/* Frequency — how often the mempool is exploited */}
+      <div className="rounded-xl border border-border bg-card/60 p-4">
+        <p className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Weekly sandwich attacks
+        </p>
+        <div className="h-56 w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={data} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
+              <CartesianGrid vertical={false} stroke={CHART_GRID} strokeDasharray="3 3" />
+              <XAxis dataKey="label" stroke={CHART_AXIS} tick={{ fontSize: 11 }} interval="preserveStartEnd" minTickGap={24} />
+              <YAxis stroke={CHART_AXIS} tick={{ fontSize: 11 }} width={40} tickFormatter={(v: number) => compactNum(v)} />
+              <Tooltip
+                cursor={{ fill: 'var(--muted)', opacity: 0.4 }}
+                contentStyle={CHART_TOOLTIP}
+                labelStyle={{ color: 'var(--foreground)', fontWeight: 600 }}
+                formatter={(value: number) => [Number(value).toLocaleString(), 'Attacks']}
+              />
+              <Bar dataKey="sandwiches" fill={CHART_SERIES[6]} radius={[3, 3, 0, 0]} maxBarSize={22} isAnimationActive={false} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      {/* Payoff — the value being extracted (the "MEV payoff variance" the WG debates) */}
+      <div className="rounded-xl border border-border bg-card/60 p-4">
+        <p className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+          {valueLabel} · weekly (USD)
+        </p>
+        <div className="h-56 w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={data} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
+              <defs>
+                <linearGradient id="mevValueFill" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor={CHART_SERIES[3]} stopOpacity={0.35} />
+                  <stop offset="100%" stopColor={CHART_SERIES[3]} stopOpacity={0.02} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid vertical={false} stroke={CHART_GRID} strokeDasharray="3 3" />
+              <XAxis dataKey="label" stroke={CHART_AXIS} tick={{ fontSize: 11 }} interval="preserveStartEnd" minTickGap={24} />
+              <YAxis stroke={CHART_AXIS} tick={{ fontSize: 11 }} width={48} tickFormatter={(v: number) => compactUsd(v)} />
+              <Tooltip
+                contentStyle={CHART_TOOLTIP}
+                labelStyle={{ color: 'var(--foreground)', fontWeight: 600 }}
+                formatter={(value: number) => [compactUsd(value), valueLabel]}
+              />
+              <Area
+                type="monotone"
+                dataKey={valueKey}
+                stroke={CHART_SERIES[3]}
+                strokeWidth={2}
+                fill="url(#mevValueFill)"
+                dot={false}
+                activeDot={{ r: 4 }}
+                isAnimationActive={false}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      <p className="text-[11px] text-muted-foreground lg:col-span-2">
+        {mev.uniqueBots.toLocaleString()} distinct sandwich bots · {compactNum(mev.uniquePools)} pools targeted · last 26 weeks.
+        The gap between a normal week and the spikes is the &ldquo;MEV payoff variance&rdquo; the working group weighs when
+        judging whether Lucid&apos;s key-reveal penalty is a strong enough deterrent.
+      </p>
+    </div>
+  );
+}
+
+function weekLabel(day: string): string {
+  if (!/^\d{4}-\d{2}-\d{2}/.test(day)) return day;
+  return new Date(`${day.slice(0, 10)}T00:00:00Z`).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+function compactNum(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(n >= 10_000_000 ? 0 : 1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n >= 10_000 ? 0 : 1)}K`;
+  return String(n);
+}
+
+function compactUsd(n: number): string {
+  if (n >= 1_000_000_000) return `$${(n / 1_000_000_000).toFixed(1)}B`;
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(0)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(0)}K`;
+  return `$${n}`;
+}
+
+function Metric({
+  icon: Icon,
+  accent,
+  label,
+  value,
+  sub,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  accent: string;
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-card/60 p-4">
+      <Icon className={cn('h-4 w-4', accent)} />
+      <p className="mt-2 text-2xl font-bold tracking-tight text-foreground">{value}</p>
+      <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{label}</p>
+      {sub && <p className="mt-0.5 text-[10px] text-muted-foreground/70">{sub}</p>}
+    </div>
+  );
+}
+
+function SectionHeader({
+  icon: Icon,
+  title,
+  action,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+      <div className="inline-flex items-center gap-2">
+        <Icon className="h-5 w-5 text-primary" />
+        <h2 className="dec-title text-xl font-semibold tracking-tight text-foreground sm:text-2xl">{title}</h2>
+      </div>
+      {action}
+    </div>
+  );
+}
+
+function formatDate(day: string): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return day;
+  return new Date(`${day}T00:00:00Z`).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -158,6 +158,7 @@ const sidebarSections: SidebarSection[] = [
               { title: "From Breakouts", href: "/decisions?series=breakouts#decisions" },
             ],
           },
+          { title: "Lucid · Mempool", href: "/lucid" },
         ],
       },
       {

--- a/src/components/upgrade/upgrade-stats-panel.tsx
+++ b/src/components/upgrade/upgrade-stats-panel.tsx
@@ -502,6 +502,8 @@ export function UpgradeStatsPanel() {
         </motion.div>
       </section>
 
+      {/* Only rendered once a stat card is selected — no empty placeholder card. */}
+      {activeTable && (
       <section ref={detailsSectionRef} id="upgrade-eip-details">
         {activeTable && (
           <div className="mb-3">
@@ -690,6 +692,7 @@ export function UpgradeStatsPanel() {
           </motion.div>
         </div>
       </section>
+      )}
     </div>
   );
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -39,6 +39,12 @@ export const env = createEnv({
     COHERE_API_KEY: z.string().min(1).optional(),
     GROQ_API_KEY: z.string().min(1).optional(),
 
+    // BlobLens ClickHouse (optional) — powers the MEV metrics on /lucid.
+    // Reachable from the app server over the internal ba-data network.
+    CLICKHOUSE_URL: z.string().url().optional(),
+    CLICKHOUSE_USER: z.string().min(1).optional(),
+    CLICKHOUSE_PASSWORD: z.string().optional(),
+
     REDIS_URL: z.string().url(),
   },
 

--- a/src/lib/clickhouse.ts
+++ b/src/lib/clickhouse.ts
@@ -1,0 +1,49 @@
+import { env } from '@/env';
+
+/**
+ * Minimal ClickHouse HTTP client for read-only analytics queries against the
+ * BlobLens `blob_lens` database (MEV sandwich data surfaced on /lucid).
+ *
+ * Credentials live in env only (CLICKHOUSE_URL / _USER / _PASSWORD). When they
+ * are not configured — e.g. local dev without network access to ba-data — the
+ * client is considered unavailable and callers should degrade gracefully.
+ */
+
+export function clickhouseConfigured(): boolean {
+  return Boolean(env.CLICKHOUSE_URL && env.CLICKHOUSE_USER);
+}
+
+export async function clickhouseQuery<T = Record<string, unknown>>(
+  sql: string,
+  { timeoutMs = 8000 }: { timeoutMs?: number } = {},
+): Promise<T[]> {
+  if (!clickhouseConfigured()) {
+    throw new Error('ClickHouse is not configured');
+  }
+
+  const url = `${env.CLICKHOUSE_URL}/?user=${encodeURIComponent(env.CLICKHOUSE_USER!)}&password=${encodeURIComponent(env.CLICKHOUSE_PASSWORD ?? '')}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      body: `${sql} FORMAT JSONEachRow`,
+      headers: { 'Content-Type': 'text/plain' },
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`ClickHouse ${res.status}: ${(await res.text()).slice(0, 300)}`);
+    }
+    const text = await res.text();
+    if (!text.trim()) return [];
+    return text
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as T);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/server/orpc/procedures/mev.ts
+++ b/src/server/orpc/procedures/mev.ts
@@ -1,0 +1,174 @@
+import { optionalAuthProcedure } from './types'
+import { unstable_cache } from 'next/cache'
+import { clickhouseConfigured, clickhouseQuery } from '@/lib/clickhouse'
+
+/**
+ * MEV metrics for the /lucid (encrypted mempool) page.
+ *
+ * Data comes from BlobLens' ClickHouse `blob_lens` database — the same
+ * sandwich-attack index that powers BlobLens' /mev dashboard. It quantifies the
+ * live MEV extraction that the Encrypt-the-Mempool working group is designing
+ * Lucid (EIP-8184) to neutralise: how many swaps get sandwiched, how many
+ * victims/bots are involved, and how much value the payoff represents.
+ *
+ * BlobLens caveats (see blob_lens/MEV_DATA_COMPARISON.md): coverage starts at
+ * the Dencun activation block (EIP-4844), across five DEX protocols
+ * (Uniswap v2/v3, SushiSwap, Curve, DODO), so figures are a conservative floor
+ * versus full-history sources like Dune.
+ */
+
+const CACHE_REVALIDATE = 300 // seconds
+
+const N = (v: unknown): number => {
+  const n = typeof v === 'string' ? Number(v) : (v as number)
+  return Number.isFinite(n) ? n : 0
+}
+
+type StatsRow = {
+  total_sandwiches: string
+  unique_victims: string
+  unique_bots: string
+  unique_pools: string
+  first_block: string
+  last_block: string
+  bot_profit_usd: number
+  gas_cost_usd: number
+  victim_volume_usd: number
+}
+
+type PctRow = { sw_blocks: string; total_blocks: string }
+type WeekRow = {
+  week: string
+  sandwiches: string
+  profit_usd: number
+  victim_usd: number
+  active_bots: string
+}
+
+export interface MempoolMevStats {
+  available: boolean
+  totalSandwiches: number
+  uniqueVictims: number
+  uniqueBots: number
+  uniquePools: number
+  firstBlock: number
+  lastBlock: number
+  botProfitUsd: number
+  victimVolumeUsd: number
+  gasCostUsd: number
+  // Share of blocks (last 30 days) that contained at least one sandwich.
+  blocksSandwichedPct: number | null
+  // Weekly trend (chronological) for the detailed chart.
+  weekly: Array<{
+    week: string
+    sandwiches: number
+    botProfitUsd: number
+    victimUsd: number
+    activeBots: number
+  }>
+  source: string
+  sourceUrl: string
+}
+
+const EMPTY: MempoolMevStats = {
+  available: false,
+  totalSandwiches: 0,
+  uniqueVictims: 0,
+  uniqueBots: 0,
+  uniquePools: 0,
+  firstBlock: 0,
+  lastBlock: 0,
+  botProfitUsd: 0,
+  victimVolumeUsd: 0,
+  gasCostUsd: 0,
+  blocksSandwichedPct: null,
+  weekly: [],
+  source: 'BlobLens',
+  sourceUrl: 'https://eipsinsight.com',
+}
+
+const getMempoolMevStatsCached = unstable_cache(
+  async (): Promise<MempoolMevStats> => {
+    if (!clickhouseConfigured()) return EMPTY
+    try {
+      const [statsRows, pctRows, weekRows] = await Promise.all([
+        clickhouseQuery<StatsRow>(`
+          SELECT
+            sum(s.sandwiches)                                                        AS total_sandwiches,
+            uniqMerge(s.unique_victims)                                              AS unique_victims,
+            uniqMerge(s.unique_bots)                                                 AS unique_bots,
+            uniqMerge(s.unique_pools)                                                AS unique_pools,
+            min(s.first_block)                                                       AS first_block,
+            max(s.last_block)                                                        AS last_block,
+            round(sum(s.gross_profit_usd) + sum(s.gross_profit_weth * coalesce(p.price_usd, 2000.0))) AS bot_profit_usd,
+            round(sum(s.gas_cost_weth * coalesce(p.price_usd, 2000.0)))              AS gas_cost_usd,
+            round(sum(s.victim_volume_weth * coalesce(p.price_usd, 2000.0)))         AS victim_volume_usd
+          FROM blob_lens.mev_daily_stats s
+          LEFT JOIN blob_lens.eth_daily_price p ON s.date = p.date
+        `),
+        clickhouseQuery<PctRow>(`
+          SELECT
+            uniqMerge(s.unique_blocks) AS sw_blocks,
+            (SELECT count() FROM ethereum.blocks WHERE timestamp >= now() - INTERVAL 30 DAY AND is_deleted = 0) AS total_blocks
+          FROM blob_lens.mev_daily_stats s
+          WHERE s.date >= toDate(now() - INTERVAL 30 DAY)
+        `),
+        clickhouseQuery<WeekRow>(`
+          SELECT
+            toStartOfWeek(s.date)       AS week,
+            sum(s.sandwiches)           AS sandwiches,
+            uniqMerge(s.unique_bots)    AS active_bots,
+            round(sum(s.gross_profit_usd) + sum(s.gross_profit_weth * coalesce(p.price_usd, 2000.0))) AS profit_usd,
+            round(sum(s.victim_volume_weth * coalesce(p.price_usd, 2000.0))) AS victim_usd
+          FROM blob_lens.mev_daily_stats s
+          LEFT JOIN blob_lens.eth_daily_price p ON s.date = p.date
+          WHERE s.date >= toDate(now() - INTERVAL 26 WEEK)
+          GROUP BY week
+          ORDER BY week ASC
+        `),
+      ])
+
+      const s = statsRows[0]
+      if (!s) return EMPTY
+
+      const swBlocks = N(pctRows[0]?.sw_blocks)
+      const totalBlocks = N(pctRows[0]?.total_blocks)
+      const blocksSandwichedPct =
+        totalBlocks > 0 ? Math.round((swBlocks / totalBlocks) * 1000) / 10 : null
+
+      return {
+        available: true,
+        totalSandwiches: N(s.total_sandwiches),
+        uniqueVictims: N(s.unique_victims),
+        uniqueBots: N(s.unique_bots),
+        uniquePools: N(s.unique_pools),
+        firstBlock: N(s.first_block),
+        lastBlock: N(s.last_block),
+        botProfitUsd: N(s.bot_profit_usd),
+        victimVolumeUsd: N(s.victim_volume_usd),
+        gasCostUsd: N(s.gas_cost_usd),
+        blocksSandwichedPct,
+        weekly: weekRows.map((w) => ({
+          week: w.week,
+          sandwiches: N(w.sandwiches),
+          botProfitUsd: N(w.profit_usd),
+          victimUsd: N(w.victim_usd),
+          activeBots: N(w.active_bots),
+        })),
+        source: 'BlobLens',
+        sourceUrl: 'https://eipsinsight.com',
+      }
+    } catch {
+      // Network/ClickHouse hiccup — /lucid degrades gracefully to no MEV panel.
+      return EMPTY
+    }
+  },
+  ['mev-getMempoolMevStats'],
+  { revalidate: CACHE_REVALIDATE },
+)
+
+export const mevProcedures = {
+  getMempoolStats: optionalAuthProcedure.handler(async (): Promise<MempoolMevStats> => {
+    return getMempoolMevStatsCached()
+  }),
+}

--- a/src/server/orpc/router.ts
+++ b/src/server/orpc/router.ts
@@ -25,6 +25,7 @@ import { pageCommentProcedures } from './procedures/pageComment'
 import { commentVoteProcedures } from './procedures/commentVote'
 import { subscriptionsProcedures } from './procedures/subscriptions'
 import { watchlistProcedures } from './procedures/watchlist'
+import { mevProcedures } from './procedures/mev'
 
 export const router = {
   auth: authProcedures,
@@ -54,4 +55,5 @@ export const router = {
   commentVote: commentVoteProcedures,
   subscriptions: subscriptionsProcedures,
   watchlist: watchlistProcedures,
+  mev: mevProcedures,
 }


### PR DESCRIPTION
This pull request introduces a new data integration for the `/lucid` (encrypted mempool) page, surfacing live MEV (Maximal Extractable Value) sandwich attack metrics from BlobLens via ClickHouse. It also adds navigation improvements and new environment variables to support this feature.

**MEV Metrics Integration for Lucid:**

* Added a minimal ClickHouse client in `src/lib/clickhouse.ts` to query MEV analytics from the BlobLens database, with graceful degradation if credentials are not configured.
* Introduced new environment variables in `src/env.ts` for ClickHouse connectivity (`CLICKHOUSE_URL`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`).
* Implemented a new ORPC procedure `mev.getMempoolStats` in `src/server/orpc/procedures/mev.ts` to fetch and cache MEV sandwich attack statistics for the `/lucid` page, including weekly trends and summary metrics.
* Registered the MEV procedure in the ORPC router (`src/server/orpc/router.ts`). [[1]](diffhunk://#diff-1e4002c569bd48f369d940dc3efd07d47d89781e435c6340884a07228d32a6daR28) [[2]](diffhunk://#diff-1e4002c569bd48f369d940dc3efd07d47d89781e435c6340884a07228d32a6daR58)

**Navigation and Routing Updates:**

* Added `/mempool` and `/encrypted-mempool` as aliases redirecting to `/lucid` in `next.config.ts`.
* Added a sidebar link to "Lucid · Mempool" in the main navigation (`src/components/app-sidebar.tsx`).

**Lucid Page Metadata:**

* Created a layout and SEO metadata for the `/lucid` page in `src/app/lucid/layout.tsx`.

**Miscellaneous:**

* Minor UI logic improvement: conditional rendering in `UpgradeStatsPanel` to avoid unnecessary placeholder cards. [[1]](diffhunk://#diff-d42ac6bb44b43764793ac21750df781b74772900126f44d5e5766c15c626acc9R505-R506) [[2]](diffhunk://#diff-d42ac6bb44b43764793ac21750df781b74772900126f44d5e5766c15c626acc9R695)