### PR TITLE
Enhance analytics layout with tab navigation and month-in-review summaries

### DIFF
--- a/src/app/analytics/analytics-layout-client.tsx
+++ b/src/app/analytics/analytics-layout-client.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import React, { createContext, useContext, useState, useMemo, useCallback, Suspense } from "react";
+import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Calendar, Database, ChevronDown } from "lucide-react";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 import { InlineBrandLoader } from "@/components/inline-brand-loader";
 
 // ─── Export Helper Functions ─────────────────────────────────────
@@ -139,6 +141,85 @@ const repoOptions: { value: RepoFilter; label: string }[] = [
   { value: "ercs", label: "ERCs" },
   { value: "rips", label: "RIPs" },
 ];
+
+// ─── View switcher (grouped segmented tabs) ──────────────────────
+// "Activity" = the data-heavy /analytics/* views (time-range + repo aware).
+// "Insights" = the editorial /insights/* views (period-driven, no controls).
+type TabDef = { label: string; href: string };
+
+const ACTIVITY_TABS: TabDef[] = [
+  { label: "EIPs", href: "/analytics/eips" },
+  { label: "PRs", href: "/analytics/prs" },
+  { label: "Editors", href: "/analytics/editors" },
+  { label: "Reviewers", href: "/analytics/reviewers" },
+  { label: "Authors", href: "/analytics/authors" },
+  { label: "Contributors", href: "/analytics/contributors" },
+  { label: "Issues", href: "/analytics/issues" },
+];
+
+const INSIGHTS_TABS: TabDef[] = [
+  { label: "This Week", href: "/insights/weekly" },
+  { label: "Monthly", href: "/insights" },
+  { label: "Commentary", href: "/insights/commentary" },
+];
+
+function isInsightsPath(pathname: string | null): boolean {
+  return Boolean(pathname && pathname.startsWith("/insights"));
+}
+
+function tabActive(pathname: string | null, href: string): boolean {
+  if (!pathname) return false;
+  // "Monthly" owns the /insights root plus its dynamic drilldowns
+  // (/insights/[year]/[month], /insights/review/[year]) — but not the
+  // sibling weekly/commentary routes.
+  if (href === "/insights") {
+    return (
+      pathname === "/insights" ||
+      (pathname.startsWith("/insights/") &&
+        !pathname.startsWith("/insights/weekly") &&
+        !pathname.startsWith("/insights/commentary"))
+    );
+  }
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+function TabGroup({
+  label,
+  tabs,
+  pathname,
+}: {
+  label: string;
+  tabs: TabDef[];
+  pathname: string | null;
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="mr-0.5 shrink-0 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+        {label}
+      </span>
+      <div className="flex flex-wrap items-center gap-1">
+        {tabs.map((t) => {
+          const active = tabActive(pathname, t.href);
+          return (
+            <Link
+              key={t.href}
+              href={t.href}
+              aria-current={active ? "page" : undefined}
+              className={cn(
+                "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+                active
+                  ? "bg-primary text-primary-foreground shadow-sm"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
+              )}
+            >
+              {t.label}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
 
 function AnalyticsLayoutInner({
   children,
@@ -290,7 +371,14 @@ function AnalyticsLayoutInner({
     ]
   );
 
+  const onInsights = isInsightsPath(pathname);
+
   const pageTitle = useMemo(() => {
+    if (onInsights) {
+      if (pathname?.startsWith("/insights/weekly")) return "This Week in EIPs";
+      if (pathname?.startsWith("/insights/commentary")) return "Editorial Commentary";
+      return "Monthly Analysis";
+    }
     const seg = pathname?.split("/").filter(Boolean) || [];
     const last = seg[seg.length - 1];
     const titles: Record<string, string> = {
@@ -303,9 +391,12 @@ function AnalyticsLayoutInner({
       contributors: "Contributors",
     };
     return titles[last] || "Analytics";
-  }, [pathname]);
+  }, [pathname, onInsights]);
 
   const pageSubtitle = useMemo(() => {
+    if (pageTitle === "This Week in EIPs") return "The last seven days of EIP, ERC, and RIP activity.";
+    if (pageTitle === "Monthly Analysis") return "Month-by-month status movements, velocity, and highlights.";
+    if (pageTitle === "Editorial Commentary") return "Editor notes and analysis on governance and proposals.";
     if (pageTitle === "EIP Analytics")
       return "A high-level overview of Ethereum Standards by type, status, and lifecycle progress.";
     if (pageTitle === "PR Analytics") return "Pull request activity and merge trends.";
@@ -319,6 +410,10 @@ function AnalyticsLayoutInner({
         {/* Single merged header — not sticky */}
         <div className="border-b border-border bg-card/80">
           <div className="mx-auto w-full px-3 py-5 sm:px-4 lg:px-5 xl:px-6">
+            {/* Full header (title + controls) only on Activity views. Insights
+                pages render their own bespoke headers, so the shell shows just
+                the tab bar there to avoid a duplicate title. */}
+            {!onInsights && (
             <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
               {/* Title + subtitle */}
               <div>
@@ -330,7 +425,8 @@ function AnalyticsLayoutInner({
                 </p>
               </div>
 
-              {/* Controls */}
+              {/* Controls — Activity views only (this block isn't rendered on
+                  Insights routes). Time-range + repo filters. */}
               <div className="flex flex-wrap items-center gap-3">
                 {/* Time Range */}
                 <div className="relative flex items-center rounded-lg border border-border bg-muted/65 px-2.5 py-1.5 shadow-sm transition-all hover:border-primary/40 focus-within:border-primary/40 focus-within:ring-1 focus-within:ring-primary/20">
@@ -395,6 +491,14 @@ function AnalyticsLayoutInner({
                 </div>
 
               </div>
+            </div>
+            )}
+
+            {/* View switcher — grouped segmented tabs (Activity · Insights) */}
+            <div className={cn("flex flex-wrap items-center gap-x-5 gap-y-2 overflow-x-auto", !onInsights && "mt-4")}>
+              <TabGroup label="Activity" tabs={ACTIVITY_TABS} pathname={pathname} />
+              <span className="hidden h-4 w-px shrink-0 bg-border sm:block" aria-hidden />
+              <TabGroup label="Insights" tabs={INSIGHTS_TABS} pathname={pathname} />
             </div>
           </div>
         </div>

--- a/src/app/analytics/issues/page.tsx
+++ b/src/app/analytics/issues/page.tsx
@@ -310,6 +310,11 @@ export default function IssuesAnalyticsPage() {
         ) : (
           <p className="text-sm text-muted-foreground">No monthly data available.</p>
         )}
+        <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
+          <strong className="text-foreground">Created</strong> and <strong className="text-foreground">Closed</strong> count issues
+          by what happened to them within each month. <strong className="text-foreground">Open EOM</strong> ={" "}
+          <em>Open at End of Month</em>: issues still open on the last day of that month (the running backlog).
+        </p>
       </Section>
 
       <Section id="issue-labels" title="Label distribution" icon={<BarChart3 className="h-4 w-4" />}>

--- a/src/app/analytics/prs/page.tsx
+++ b/src/app/analytics/prs/page.tsx
@@ -225,7 +225,12 @@ export default function PRsAnalyticsPage() {
   const [issuesCurrentPage, setIssuesCurrentPage] = useState(1);
   const [prSearchFilter, setPrSearchFilter] = useState<string>("");
   const [issuesSearchFilter, setIssuesSearchFilter] = useState<string>("");
-  const [prStateFilter, setPrStateFilter] = useState<"all" | "open" | "created" | "merged" | "closed">("all");
+  // Initial state tab can be deep-linked (?prState=merged) so cross-links from
+  // the Insights "Month in review" cards land on the right PR list.
+  const [prStateFilter, setPrStateFilter] = useState<"all" | "open" | "created" | "merged" | "closed">(() => {
+    const v = searchParams.get("prState");
+    return v === "open" || v === "created" || v === "merged" || v === "closed" ? v : "all";
+  });
   const [processCategories, setProcessCategories] = useState<ProcessCategory[]>([]);
   const [govWaitStates, setGovWaitStates] = useState<GovernanceWaitState[]>([]);
   const [crossTabRaw, setCrossTabRaw] = useState<Array<{ processType: string; govState: string; count: number }>>([]);
@@ -423,6 +428,10 @@ export default function PRsAnalyticsPage() {
     const to = trendToMonth ?? monthlySeries[monthlySeries.length - 1].month;
     return monthlySeries.filter((row) => row.month >= from && row.month <= to);
   }, [monthlySeries, trendFromMonth, trendToMonth]);
+
+  // Dropdown options list the months latest-first (the chart data itself stays
+  // chronological). Newest month is the one people pick most often.
+  const monthOptionsDesc = useMemo(() => [...monthlySeries].reverse(), [monthlySeries]);
 
   const monthlyOption = useMemo(() => {
     const months = rangeMonths.map((m) => m.month);
@@ -958,7 +967,7 @@ export default function PRsAnalyticsPage() {
               }}
               className="h-8 rounded-md border border-border bg-muted/40 px-2.5 text-xs text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
             >
-              {monthlySeries.map((m) => (
+              {monthOptionsDesc.map((m) => (
                 <option key={`from-${m.month}`} value={m.month}>
                   {m.month}
                 </option>
@@ -974,7 +983,7 @@ export default function PRsAnalyticsPage() {
               }}
               className="h-8 rounded-md border border-border bg-muted/40 px-2.5 text-xs text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
             >
-              {monthlySeries.map((m) => (
+              {monthOptionsDesc.map((m) => (
                 <option key={`to-${m.month}`} value={m.month}>
                   {m.month}
                 </option>
@@ -986,7 +995,7 @@ export default function PRsAnalyticsPage() {
               onChange={(e) => setSelectedMonth(e.target.value || null)}
               className="h-8 rounded-md border border-border bg-muted/40 px-2.5 text-xs text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
             >
-              {monthlySeries.map((m) => (
+              {monthOptionsDesc.map((m) => (
                 <option key={`ctx-${m.month}`} value={m.month}>
                   {m.month}
                 </option>
@@ -1020,6 +1029,12 @@ export default function PRsAnalyticsPage() {
             />
           </div>
         )}
+        <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
+          <strong className="text-foreground">Created</strong>, <strong className="text-foreground">Merged</strong> and{" "}
+          <strong className="text-foreground">Closed</strong> count PRs by what happened to them within each month.{" "}
+          <strong className="text-foreground">Open EOM</strong> = <em>Open at End of Month</em>: the number of PRs still open on the
+          last day of that month (the running backlog), not a per-month action.
+        </p>
         <GraphFooter nextUpdateAt={nextUpdateAt} />
       </Section>
 

--- a/src/app/insights/layout.tsx
+++ b/src/app/insights/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
 import { buildMetadata } from "@/lib/seo";
+// Insights shares the merged Analytics/Insights hub shell (grouped tab bar +
+// header). The shell hides the time-range/repo controls on /insights routes.
+import DataHubLayout from "@/app/analytics/analytics-layout-client";
 
 export const metadata: Metadata = buildMetadata({
   title: "Insights",
@@ -10,5 +13,5 @@ export const metadata: Metadata = buildMetadata({
 });
 
 export default function InsightsLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+  return <DataHubLayout>{children}</DataHubLayout>;
 }

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -11,11 +11,9 @@ import {
   ClipboardList,
   Layers,
   LineChart,
-  Lightbulb,
   Package,
   Settings,
   ChevronRight,
-  Sparkles,
   ListTree,
   PanelLeft,
   PanelLeftOpen,
@@ -27,9 +25,6 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { useSidebarStore } from "@/stores/sidebarStore";
-import { usePersonaStore } from "@/stores/personaStore";
-import { DEFAULT_PERSONA, type Persona } from "@/lib/persona";
-import { FEATURES } from "@/lib/features";
 import { cn } from "@/lib/utils";
 import { client } from "@/lib/orpc";
 import {
@@ -108,69 +103,9 @@ const sidebarSections: SidebarSection[] = [
     ],
   },
   {
-    id: "standards",
-    label: "Standards & Governance",
+    id: "explore",
+    label: "Explore",
     items: [
-      {
-        title: "Upgrades",
-        icon: Package,
-        href: "/upgrade",
-        items: [
-          { title: "Overview", href: "/upgrade" },
-          { title: "Upgrade EIP Directory", href: "/upgrade/eips" },
-          {
-            title: "Current Upgrades",
-            href: "/upgrade",
-            items: [
-              { title: "Hegotá", href: "/upgrade/hegota" },
-              { title: "Glamsterdam", href: "/upgrade/glamsterdam" },
-              { title: "Fusaka", href: "/upgrade/fusaka" },
-            ],
-          },
-          { title: "Previous Upgrades", href: "/upgrade/archive" },
-          { title: "Devnets", href: "/upgrade/devnets" },
-          { title: "Schedule", href: "/upgrade/schedule" },
-        ],
-      },
-      {
-        title: "Calls",
-        icon: CalendarClock,
-        href: "/calls",
-        items: [
-          { title: "All Calls", href: "/calls" },
-          {
-            title: "ACD Calls",
-            href: "/calls?series=acd#recent",
-            items: [
-              { title: "ACDE - Execution", href: "/calls?series=acd&acd=acde#recent" },
-              { title: "ACDC - Consensus", href: "/calls?series=acd&acd=acdc#recent" },
-              { title: "ACDT - Testing", href: "/calls?series=acd&acd=acdt#recent" },
-              { title: "ACDT-CL Breakout", href: "/calls?series=acd&acd=acdtcl#recent" },
-            ],
-          },
-          { title: "Breakout Calls", href: "/calls?series=breakouts#recent" },
-          {
-            title: "Decisions",
-            href: "/decisions",
-            items: [
-              { title: "All Decisions", href: "/decisions" },
-              { title: "From ACD", href: "/decisions?series=acd#decisions" },
-              { title: "From Breakouts", href: "/decisions?series=breakouts#decisions" },
-            ],
-          },
-          { title: "Lucid · Mempool", href: "/lucid" },
-        ],
-      },
-      {
-        title: "Open PR Board",
-        icon: ClipboardList,
-        href: "/board",
-        items: [
-          { title: "Open PR Board", href: "/board" },
-          { title: "Waiting on Editor", href: "/board?status=Waiting+on+Editor" },
-          { title: "Agenda Maker", href: "/board/agenda" },
-        ],
-      },
       {
         title: "Standards",
         icon: Layers,
@@ -197,46 +132,75 @@ const sidebarSections: SidebarSection[] = [
     ],
   },
   {
-    id: "analytics",
-    label: "Analytics & Insights",
+    id: "governance",
+    label: "Roadmap & Governance",
     items: [
       {
-        title: "Analytics",
-        icon: LineChart,
-        href: "/analytics",
+        title: "Upgrades",
+        icon: Package,
+        href: "/upgrade",
+        // Flattened to two levels — current forks sit alongside the other
+        // upgrade views instead of behind a "Current Upgrades" sub-tree.
         items: [
-          // Most-used first: PR and Editor analytics are the daily drivers.
-          { title: "PRs", href: "/analytics/prs" },
-          { title: "Editors Leadership Board", href: "/analytics/editors" },
-          { title: "EIPs", href: "/analytics/eips" },
-          { title: "Reviewers", href: "/analytics/reviewers" },
-          { title: "Authors", href: "/analytics/authors" },
-          { title: "Contributors", href: "/analytics/contributors" },
-          { title: "Issues", href: "/analytics/issues" },
+          { title: "Overview", href: "/upgrade" },
+          { title: "Upgrade EIP Directory", href: "/upgrade/eips" },
+          { title: "Hegotá", href: "/upgrade/hegota" },
+          { title: "Glamsterdam", href: "/upgrade/glamsterdam" },
+          { title: "Fusaka", href: "/upgrade/fusaka" },
+          { title: "Previous Upgrades", href: "/upgrade/archive" },
+          { title: "Devnets", href: "/upgrade/devnets" },
+          { title: "Schedule", href: "/upgrade/schedule" },
         ],
       },
       {
-        title: "Insights",
-        icon: Lightbulb,
-        href: "/insights",
+        title: "Protocol Calls",
+        icon: CalendarClock,
+        href: "/calls",
+        // Flattened — ACD sub-types and Decision filters are chosen in-page,
+        // not via a third sidebar level.
         items: [
-          { title: "This Week in EIPs", href: "/insights/weekly" },
-          { title: "Monthly Analysis", href: "/insights" },
-          { title: "Editorial Commentary", href: "/insights/commentary" },
+          { title: "All Calls", href: "/calls" },
+          { title: "ACD Calls", href: "/calls?series=acd#recent" },
+          { title: "Breakout Calls", href: "/calls?series=breakouts#recent" },
+          { title: "Decisions", href: "/decisions" },
+          { title: "Lucid · Mempool", href: "/lucid" },
+        ],
+      },
+      {
+        title: "Open PR Board",
+        icon: ClipboardList,
+        href: "/board",
+        items: [
+          { title: "Open PR Board", href: "/board" },
+          { title: "Waiting on Editor", href: "/board?status=Waiting+on+Editor" },
+          { title: "Agenda Maker", href: "/board/agenda" },
         ],
       },
     ],
   },
   {
-    id: "tools",
-    label: "Productivity",
+    id: "analytics",
+    label: "Analytics",
+    items: [
+      // One destination — the merged hub. Activity (PRs, Editors, EIPs…) and
+      // Insights (This Week, Monthly, Commentary) are switched via grouped
+      // tabs inside the page header, not the sidebar tree.
+      {
+        title: "Analytics & Insights",
+        icon: LineChart,
+        href: "/analytics/eips",
+      },
+    ],
+  },
+  {
+    id: "build",
+    label: "Build",
     items: [
       {
         title: "Tools",
         icon: Wrench,
         href: "/tools",
         items: [
-          // Board lives at top level as "EIP Board" — not duplicated here.
           { title: "EIP Builder", href: "/eip-builder" },
           { title: "Timeline", href: "/timeline" },
           { title: "Dependencies", href: "/dependencies" },
@@ -257,6 +221,8 @@ const sidebarSections: SidebarSection[] = [
           { title: "Blogs", href: "/resources/blogs" },
           { title: "Videos", href: "/resources/videos" },
           { title: "News", href: "/resources/news" },
+          { title: "FAQ", href: "/resources/faq" },
+          { title: "Milestones", href: "/resources/milestones" },
           { title: "About Us", href: "/about" },
         ],
       },
@@ -287,153 +253,13 @@ const sidebarSections: SidebarSection[] = [
 ];
 
 // ============================================================================
-// Persona-based section ordering
-// "main" is always first, "account" is always last.
-// Only the middle sections are reordered per persona.
-// ============================================================================
-
-const PERSONA_SECTION_ORDER: Record<Persona, string[]> = {
-  developer: ["standards", "analytics", "tools", "learn"],
-  editor: ["analytics", "tools", "standards", "learn"],
-  researcher: ["analytics", "standards", "tools", "learn"],
-  builder: ["tools", "standards", "learn", "analytics"],
-  enterprise: ["standards", "analytics", "learn", "tools"],
-  newcomer: ["learn", "standards", "analytics", "tools"],
-};
-
-const DEFAULT_SECTION_ORDER = ["standards", "analytics", "tools", "learn"];
-
-// ============================================================================
-// Persona-based visibility
-// "main" and "account" sections are always shown (pinned first/last).
-// Developer = all sections visible (baseline, ordering only).
-// ============================================================================
-
-const PERSONA_VISIBLE_SECTIONS: Record<Persona, string[]> = {
-  developer:  ["standards", "analytics", "tools", "learn"], // all - baseline
-  editor:     ["analytics", "standards"],                    // hide tools + learn
-  researcher: ["analytics", "standards", "tools", "learn"],
-  builder:    ["tools", "standards", "learn", "analytics"],
-  enterprise: ["standards", "analytics", "learn", "tools"],
-  newcomer:   ["learn", "standards", "analytics", "tools"],
-};
-
-// Sub-item allow-lists per persona. Keyed by SidebarItem title.
-// Undefined entry = allow all sub-items.
-const PERSONA_VISIBLE_SUBITEMS: Partial<Record<Persona, Record<string, string[]>>> = {
-  editor: {
-    // Authors and Contributors are not part of the editorial workflow.
-    // (Board moved out of Analytics to its own top-level "EIP Board" item.)
-    Analytics: ["PRs", "Editor Leadership Board", "EIPs", "Reviewers"],
-  },
-};
-
-// The four daily drivers — Upgrades, Calls & Decisions, EIP Board, Analytics/Insights —
-// are ranked first for the personas that actually use them.
-const PERSONA_ITEM_PRIORITY: Record<Persona, string[]> = {
-  developer: [
-    "Upgrades",
-    "Calls",
-    "EIP Board",
-    "Analytics",
-    "Insights",
-    "Standards",
-    "Explore",
-    "Tools",
-    "Resources",
-    "Search",
-    "Home",
-    "Dashboard",
-  ],
-  editor: [
-    "EIP Board",
-    "Calls",
-    "Analytics",
-    "Upgrades",
-    "Insights",
-    "Search",
-    "Standards",
-    "Tools",
-    "Explore",
-    "Resources",
-    "Home",
-    "Dashboard",
-  ],
-  researcher: [
-    "Analytics",
-    "Insights",
-    "Upgrades",
-    "Calls",
-    "Standards",
-    "EIP Board",
-    "Explore",
-    "Search",
-    "Tools",
-    "Resources",
-    "Home",
-    "Dashboard",
-  ],
-  builder: [
-    "Tools",
-    "Upgrades",
-    "Standards",
-    "EIP Board",
-    "Search",
-    "Explore",
-    "Resources",
-    "Calls",
-    "Insights",
-    "Analytics",
-    "Home",
-    "Dashboard",
-  ],
-  enterprise: [
-    "Upgrades",
-    "Calls",
-    "Insights",
-    "Standards",
-    "Analytics",
-    "Explore",
-    "Resources",
-    "EIP Board",
-    "Tools",
-    "Search",
-    "Home",
-    "Dashboard",
-  ],
-  newcomer: [
-    "Resources",
-    "Upgrades",
-    "Standards",
-    "Explore",
-    "Home",
-    "Dashboard",
-    "Insights",
-    "Calls",
-    "Analytics",
-    "EIP Board",
-    "Tools",
-    "Search",
-  ],
-};
-
-// ============================================================================
 // Helpers
 // ============================================================================
 
-function sortItemsByPersonaPriority(
-  items: SidebarItem[],
-  persona: Persona
-): SidebarItem[] {
-  const priority = PERSONA_ITEM_PRIORITY[persona];
-  const rank = new Map(priority.map((title, idx) => [title, idx]));
-  return [...items].sort((a, b) => {
-    const ar = rank.get(a.title) ?? Number.MAX_SAFE_INTEGER;
-    const br = rank.get(b.title) ?? Number.MAX_SAFE_INTEGER;
-    if (ar !== br) return ar - br;
-    return a.title.localeCompare(b.title);
-  });
-}
+// NOTE: The sidebar renders one canonical structure. It used to be reordered
+// and filtered per persona; that layer was removed (persona is being
+// deprecated) so `sidebarSections` is now the single source of truth for order
+// and visibility, with the only runtime gate being the Admin item (role-based).
 
 /**
  * Display-label overrides for "On this page", keyed by section id.
@@ -460,37 +286,6 @@ const SECTION_LABEL_OVERRIDES: Record<string, string> = {
   "upgrade-eip-details": "EIP Details",
 };
 
-function getOrderedSections(persona: Persona | null): SidebarSection[] {
-  const sectionMap = new Map(sidebarSections.map((s) => [s.id, s]));
-  const mainSection = sectionMap.get("main")!;
-  const accountSection = sectionMap.get("account")!;
-
-  // Respect the feature flag — if persona nav reordering is off, use default order
-  const effectivePersona = persona || DEFAULT_PERSONA;
-
-  if (!FEATURES.PERSONA_NAV_REORDER) {
-    const middleSections = DEFAULT_SECTION_ORDER
-      .map((id) => sectionMap.get(id))
-      .filter((s): s is SidebarSection => !!s);
-    return [mainSection, ...middleSections, accountSection].map((section) => ({
-      ...section,
-      items: sortItemsByPersonaPriority(section.items, effectivePersona),
-    }));
-  }
-
-  const order =
-    PERSONA_SECTION_ORDER[effectivePersona] || DEFAULT_SECTION_ORDER;
-
-  const middleSections = order
-    .map((id) => sectionMap.get(id))
-    .filter((s): s is SidebarSection => !!s);
-
-  return [mainSection, ...middleSections, accountSection].map((section) => ({
-    ...section,
-    items: sortItemsByPersonaPriority(section.items, effectivePersona),
-  }));
-}
-
 /**
  * Determine which collapsible menu item should be auto-expanded
  * based on the current pathname.
@@ -508,16 +303,24 @@ function getActiveItemTitle(pathname: string): string | null {
     return "Standards";
   if (pathname.startsWith("/explore")) return "Explore";
   if (pathname.startsWith("/upgrade")) return "Upgrades";
-  if (pathname.startsWith("/analytics")) return "Analytics";
+  // Analytics + Insights are one destination now.
+  if (pathname.startsWith("/analytics") || pathname.startsWith("/insights"))
+    return "Analytics & Insights";
+  // Protocol Calls covers calls, decisions and the Lucid mempool page.
   if (
-    pathname === "/board" ||
+    pathname.startsWith("/calls") ||
+    pathname.startsWith("/decisions") ||
+    pathname.startsWith("/lucid")
+  )
+    return "Protocol Calls";
+  if (pathname === "/board" || pathname.startsWith("/board")) return "Open PR Board";
+  if (
     pathname.startsWith("/eip-builder") ||
     pathname.startsWith("/timeline") ||
     pathname.startsWith("/dependencies") ||
     pathname.startsWith("/tools")
   )
     return "Tools";
-  if (pathname.startsWith("/insights")) return "Insights";
   if (pathname.startsWith("/resources")) return "Resources";
   if (pathname.startsWith("/profile")) return "Settings";
   if (pathname.startsWith("/settings")) return "Settings";
@@ -534,10 +337,6 @@ function AppSidebarContent() {
   const searchParams = useSearchParams();
   const { state, toggleSidebar: toggleSidebarUI } = useSidebar();
   const { isOpen, toggleSidebar } = useSidebarStore();
-  const persona = usePersonaStore((s) => s.persona);
-  const sidebarShowAllSections = usePersonaStore(
-    (s) => s.defaultView.sidebarShowAllSections ?? false
-  );
 
   // Accordion behavior: only one parent open at a time
   const [openItem, setOpenItem] = React.useState<string | null>(null);
@@ -673,51 +472,21 @@ function AppSidebarContent() {
     };
   }, []);
 
-  // Get persona-ordered sections
-  const orderedSections = React.useMemo(
-    () => getOrderedSections(persona),
-    [persona]
-  );
-
+  // One canonical structure (declared order). The only runtime gate left is the
+  // role-based Admin item in the account section.
   const visibleSections = React.useMemo(() => {
-    const effectivePersona = persona || DEFAULT_PERSONA;
-    const bypassFilter = sidebarShowAllSections || !FEATURES.PERSONA_NAV_VISIBILITY;
-
-    return orderedSections
-      .filter((section) => {
-        // main and account are always shown
-        if (section.id === "main" || section.id === "account") return true;
-        if (bypassFilter) return true;
-        return PERSONA_VISIBLE_SECTIONS[effectivePersona]?.includes(section.id) ?? true;
-      })
-      .map((section) => {
-        // account section: preserve existing Admin gate
-        if (section.id === "account") {
-          return {
-            ...section,
-            items: section.items.filter((item) => {
-              if (item.title === "Admin") return isAdmin;
-              return true;
-            }),
-          };
-        }
-        // sub-item filtering per persona
-        if (bypassFilter) return section;
-        const personaSubFilter = PERSONA_VISIBLE_SUBITEMS[effectivePersona];
-        if (!personaSubFilter) return section;
+    return sidebarSections.map((section) => {
+      if (section.id === "account") {
         return {
           ...section,
-          items: section.items.map((item) => {
-            const allowedSubs = personaSubFilter[item.title];
-            if (!allowedSubs || !item.items) return item;
-            return {
-              ...item,
-              items: item.items.filter((sub) => allowedSubs.includes(sub.title)),
-            };
-          }),
+          items: section.items.filter((item) =>
+            item.title === "Admin" ? isAdmin : true
+          ),
         };
-      });
-  }, [orderedSections, isAdmin, persona, sidebarShowAllSections]);
+      }
+      return section;
+    });
+  }, [isAdmin]);
 
   // ========================================================================
   // Collapsible management
@@ -1017,9 +786,6 @@ function AppSidebarContent() {
     const isItemOpen = openItem === item.title;
     const isChildActive = hasActiveChild([...staticItems, ...contextualSectionItems]);
     const isHighlighted = isActive || isChildActive;
-    const effectivePersona = persona ?? DEFAULT_PERSONA;
-    const personaPriority = PERSONA_ITEM_PRIORITY[effectivePersona] ?? [];
-    const isRecommended = personaPriority.slice(0, 2).includes(item.title);
 
     if (hasSubItems) {
       return (
@@ -1068,9 +834,6 @@ function AppSidebarContent() {
                     >
                       {item.title}
                     </span>
-                    {isRecommended && (
-                      <Sparkles className="mr-1 h-3.5 w-3.5 text-primary" aria-label="Recommended" />
-                    )}
                     <ChevronRight
                       className={cn(
                         "h-3.5 w-3.5 text-muted-foreground transition-all duration-300",

--- a/src/components/insights/MonthlyDrilldown.tsx
+++ b/src/components/insights/MonthlyDrilldown.tsx
@@ -9,9 +9,14 @@ import { CHART_SERIES } from "@/lib/chart-colors";
 import { PageHeader, SectionSeparator } from "@/components/header";
 import {
   ArrowLeft,
+  ArrowUpRight,
+  CalendarClock,
+  CircleDot,
   Download,
   ChevronLeft,
   ChevronRight,
+  GitPullRequest,
+  Gavel,
   TrendingUp,
 } from "lucide-react";
 import { LastUpdated } from "@/components/analytics/LastUpdated";
@@ -145,6 +150,15 @@ export function MonthlyDrilldown({ initialMonth, basePath = "/insights" }: Month
   const [rangeDays, setRangeDays] = useState<number | null>(null); // null = all time
   const tableSectionRef = useRef<HTMLDivElement>(null);
 
+  // "Month in review" — activity beyond EIP status changes for the selected
+  // month: PRs, Issues, and the protocol calls + decisions that landed that
+  // month. Fetched separately (keyed on month+repo) so it stays independent of
+  // the heavier drilldown/table query above.
+  const [prKpis, setPrKpis] = useState<Awaited<ReturnType<typeof client.analytics.getPRMonthHeroKPIs>> | null>(null);
+  const [issueKpis, setIssueKpis] = useState<Awaited<ReturnType<typeof client.analytics.getIssueMonthlySummary>> | null>(null);
+  const [monthCalls, setMonthCalls] = useState<Array<Awaited<ReturnType<typeof client.calls.listRecentCalls>>[number]>>([]);
+  const [monthDecisions, setMonthDecisions] = useState<Array<Awaited<ReturnType<typeof client.calls.listRecentDecisions>>[number]>>([]);
+
   useEffect(() => {
     client.insights.getAvailableMonths().then(setAvailableMonths).catch(console.error);
   }, []);
@@ -217,6 +231,33 @@ export function MonthlyDrilldown({ initialMonth, basePath = "/insights" }: Month
     };
     run();
   }, [repo, month, page, pageSize, tableStatusFilter, tableRepoFilter, changeFilter, sortFilter, globalSearch, historyFrom, historyTo, statusTrendStatus]);
+
+  // Month-in-review: PRs, Issues, Calls & Decisions for the selected month.
+  useEffect(() => {
+    let cancelled = false;
+    const [yearStr, monthStr] = month.split("-");
+    const year = Number(yearStr);
+    const monthNum = Number(monthStr);
+    if (!year || !monthNum) return;
+    const repoArg = repo === "all" ? undefined : repo;
+
+    Promise.all([
+      client.analytics.getPRMonthHeroKPIs({ year, month: monthNum, repo: repoArg }).catch(() => null),
+      client.analytics.getIssueMonthlySummary({ year, month: monthNum, repo: repoArg }).catch(() => null),
+      client.calls.listRecentCalls({ limit: 300 }).catch(() => []),
+      client.calls.listRecentDecisions({ limit: 300 }).catch(() => []),
+    ]).then(([pr, issue, calls, decisions]) => {
+      if (cancelled) return;
+      setPrKpis(pr);
+      setIssueKpis(issue);
+      // Both feeds are date-ordered; keep only the selected month (occurred_on = YYYY-MM-DD).
+      setMonthCalls((calls as typeof monthCalls).filter((c) => c.occurred_on.startsWith(month)));
+      setMonthDecisions((decisions as typeof monthDecisions).filter((d) => d.occurred_on.startsWith(month)));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [repo, month]);
 
   useEffect(() => {
     setTableStatusFilter(null);
@@ -757,6 +798,17 @@ export function MonthlyDrilldown({ initialMonth, basePath = "/insights" }: Month
             </div>
           ) : (
             <div className="flex flex-col gap-4">
+              {/* Month in review — the whole month across EIPs: PRs, issues,
+                  protocol calls and decisions, not just status changes. */}
+              <MonthInReview
+                month={month}
+                repo={repo}
+                prKpis={prKpis}
+                issueKpis={issueKpis}
+                calls={monthCalls}
+                decisions={monthDecisions}
+              />
+
               <div className="grid items-stretch gap-3 xl:grid-cols-12">
                 <div className="xl:col-span-5 rounded-xl border border-border bg-card p-4">
                   <div className="mx-auto flex h-full w-full max-w-[860px] flex-col justify-center">
@@ -1231,5 +1283,188 @@ export function MonthlyDrilldown({ initialMonth, basePath = "/insights" }: Month
         </div>
       </div>
     </div>
+  );
+}
+
+// ============================================================================
+// Month in review — cross-activity digest for the selected month
+// ============================================================================
+
+type PRKpis = Awaited<ReturnType<typeof client.analytics.getPRMonthHeroKPIs>>;
+type IssueKpis = Awaited<ReturnType<typeof client.analytics.getIssueMonthlySummary>>;
+type CallRow = Awaited<ReturnType<typeof client.calls.listRecentCalls>>[number];
+type DecisionRow = Awaited<ReturnType<typeof client.calls.listRecentDecisions>>[number];
+
+/**
+ * key_decisions is loosely-typed JSON. The stored shape is an object
+ * `{ meeting, key_decisions: [{ type, context, timestamp }] }`, but tolerate a
+ * bare array or flat objects too. Pull readable decision strings out of it.
+ */
+function decisionTexts(kd: unknown): string[] {
+  if (!kd) return [];
+  let list: unknown[] = [];
+  if (Array.isArray(kd)) {
+    list = kd;
+  } else if (typeof kd === "object") {
+    const o = kd as Record<string, unknown>;
+    list = Array.isArray(o.key_decisions) ? o.key_decisions : [kd];
+  }
+  return list
+    .map((d) => {
+      if (typeof d === "string") return d;
+      if (d && typeof d === "object") {
+        const o = d as Record<string, unknown>;
+        for (const f of ["context", "decision", "text", "summary", "title"]) {
+          if (typeof o[f] === "string" && o[f]) return o[f] as string;
+        }
+      }
+      return "";
+    })
+    .filter(Boolean);
+}
+
+function callHref(row: { series: string; call_number: string | null; call_id: string }): string {
+  return `/calls/${row.series}/${row.call_number ?? row.call_id}`;
+}
+
+function callTitle(row: { series: string; call_number: string | null; display_name: string | null }): string {
+  return row.display_name || `${row.series.toUpperCase()} #${row.call_number ?? ""}`.trim();
+}
+
+function MonthInReview({
+  month,
+  repo,
+  prKpis,
+  issueKpis,
+  calls,
+  decisions,
+}: {
+  month: string;
+  repo: "all" | "eips" | "ercs" | "rips";
+  prKpis: PRKpis | null;
+  issueKpis: IssueKpis | null;
+  calls: CallRow[];
+  decisions: DecisionRow[];
+}) {
+  const decisionCount = decisions.reduce((n, d) => n + decisionTexts(d.key_decisions).length, 0);
+
+  // Deep-link into an analytics page scoped to THIS month (and repo). The
+  // analytics shell reads range/fromMonth/toMonth/repo from the URL, so the
+  // target page opens filtered to the same month the card summarises.
+  const analyticsHref = (page: "prs" | "issues", extra?: Record<string, string>): string => {
+    const p = new URLSearchParams({ range: "custom", fromMonth: month, toMonth: month });
+    if (repo !== "all") p.set("repo", repo);
+    for (const [k, v] of Object.entries(extra ?? {})) p.set(k, v);
+    return `/analytics/${page}?${p.toString()}`;
+  };
+
+  return (
+    <section className="rounded-xl border border-border bg-card p-4">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-semibold text-foreground">Month in review</h3>
+          <p className="text-xs text-muted-foreground">
+            Everything that moved in {monthLabel(month)} — not just status changes.
+          </p>
+        </div>
+      </div>
+
+      {/* KPI band: PRs · Issues · Calls · Decisions — each opens its analytics
+          page scoped to this month. */}
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-6">
+        <Kpi icon={GitPullRequest} accent="text-emerald-500" label="PRs merged" value={prKpis?.mergedPRs} href={analyticsHref("prs", { prState: "merged" })} />
+        <Kpi icon={GitPullRequest} accent="text-blue-500" label="PRs opened" value={prKpis?.newPRs} href={analyticsHref("prs", { prState: "created" })} />
+        <Kpi icon={GitPullRequest} accent="text-rose-500" label="PRs closed" value={prKpis?.closedUnmerged} href={analyticsHref("prs", { prState: "closed" })} />
+        <Kpi icon={CircleDot} accent="text-amber-500" label="Issues opened" value={issueKpis?.newIssues} href={analyticsHref("issues")} />
+        <Kpi icon={CalendarClock} accent="text-violet-500" label="Protocol calls" value={calls.length} href="/calls" />
+        <Kpi icon={Gavel} accent="text-cyan-500" label="Decisions" value={decisionCount} href="/decisions" />
+      </div>
+
+      {/* Calls & decisions detail for the month */}
+      <div className="mt-3 grid gap-3 lg:grid-cols-2">
+        <div className="rounded-lg border border-border/70 bg-background/40 p-3">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-foreground">
+              <CalendarClock className="h-3.5 w-3.5 text-violet-500" /> Protocol calls
+            </span>
+            <Link href="/calls" className="inline-flex items-center gap-0.5 text-[11px] text-primary hover:underline">
+              All calls <ArrowUpRight className="h-3 w-3" />
+            </Link>
+          </div>
+          {calls.length === 0 ? (
+            <p className="py-3 text-center text-xs text-muted-foreground">No calls recorded this month.</p>
+          ) : (
+            <ul className="space-y-1">
+              {calls.slice(0, 8).map((c) => (
+                <li key={`${c.series}-${c.call_id}`}>
+                  <Link
+                    href={callHref(c)}
+                    className="flex items-center justify-between gap-2 rounded-md px-2 py-1 text-xs text-foreground/90 transition-colors hover:bg-muted/60"
+                  >
+                    <span className="min-w-0 truncate">{callTitle(c)}</span>
+                    <span className="shrink-0 text-[11px] text-muted-foreground">{c.occurred_on.slice(5)}</span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="rounded-lg border border-border/70 bg-background/40 p-3">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-foreground">
+              <Gavel className="h-3.5 w-3.5 text-cyan-500" /> Decisions
+            </span>
+            <Link href="/decisions" className="inline-flex items-center gap-0.5 text-[11px] text-primary hover:underline">
+              All decisions <ArrowUpRight className="h-3 w-3" />
+            </Link>
+          </div>
+          {decisions.length === 0 ? (
+            <p className="py-3 text-center text-xs text-muted-foreground">No decisions recorded this month.</p>
+          ) : (
+            <ul className="space-y-1.5">
+              {decisions.slice(0, 5).flatMap((d) => {
+                const texts = decisionTexts(d.key_decisions).slice(0, 2);
+                return texts.map((t, i) => (
+                  <li key={`${d.series}-${d.call_id}-${i}`} className="flex gap-2 text-xs text-muted-foreground">
+                    <span className="mt-1 h-1 w-1 shrink-0 rounded-full bg-cyan-500" />
+                    <Link href={callHref(d)} className="min-w-0 hover:text-foreground">
+                      <span className="line-clamp-2">{t}</span>
+                    </Link>
+                  </li>
+                ));
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Kpi({
+  icon: Icon,
+  accent,
+  label,
+  value,
+  href,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  accent: string;
+  label: string;
+  value: number | undefined;
+  href: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className="group rounded-lg border border-border bg-background/40 p-2.5 transition-colors hover:border-primary/40"
+    >
+      <Icon className={`h-4 w-4 ${accent}`} />
+      <p className="mt-1.5 text-xl font-bold tracking-tight text-foreground">
+        {value == null ? "—" : value.toLocaleString()}
+      </p>
+      <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">{label}</p>
+    </Link>
   );
 }


### PR DESCRIPTION
This pull request introduces a major reorganization and simplification of the navigation structure, as well as several usability improvements for the Analytics and Insights sections. The main navigation sidebar has been flattened and clarified, with related sections grouped more intuitively. The Analytics and Insights views are now unified under a single hub with a grouped tab bar for switching between data-heavy and editorial views. Additionally, minor UX improvements have been made to analytics pages, such as better dropdown ordering and explanatory text.

**Navigation and Layout Overhaul**

- The sidebar navigation is reorganized for clarity: "Standards" and "Explore" are grouped under a new "Explore" section, "Roadmap & Governance" is separated, and "Analytics & Insights" is merged into a single entry that routes to the new analytics hub. The "Build" section replaces "Productivity" for tools. [[1]](diffhunk://#diff-167140c3830943094d6b84a9cdb9155e4c4762762d1d8245330b48be404758a6L111-R165) [[2]](diffhunk://#diff-167140c3830943094d6b84a9cdb9155e4c4762762d1d8245330b48be404758a6L174-L239) [[3]](diffhunk://#diff-167140c3830943094d6b84a9cdb9155e4c4762762d1d8245330b48be404758a6R224-R225)
- The Analytics and Insights pages now share a single layout with a grouped segmented tab bar for switching between "Activity" (data views) and "Insights" (editorial content). The header and controls are contextually rendered based on the current view. [[1]](diffhunk://#diff-de826d26953174dad8aff8172c1bb2a236c3bd708297701128a12137de198837R145-R223) [[2]](diffhunk://#diff-de826d26953174dad8aff8172c1bb2a236c3bd708297701128a12137de198837R374-R381) [[3]](diffhunk://#diff-de826d26953174dad8aff8172c1bb2a236c3bd708297701128a12137de198837L306-R399) [[4]](diffhunk://#diff-de826d26953174dad8aff8172c1bb2a236c3bd708297701128a12137de198837R413-R416) [[5]](diffhunk://#diff-de826d26953174dad8aff8172c1bb2a236c3bd708297701128a12137de198837R495-R502) [[6]](diffhunk://#diff-159ecfeb2dcf074366bfdcfbc6f186feef0a88e4d803166e75268302496e8ff8R3-R5) [[7]](diffhunk://#diff-159ecfeb2dcf074366bfdcfbc6f186feef0a88e4d803166e75268302496e8ff8L13-R16)

**Analytics & Insights UX Improvements**

- Analytics dropdowns for selecting months now show the newest month first, making frequent selections easier. [[1]](diffhunk://#diff-9538e727ae560d5e5bb01d471e18d2c133b644d15c3af662e8ad6bb3be9b1cc7R432-R435) [[2]](diffhunk://#diff-9538e727ae560d5e5bb01d471e18d2c133b644d15c3af662e8ad6bb3be9b1cc7L961-R970) [[3]](diffhunk://#diff-9538e727ae560d5e5bb01d471e18d2c133b644d15c3af662e8ad6bb3be9b1cc7L977-R986) [[4]](diffhunk://#diff-9538e727ae560d5e5bb01d471e18d2c133b644d15c3af662e8ad6bb3be9b1cc7L989-R998)
- The PR analytics page now reads the initial tab state from the URL, allowing deep links to specific PR states (e.g., from Insights cards).
- Explanatory text has been added to the PRs and Issues analytics pages to clarify the meaning of metrics like "Created," "Closed," "Merged," and "Open EOM." [[1]](diffhunk://#diff-9538e727ae560d5e5bb01d471e18d2c133b644d15c3af662e8ad6bb3be9b1cc7R1032-R1037) [[2]](diffhunk://#diff-eae4a3c1ea78a7b8d0b3dd34685587f3a68fc80b47a293d593307205415dbc4eR313-R317)

These changes greatly improve navigation clarity and user experience, especially for users switching between data analytics and editorial insights.