### PR TITLE
Change default selected chart tab to Distribution of EIPs

### DIFF
--- a/src/components/upgrade/upgrade-charts-tabs.tsx
+++ b/src/components/upgrade/upgrade-charts-tabs.tsx
@@ -19,7 +19,7 @@ const TABS: { key: ChartTab; label: string }[] = [
 ];
 
 export function UpgradeChartsTabs() {
-  const [tab, setTab] = useState<ChartTab>('timeline');
+  const [tab, setTab] = useState<ChartTab>('distribution');
 
   return (
     <div className="space-y-4">


### PR DESCRIPTION
This pull request makes a small change to the default selected tab in the `UpgradeChartsTabs` component. The initial tab is now set to `'distribution'` instead of `'timeline'`.