### PR TITLE
Add OpenGraph social cards for /lucid and /office-hours routes

### DIFF
--- a/src/app/lucid/layout.tsx
+++ b/src/app/lucid/layout.tsx
@@ -7,6 +7,7 @@ export const metadata: Metadata = buildMetadata({
     'A dedicated tracker for Lucid (EIP-8184), Ethereum\'s encrypted mempool effort — working-group meeting summaries, key decisions, and research links, built with encryptedmempool.org.',
   path: '/lucid',
   keywords: ['Lucid', 'encrypted mempool', 'EIP-8184', 'Encrypt the Mempool', 'MEV', 'Ethereum'],
+  image: null,
 });
 
 export default function LucidLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/lucid/opengraph-image.tsx
+++ b/src/app/lucid/opengraph-image.tsx
@@ -1,0 +1,32 @@
+import { ImageResponse } from 'next/og';
+import { ogCard, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og-card';
+
+export const runtime = 'nodejs';
+export const revalidate = 300;
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = 'Lucid — Encrypted Mempool Tracker on EIPsInsight';
+
+export default function Image() {
+  const rows = [
+    'A dedicated tracker for EIP-8184 (Lucid), Ethereum\'s encrypted mempool effort.',
+    'Browse working-group meeting summaries, key decisions, and research links.',
+  ];
+
+  const chips = [
+    'Encrypted Mempool',
+    'EIP-8184 Tracker',
+    'EIPsInsight',
+  ];
+
+  return new ImageResponse(
+    ogCard({
+      badge: 'LUCID',
+      meta: 'eipsinsight.com/lucid',
+      title: 'Lucid — Encrypted Mempool Tracker',
+      rows,
+      chips,
+    }),
+    size
+  );
+}

--- a/src/app/office-hours/layout.tsx
+++ b/src/app/office-hours/layout.tsx
@@ -7,6 +7,7 @@ export const metadata: Metadata = buildMetadata({
     "Editorial-activity dashboard for EIP Editing Office Hours — editor leaderboard, status changes, and proposals worked on, for any day or date range.",
   path: "/office-hours",
   keywords: ["EIP Editing Office Hour", "EIP editors", "editorial activity", "Ethereum"],
+  image: null,
 });
 
 export default function OfficeHoursLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/office-hours/opengraph-image.tsx
+++ b/src/app/office-hours/opengraph-image.tsx
@@ -1,0 +1,32 @@
+import { ImageResponse } from 'next/og';
+import { ogCard, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og-card';
+
+export const runtime = 'nodejs';
+export const revalidate = 300;
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = 'EIP Editing Office Hours Dashboard on EIPsInsight';
+
+export default function Image() {
+  const rows = [
+    'Editorial-activity dashboard for EIP Editing Office Hours.',
+    'Browse editor leaderboard, status changes, and proposals worked on.',
+  ];
+
+  const chips = [
+    'EIP Editing',
+    'Editor Leaderboard',
+    'EIPsInsight',
+  ];
+
+  return new ImageResponse(
+    ogCard({
+      badge: 'OFFICE HOURS',
+      meta: 'eipsinsight.com/office-hours',
+      title: 'EIP Editing Office Hours',
+      rows,
+      chips,
+    }),
+    size
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -33,6 +33,8 @@ const STATIC_PUBLIC_PATHS = [
   "/dependencies",
   "/eip-builder",
   "/timeline",
+  "/lucid",
+  "/office-hours",
   "/upgrade",
   "/upgrade/archive",
 ] as const;


### PR DESCRIPTION
This pull request adds Open Graph (OG) image generation for the `/lucid` and `/office-hours` pages, improves SEO metadata, and ensures these pages are included in the sitemap. These changes enhance link previews and discoverability for these sections of the site.

**Open Graph image generation:**

* Added `src/app/lucid/opengraph-image.tsx` to generate a custom OG image for the `/lucid` page, including relevant titles, descriptions, and tags.
* Added `src/app/office-hours/opengraph-image.tsx` to generate a custom OG image for the `/office-hours` page, with tailored content and branding.

**SEO and metadata improvements:**

* Updated the `metadata` in `src/app/lucid/layout.tsx` and `src/app/office-hours/layout.tsx` to explicitly set `image: null`, delegating OG image handling to the new dynamic generators. [[1]](diffhunk://#diff-e9cfa00f1648c2afbf3b1a4e4743a1210ea53e3c391ce6843fc08d463dc01a0cR10) [[2]](diffhunk://#diff-6ff8bda57dacc90dcc796f0f69060f45c9213317738cb5dc4ada0a15b7c90385R10)

**Sitemap updates:**

* Added `/lucid` and `/office-hours` to the `STATIC_PUBLIC_PATHS` array in `src/app/sitemap.ts`, ensuring these pages are included in the generated sitemap for better search engine indexing.