### PR TITLE
Add Google Tag (gtag.js) to root layout HTML head

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -63,6 +63,18 @@ export default function RootLayout({
   return (
     <html lang="en" data-scroll-behavior="smooth" suppressHydrationWarning>
       <head>
+        {/* Google tag (gtag.js) */}
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-N59QCDB9WN" />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', 'G-N59QCDB9WN');
+            `,
+          }}
+        />
         <script
           defer
           src="https://analytics.eipsinsight.com/script.js"


### PR DESCRIPTION
This pull request adds Google Analytics tracking to the application by including the necessary `gtag.js` scripts in the root layout.

Analytics integration:

* [`src/app/layout.tsx`](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R66-R77): Added the Google Analytics `gtag.js` script and initialization code in the `<head>` section to enable tracking with the measurement ID `G-N59QCDB9WN`.