### PR TITLE
Replace AI-generated em dashes with standard hyphens in Lucid Tracker

### DIFF
--- a/src/app/lucid/layout.tsx
+++ b/src/app/lucid/layout.tsx
@@ -2,9 +2,9 @@ import type { Metadata } from 'next';
 import { buildMetadata } from '@/lib/seo';
 
 export const metadata: Metadata = buildMetadata({
-  title: 'Lucid — Encrypted Mempool',
+  title: 'Lucid - Encrypted Mempool',
   description:
-    'A dedicated tracker for Lucid (EIP-8184), Ethereum\'s encrypted mempool effort — working-group meeting summaries, key decisions, and research links, built with encryptedmempool.org.',
+    'A dedicated tracker for Lucid (EIP-8184), Ethereum\'s encrypted mempool effort - working-group meeting summaries, key decisions, and research links, built with encryptedmempool.org.',
   path: '/lucid',
   keywords: ['Lucid', 'encrypted mempool', 'EIP-8184', 'Encrypt the Mempool', 'MEV', 'Ethereum'],
   image: null,

--- a/src/app/lucid/opengraph-image.tsx
+++ b/src/app/lucid/opengraph-image.tsx
@@ -5,7 +5,7 @@ export const runtime = 'nodejs';
 export const revalidate = 300;
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
-export const alt = 'Lucid — Encrypted Mempool Tracker on EIPsInsight';
+export const alt = 'Lucid - Encrypted Mempool Tracker on EIPsInsight';
 
 export default function Image() {
   const rows = [
@@ -23,7 +23,7 @@ export default function Image() {
     ogCard({
       badge: 'LUCID',
       meta: 'eipsinsight.com/lucid',
-      title: 'Lucid — Encrypted Mempool Tracker',
+      title: 'Lucid - Encrypted Mempool Tracker',
       rows,
       chips,
     }),

--- a/src/app/lucid/page.tsx
+++ b/src/app/lucid/page.tsx
@@ -35,7 +35,7 @@ import { cn } from '@/lib/utils';
 import { InlineBrandLoader } from '@/components/inline-brand-loader';
 
 /**
- * Dedicated tracker for Lucid (EIP-8184) — Ethereum's encrypted mempool effort,
+ * Dedicated tracker for Lucid (EIP-8184) - Ethereum's encrypted mempool effort,
  * built with encryptedmempool.org. Pulls the "Encrypt The Mempool" (ETM) working
  * group call summaries/decisions we already ingest, alongside the EIP and the
  * research threads. Route aliases /mempool and /encrypted-mempool redirect here.
@@ -63,20 +63,20 @@ const RESOURCES = [
   {
     label: 'encryptedmempool.org',
     href: 'https://encryptedmempool.org/',
-    desc: 'Project hub — the partner site coordinating the encrypted-mempool effort.',
+    desc: 'Project hub - the partner site coordinating the encrypted-mempool effort.',
   },
   {
-    label: 'EIP-8184 — LUCID encrypted mempool',
+    label: 'EIP-8184 - LUCID encrypted mempool',
     href: 'https://eips.ethereum.org/EIPS/eip-8184',
     desc: 'The specification (Draft, Core / Standards Track).',
   },
   {
-    label: 'Ethereum Magicians — EIP-8184: Lucid',
+    label: 'Ethereum Magicians - EIP-8184: Lucid',
     href: 'https://ethereum-magicians.org/t/eip-8184-lucid-encrypted-mempool/28017',
     desc: 'Standards discussion thread.',
   },
   {
-    label: 'ethresear.ch — Lucid: encrypted mempool with distributed payload propagation',
+    label: 'ethresear.ch - Lucid: encrypted mempool with distributed payload propagation',
     href: 'https://ethresear.ch/t/lucid-encrypted-mempool-with-distributed-payload-propagation/24042',
     desc: 'The design & research writeup.',
   },
@@ -117,14 +117,14 @@ function parseHighlights(value: unknown): Array<{ topic: string; items: string[]
   return [];
 }
 
-/** Action items are [{owner, action, timestamp}] — render "action — owner". */
+/** Action items are [{owner, action, timestamp}] - render "action - owner". */
 function parseActionItems(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value
     .map((it) => {
       const action = textOf(it, ['action', 'item', 'text', 'decision']);
       const owner = it && typeof it === 'object' ? String((it as Record<string, unknown>).owner ?? '') : '';
-      return action ? (owner ? `${action} — ${owner}` : action) : '';
+      return action ? (owner ? `${action} - ${owner}` : action) : '';
     })
     .filter(Boolean);
 }
@@ -179,7 +179,7 @@ export default function LucidPage() {
               Lucid
             </h1>
             <p className="mt-2 max-w-2xl text-pretty text-sm leading-relaxed text-muted-foreground sm:text-base">
-              An encrypted mempool for Ethereum — encrypting transactions until they&apos;re included
+              An encrypted mempool for Ethereum - encrypting transactions until they&apos;re included
               so builders and relays can&apos;t reorder or censor them, mitigating harmful MEV.
               Tracked here with <strong className="text-foreground">encryptedmempool.org</strong>:
               every working-group meeting, decision, and the live spec in one place.
@@ -200,9 +200,9 @@ export default function LucidPage() {
 
       {/* Metrics */}
       <section className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <Metric icon={Video} accent="text-violet-500" label="WG meetings" value={loading ? '—' : String(stats.meetings)} />
-        <Metric icon={CheckSquare} accent="text-emerald-500" label="Decisions logged" value={loading ? '—' : String(stats.decisions)} />
-        <Metric icon={CalendarClock} accent="text-amber-500" label="Latest meeting" value={stats.latest ? formatDate(stats.latest) : '—'} />
+        <Metric icon={Video} accent="text-violet-500" label="WG meetings" value={loading ? '-' : String(stats.meetings)} />
+        <Metric icon={CheckSquare} accent="text-emerald-500" label="Decisions logged" value={loading ? '-' : String(stats.decisions)} />
+        <Metric icon={CalendarClock} accent="text-amber-500" label="Latest meeting" value={stats.latest ? formatDate(stats.latest) : '-'} />
         <Metric icon={FileText} accent="text-blue-500" label="EIP status" value="Draft" sub="Core · Standards Track" />
       </section>
 
@@ -228,7 +228,7 @@ export default function LucidPage() {
         </div>
       </section>
 
-      {/* The MEV problem Lucid targets — live data from BlobLens */}
+      {/* The MEV problem Lucid targets - live data from BlobLens */}
       {mev && <MevSection mev={mev} />}
 
       {/* Meeting summaries */}
@@ -386,7 +386,7 @@ function MevSection({ mev }: { mev: MempoolMevStats }) {
       />
       <p className="mb-4 max-w-3xl text-pretty text-sm leading-relaxed text-muted-foreground">
         Because today&apos;s mempool is public, searchers can see pending swaps and{' '}
-        <strong className="text-foreground">sandwich</strong> them — front-running and back-running a
+        <strong className="text-foreground">sandwich</strong> them - front-running and back-running a
         victim&apos;s trade to skim value. This is the harm an encrypted mempool removes at the source.
         Measured since the Dencun upgrade (EIP-4844) across five major DEXs:
       </p>
@@ -417,7 +417,7 @@ function MevSection({ mev }: { mev: MempoolMevStats }) {
           icon={Crosshair}
           accent="text-violet-500"
           label="Blocks sandwiched"
-          value={pct != null ? `${pct}%` : '—'}
+          value={pct != null ? `${pct}%` : '-'}
           sub="of all blocks · last 30 days"
         />
       </div>
@@ -437,7 +437,7 @@ type WeekPoint = MempoolMevStats['weekly'][number] & { label: string };
 /**
  * The chart the working group actually reasons about: weekly sandwich frequency
  * (bars, left axis) against the dollar value extracted (line, right axis). The
- * two together show the "MEV payoff variance" the group debates — weeks where a
+ * two together show the "MEV payoff variance" the group debates - weeks where a
  * few large extractions dwarf a normal week of activity, i.e. exactly the payoff
  * distribution Lucid's key-reveal penalty has to deter.
  */
@@ -457,7 +457,7 @@ function MevWeeklyChart({ mev }: { mev: MempoolMevStats }) {
 
   return (
     <div className="mt-3 grid gap-3 lg:grid-cols-2">
-      {/* Frequency — how often the mempool is exploited */}
+      {/* Frequency - how often the mempool is exploited */}
       <div className="rounded-xl border border-border bg-card/60 p-4">
         <p className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
           Weekly sandwich attacks
@@ -480,7 +480,7 @@ function MevWeeklyChart({ mev }: { mev: MempoolMevStats }) {
         </div>
       </div>
 
-      {/* Payoff — the value being extracted (the "MEV payoff variance" the WG debates) */}
+      {/* Payoff - the value being extracted (the "MEV payoff variance" the WG debates) */}
       <div className="rounded-xl border border-border bg-card/60 p-4">
         <p className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
           {valueLabel} · weekly (USD)


### PR DESCRIPTION
This pull request makes consistent changes across the Lucid tracker pages to use hyphens ("-") instead of em dashes ("—") in titles, descriptions, labels, and UI text. It also standardizes the placeholder for missing metric values from "—" to "-", improving clarity and uniformity throughout the UI.

**Text and Label Standardization:**

* Changed all instances of "Lucid — Encrypted Mempool" and similar titles to use a hyphen ("-") instead of an em dash for consistency across metadata, alt text, and Open Graph images (`src/app/lucid/layout.tsx`, `src/app/lucid/opengraph-image.tsx`). [[1]](diffhunk://#diff-e9cfa00f1648c2afbf3b1a4e4743a1210ea53e3c391ce6843fc08d463dc01a0cL5-R7) [[2]](diffhunk://#diff-55dafe8829013712b80f79064c528f52acf22ff2f37ccd37bba69e32eb725395L8-R8) [[3]](diffhunk://#diff-55dafe8829013712b80f79064c528f52acf22ff2f37ccd37bba69e32eb725395L26-R26)
* Updated all resource labels, section headings, and inline documentation to use hyphens instead of em dashes, ensuring a uniform style in both UI and code comments (`src/app/lucid/page.tsx`). [[1]](diffhunk://#diff-8267db1577591a4b478b252b8b96fbb0c16d97abfed425f915edb1929c4a7300L38-R38) [[2]](diffhunk://#diff-8267db1577591a4b478b252b8b96fbb0c16d97abfed425f915edb1929c4a7300L66-R79) [[3]](diffhunk://#diff-8267db1577591a4b478b252b8b96fbb0c16d97abfed425f915edb1929c4a7300L120-R127) [[4]](diffhunk://#diff-8267db1577591a4b478b252b8b96fbb0c16d97abfed425f915edb1929c4a7300L182-R182) [[5]](diffhunk://#diff-8267db1577591a4b478b252b8b96fbb0c16d97abfed425f915edb1929c4a7300L231-R231) [[6]](diffhunk://#diff-8267db1577591a4b478b252b8b96fbb0c16d97abfed425f915edb1929c4a7300L389-R389) [[7]](diffhunk://#diff-8267db1577591a4b478b252b8b96fbb0c16d97abfed425f915edb1929c4a7300L440-R440) [[8]](diffhunk://#diff-8267db1577591a4b478b252b8b96fbb0c16d97abfed425f915edb1929c4a7300L460-R460) [[9]](diffhunk://#diff-8267db1577591a4b478b252b8b96fbb0c16d97abfed425f915edb1929c4a7300L483-R483)

**UI Placeholder Improvements:**

* Standardized the placeholder for missing metric values from "—" to "-" in the metrics section and MEV statistics, improving clarity for users when data is unavailable (`src/app/lucid/page.tsx`). [[1]](diffhunk://#diff-8267db1577591a4b478b252b8b96fbb0c16d97abfed425f915edb1929c4a7300L203-R205) [[2]](diffhunk://#diff-8267db1577591a4b478b252b8b96fbb0c16d97abfed425f915edb1929c4a7300L420-R420)

**Code Comment Consistency:**

* Updated code comments to reflect the new hyphen usage, maintaining consistency between code and UI text (`src/app/lucid/page.tsx`). [[1]](diffhunk://#diff-8267db1577591a4b478b252b8b96fbb0c16d97abfed425f915edb1929c4a7300L38-R38) [[2]](diffhunk://#diff-8267db1577591a4b478b252b8b96fbb0c16d97abfed425f915edb1929c4a7300L120-R127)

These changes ensure a more consistent and professional appearance throughout the Lucid tracker UI and codebase.