### PR TITLE
Refactor EIP Brief and implement Proposal Timeline component

### DIFF
--- a/src/app/(proposal)/[repo]/[number]/page.tsx
+++ b/src/app/(proposal)/[repo]/[number]/page.tsx
@@ -4,17 +4,12 @@ import React, { useEffect, useState } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
 import { motion } from 'motion/react';
 import {
-  TrendingUp,
   ExternalLink,
   AlertCircle,
-  ArrowRight,
   Github,
-  Activity,
-  Package,
   Copy,
   Check,
   FileCode,
-  ChevronRight,
   RefreshCw,
   Newspaper,
   Sparkles,
@@ -33,83 +28,12 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { ProposalSubscriptionCard } from '@/components/proposal-subscription-card';
 import { RepositorySubscriptionCard } from '@/components/repository-subscription-card';
 import { rawData, pairedUpgradeNames } from '@/data/network-upgrades';
-import { normalizeUpgradeBucket, stageAbbreviation, stageBadgeClass } from '@/lib/upgrade-stages';
+import { normalizeUpgradeBucket } from '@/lib/upgrade-stages';
 import { UpgradeStageSplitBadge } from '@/components/upgrade/stage-badge';
 import { EnterpriseEIPBrief, type EipCuration } from '@/components/enterprise-eip-brief';
+import { ProposalTimeline } from '@/components/proposal-timeline';
 import { BrandLoader } from '@/components/brand-loader';
 
-// Status color mapping for timeline - richer colors
-const statusColors: Record<string, { 
-  bg: string; 
-  bgGradient: string;
-  text: string; 
-  border: string; 
-  leftBorder: string;
-  dot: string;
-  dotGlow: string;
-  cardBg: string;
-}> = {
-  'Draft': { 
-    bg: 'bg-cyan-500/10', 
-    bgGradient: 'bg-gradient-to-br from-cyan-500/15 via-cyan-500/8 to-transparent',
-    text: 'text-cyan-700 dark:text-cyan-200', 
-    border: 'border-cyan-400/40', 
-    leftBorder: 'border-l-cyan-500 dark:border-l-cyan-400',
-    dot: 'bg-cyan-500',
-    dotGlow: 'shadow-cyan-500/50',
-    cardBg: 'bg-gradient-to-br from-cyan-500/20 via-cyan-500/10 to-cyan-500/5 dark:from-cyan-500/20 dark:via-cyan-500/10 dark:to-cyan-500/5'
-  },
-  'Review': { 
-    bg: 'bg-blue-500/10', 
-    bgGradient: 'bg-gradient-to-br from-blue-500/15 via-blue-500/8 to-transparent',
-    text: 'text-blue-700 dark:text-blue-200', 
-    border: 'border-blue-400/40', 
-    leftBorder: 'border-l-blue-500 dark:border-l-blue-400',
-    dot: 'bg-blue-500',
-    dotGlow: 'shadow-blue-500/50',
-    cardBg: 'bg-gradient-to-br from-blue-500/20 via-blue-500/10 to-blue-500/5'
-  },
-  'Last Call': { 
-    bg: 'bg-amber-500/10', 
-    bgGradient: 'bg-gradient-to-br from-amber-500/15 via-amber-500/8 to-transparent',
-    text: 'text-amber-700 dark:text-amber-200', 
-    border: 'border-amber-400/40', 
-    leftBorder: 'border-l-amber-500 dark:border-l-amber-400',
-    dot: 'bg-amber-500',
-    dotGlow: 'shadow-amber-500/50',
-    cardBg: 'bg-gradient-to-br from-amber-500/20 via-amber-500/10 to-amber-500/5'
-  },
-  'Final': { 
-    bg: 'bg-emerald-500/10', 
-    bgGradient: 'bg-gradient-to-br from-emerald-500/15 via-emerald-500/8 to-transparent',
-    text: 'text-emerald-700 dark:text-emerald-200', 
-    border: 'border-emerald-400/40', 
-    leftBorder: 'border-l-emerald-500 dark:border-l-emerald-400',
-    dot: 'bg-emerald-500',
-    dotGlow: 'shadow-emerald-500/50',
-    cardBg: 'bg-gradient-to-br from-emerald-500/20 via-emerald-500/10 to-emerald-500/5'
-  },
-  'Stagnant': { 
-    bg: 'bg-slate-500/10', 
-    bgGradient: 'bg-gradient-to-br from-slate-500/15 via-slate-500/8 to-transparent',
-    text: 'text-slate-700 dark:text-slate-300', 
-    border: 'border-slate-400/30', 
-    leftBorder: 'border-l-slate-500 dark:border-l-slate-400',
-    dot: 'bg-slate-500',
-    dotGlow: 'shadow-slate-500/30',
-    cardBg: 'bg-gradient-to-br from-slate-500/15 via-slate-500/8 to-slate-500/5'
-  },
-  'Withdrawn': { 
-    bg: 'bg-red-500/10', 
-    bgGradient: 'bg-gradient-to-br from-red-500/15 via-red-500/8 to-transparent',
-    text: 'text-red-700 dark:text-red-200', 
-    border: 'border-red-400/40', 
-    leftBorder: 'border-l-red-500 dark:border-l-red-400',
-    dot: 'bg-red-500',
-    dotGlow: 'shadow-red-500/50',
-    cardBg: 'bg-gradient-to-br from-red-500/20 via-red-500/10 to-red-500/5'
-  },
-};
 
 interface ProposalData {
   repo: string;
@@ -130,6 +54,15 @@ interface StatusEvent {
   to: string;
   changed_at: string;
   commit_sha?: string;
+}
+
+interface StageEvent {
+  upgrade_id: number | null;
+  upgrade: string;
+  slug: string;
+  bucket: string;
+  commit_sha: string | null;
+  commit_date: string | null;
 }
 
 interface GovernanceState {
@@ -253,15 +186,6 @@ type ProposalRepo = 'eip' | 'erc' | 'rip';
 // Helper functions
 // =============================================================================
 
-function formatInclusionBucket(bucket: string | null): string {
-  const normalized = normalizeUpgradeBucket(bucket);
-  return normalized ? stageAbbreviation(normalized) : 'Unknown';
-}
-
-function getBucketBadgeClass(bucket: string | null): string {
-  return stageBadgeClass(normalizeUpgradeBucket(bucket));
-}
-
 // Higher = more "active"/advanced. When an EIP sits in several upgrades (e.g.
 // declined in one, then re-proposed in a newer one), the headline inclusion
 // status should surface the live stage, not the dead-end DFI. Per-upgrade stages
@@ -294,26 +218,6 @@ function getStatusBadgeClass(status: string | null): string {
   if (norm === 'stagnant') return 'border-gray-500/25 bg-gray-500/12 text-gray-700 dark:text-gray-400';
   if (norm === 'withdrawn') return 'border-red-500/25 bg-red-500/12 text-red-700 dark:text-red-300';
   return 'border-slate-500/25 bg-slate-500/12 text-slate-700 dark:text-slate-300';
-}
-
-// Helper to format waiting_on state
-function formatWaitingOn(state: string | null): string {
-  if (!state) return '';
-  return state
-    .replace(/WAITING_ON_/g, 'Waiting on ')
-    .replace(/_/g, ' ')
-    .toLowerCase()
-    .replace(/\b\w/g, l => l.toUpperCase());
-}
-
-// Helper to calculate duration between events
-function calculateDuration(prevDate: string | null, currentDate: string): string | null {
-  if (!prevDate) return null;
-  const prev = new Date(prevDate);
-  const curr = new Date(currentDate);
-  const days = Math.floor((curr.getTime() - prev.getTime()) / (1000 * 60 * 60 * 24));
-  if (days === 0) return null;
-  return `${days} day${days !== 1 ? 's' : ''}`;
 }
 
 // Helper to get author initials
@@ -366,6 +270,7 @@ export default function ProposalDetailPage() {
 
   const [proposal, setProposal] = useState<ProposalData | null>(null);
   const [statusEvents, setStatusEvents] = useState<StatusEvent[]>([]);
+  const [stageEvents, setStageEvents] = useState<StageEvent[]>([]);
   const [governanceState, setGovernanceState] = useState<GovernanceState | null>(null);
   const [curation, setCuration] = useState<EipCuration | null>(null);
   const [upgrades, setUpgrades] = useState<UpgradeInclusion[]>([]);
@@ -445,9 +350,11 @@ export default function ProposalDetailPage() {
         setLoading(true);
         setError(null);
 
-        const [proposalData, statusData, governanceData, upgradesData, curationData] = await Promise.all([
+        const [proposalData, statusData, stageData, governanceData, upgradesData, curationData] = await Promise.all([
           client.proposals.getProposal({ repo: proposalRepo, number }),
           client.proposals.getStatusEvents({ repo: proposalRepo, number }),
+          // Historical stage journey (PFI → CFI → SFI, declines, re-proposals).
+          client.proposals.getStageEvents({ repo: proposalRepo, number }).catch(() => []),
           client.proposals.getGovernanceState({ repo: proposalRepo, number }),
           client.proposals.getUpgrades({ repo: proposalRepo, number }),
           // Curated per-EIP stakeholder impacts (editable in admin) ground the
@@ -457,6 +364,7 @@ export default function ProposalDetailPage() {
 
         setProposal(proposalData);
         setStatusEvents(statusData);
+        setStageEvents(stageData);
         setGovernanceState(governanceData);
         setCuration(curationData?.[0] ?? null);
         const historical = getHistoricalIncludedUpgrades(number);
@@ -669,14 +577,6 @@ export default function ProposalDetailPage() {
   const proposalId = `${repoDisplayName}-${proposal.number}`;
   const githubUrl = `https://github.com/ethereum/${repoPath}/blob/master/${filePath}/${fileName}`;
   const discussionUrl = proposal.discussions_to || discussionsTo || null;
-
-  // Determine urgency color for governance signals
-  const getUrgencyColor = (days: number | null) => {
-    if (!days) return 'text-muted-foreground';
-    if (days > 60) return 'text-red-600 dark:text-red-400';
-    if (days > 30) return 'text-amber-600 dark:text-amber-400';
-    return 'text-emerald-600 dark:text-emerald-300';
-  };
 
   return (
     <div className="min-h-screen bg-background">
@@ -928,6 +828,18 @@ export default function ProposalDetailPage() {
             />
           )}
 
+          {/* Unified lifecycle, upgrade-stage & PR timeline — right after the
+              Enterprise Assessment so the journey reads before the raw preamble. */}
+          <ProposalTimeline
+            proposal={proposal}
+            statusEvents={statusEvents}
+            stageEvents={stageEvents}
+            upgrades={upgrades}
+            governanceState={governanceState}
+            repoPath={repoPath}
+            normalizedRepo={normalizedRepo}
+          />
+
           {/* 2. Preamble Table (RFC-style, flat, authoritative) */}
           <div id="preamble" className="scroll-mt-28">
             <div className="overflow-hidden rounded-xl border border-border bg-card/60">
@@ -981,108 +893,6 @@ export default function ProposalDetailPage() {
             </div>
           </div>
 
-          {/* 3. Lifecycle Timeline */}
-          {statusEvents.length > 0 && (
-            <motion.div
-              id="lifecycle"
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: 0.1 }}
-              className="scroll-mt-28 rounded-xl border border-border bg-card/60 p-6"
-            >
-              <div className="mb-6 flex items-center justify-between gap-3">
-                <div className="flex items-center gap-2">
-                  <TrendingUp className="h-5 w-5 text-primary" />
-                  <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Lifecycle Timeline</h3>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Link href={`/timeline?repo=${normalizedRepo}s&number=${proposal.number}`}>
-                    <Button variant="outline" size="sm" className="h-8 border-border bg-muted/50 text-xs text-foreground hover:bg-muted">
-                      Show Full Timeline
-                    </Button>
-                  </Link>
-                  {proposal.status && (
-                    <span className={cn(
-                      "inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold",
-                      statusColors[proposal.status]?.bg || 'bg-slate-500/20',
-                      statusColors[proposal.status]?.text || 'text-slate-300',
-                      statusColors[proposal.status]?.border || 'border-slate-400/30'
-                    )}>
-                      {proposal.status}
-                    </span>
-                  )}
-                </div>
-              </div>
-              <div className="relative overflow-x-auto pb-2">
-                <div className="absolute left-6 right-6 top-3 h-px bg-border/80" />
-                <div className="relative flex min-w-max items-start gap-4 pr-4">
-                  {statusEvents.map((event, index) => {
-                    const prevEvent = index > 0 ? statusEvents[index - 1] : null;
-                    const duration = calculateDuration(prevEvent?.changed_at || null, event.changed_at);
-                    const eventColor = statusColors[event.to] || statusColors.Draft;
-                    const commitUrl = event.commit_sha && event.commit_sha.trim() !== ''
-                      ? `https://github.com/ethereum/${repoPath}/commit/${event.commit_sha}`
-                      : null;
-                    const isLatest = index === statusEvents.length - 1;
-
-                    return (
-                      <div key={`${event.changed_at}-${event.to}-${index}`} className="w-[280px] shrink-0">
-                        <div className="mb-3 flex items-center gap-2">
-                          <span
-                            className={cn(
-                              "h-3 w-3 rounded-full ring-2 ring-background",
-                              eventColor.dot,
-                              isLatest && "shadow-md shadow-primary/30"
-                            )}
-                          />
-                          {index < statusEvents.length - 1 && (
-                            <div className="h-px flex-1 bg-border/70" />
-                          )}
-                        </div>
-
-                        <div className={cn("rounded-lg border border-border/70 bg-muted/30 p-4", isLatest && "border-primary/30 bg-primary/5")}>
-                          <div className="flex items-center gap-2">
-                            {event.from && (
-                              <>
-                                <span className={cn("rounded px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide", statusColors[event.from]?.bg || "bg-muted", statusColors[event.from]?.text || "text-foreground")}>
-                                  {event.from}
-                                </span>
-                                <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
-                              </>
-                            )}
-                            <span className={cn("rounded border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide", eventColor.bg, eventColor.text, eventColor.border)}>
-                              {event.to}
-                            </span>
-                          </div>
-
-                          <div className="mt-2 text-xs text-muted-foreground">
-                            {new Date(event.changed_at).toLocaleString()}
-                          </div>
-
-                          <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
-                            {duration && prevEvent && <span>{duration} in {prevEvent.to}</span>}
-                            {event.commit_sha && <span className="font-mono">{event.commit_sha.slice(0, 8)}</span>}
-                            {commitUrl && (
-                              <a
-                                href={commitUrl}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="inline-flex items-center gap-1 text-primary hover:text-primary/80"
-                              >
-                                <Github className="h-3.5 w-3.5" />
-                                View commit
-                              </a>
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            </motion.div>
-          )}
-
           <ProposalSubscriptionCard
             repo={normalizedRepo as 'eip' | 'erc' | 'rip'}
             number={number}
@@ -1093,146 +903,7 @@ export default function ProposalDetailPage() {
             repo={normalizedRepo as 'eip' | 'erc' | 'rip'}
           />
 
-          {/* 4. Editorial Review & PR Coordination */}
-          <div className="space-y-8">
-            {governanceState && (
-              <motion.div
-                id="coordination"
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.5 }}
-                className="scroll-mt-28 rounded-xl border border-border bg-card/60 p-6"
-              >
-                <div className="flex items-center justify-between gap-3 mb-4">
-                  <div className="flex items-center gap-2">
-                    <Activity className="h-5 w-5 text-primary" />
-                    <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                      Editorial Review & PR Coordination
-                    </h3>
-                  </div>
-                  {governanceState.pr_number && (
-                    <span className={cn(
-                      'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium',
-                      governanceState.current_pr_state === 'open'
-                        ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
-                        : governanceState.current_pr_state === 'merged'
-                          ? 'border-violet-500/20 bg-violet-500/10 text-violet-700 dark:text-violet-300'
-                          : 'border-slate-500/20 bg-slate-500/10 text-muted-foreground'
-                    )}>
-                      PR {governanceState.current_pr_state || 'unknown'}
-                    </span>
-                  )}
-                </div>
 
-                {governanceState.pr_number ? (
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                    <div>
-                      <p className="mb-1 text-xs text-muted-foreground font-medium">Active Pull Request</p>
-                      {governanceState.pr_url ? (
-                        <a
-                          href={governanceState.pr_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1.5 text-sm font-semibold text-primary hover:underline"
-                        >
-                          <Github className="h-4 w-4 shrink-0" />
-                          PR #{governanceState.pr_number}
-                          <ExternalLink className="h-3 w-3 opacity-60" />
-                        </a>
-                      ) : (
-                        <p className="text-sm font-semibold text-foreground">#{governanceState.pr_number}</p>
-                      )}
-                    </div>
-
-                    {governanceState.waiting_on && (
-                      <div>
-                        <p className="mb-1 text-xs text-muted-foreground font-medium">Review Stage / Waiting On</p>
-                        {(() => {
-                          const waitingStr = formatWaitingOn(governanceState.waiting_on);
-                          const isClosed = /closed/i.test(waitingStr);
-                          const valueClass = isClosed
-                            ? 'text-sm font-semibold text-slate-600 dark:text-slate-400'
-                            : 'text-sm font-semibold text-emerald-600 dark:text-emerald-400';
-                          return <p className={valueClass}>{waitingStr}</p>;
-                        })()}
-                      </div>
-                    )}
-
-                    {governanceState.days_since_last_action !== null && (
-                      <div>
-                        <p className="mb-1 text-xs text-muted-foreground font-medium">Last Queue Update</p>
-                        <p className={cn("text-sm font-semibold", getUrgencyColor(governanceState.days_since_last_action))}>
-                          {governanceState.days_since_last_action === 0
-                            ? 'Updated today'
-                            : `${governanceState.days_since_last_action} day${governanceState.days_since_last_action !== 1 ? 's' : ''} ago`}
-                        </p>
-                      </div>
-                    )}
-                  </div>
-                ) : (
-                  <div className="text-sm text-muted-foreground flex items-center gap-2 py-2">
-                    <AlertCircle className="h-4 w-4 shrink-0 opacity-70" />
-                    <span>No active editorial PRs are currently linked to this proposal in the tracking database.</span>
-                  </div>
-                )}
-              </motion.div>
-            )}
-          </div>
-
-          {/* 5. Upgrade Participation */}
-          {upgrades.length > 0 && (
-            <motion.div
-              id="upgrades"
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: 0.2 }}
-              className="scroll-mt-28 rounded-xl border border-border bg-card/60 p-6"
-            >
-              <div className="flex items-center gap-2 mb-4">
-                <Package className="h-5 w-5 text-primary" />
-                <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Network Upgrades</h3>
-              </div>
-              <div className="space-y-3">
-                {upgrades.map((upgrade, index) => (
-                  <TooltipProvider key={index}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <div className="flex cursor-help items-center justify-between rounded-lg border border-border/70 bg-muted/30 p-3 transition-colors hover:bg-muted/50">
-                          <div>
-                            <div className="flex flex-wrap items-center gap-2">
-                              <p className="text-sm font-semibold text-foreground">
-                                {upgrade.name}
-                              </p>
-                              <span className={cn('inline-flex rounded-full border px-2 py-0.5 text-[11px] font-medium', getBucketBadgeClass(upgrade.bucket))}>
-                                {formatInclusionBucket(upgrade.bucket)}
-                              </span>
-                            </div>
-                            {upgrade.commit_date && (
-                              <p className="mt-0.5 text-xs text-muted-foreground">
-                                {new Date(upgrade.commit_date).toLocaleDateString('en-US', {
-                                  year: 'numeric',
-                                  month: 'long',
-                                  day: 'numeric'
-                                })}
-                              </p>
-                            )}
-                          </div>
-                          <Link href={upgrade.slug ? `/upgrade/${upgrade.slug}` : '#'}>
-                            <Button variant="ghost" size="sm" className="text-primary hover:text-primary/80">
-                              View <ArrowRight className="h-3.5 w-3.5 ml-1" />
-                            </Button>
-                          </Link>
-                        </div>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p className="text-xs">Source: {proposalId}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                ))}
-              </div>
-            </motion.div>
-          )}
 
           {/* 6. Proposal Body */}
           <motion.div

--- a/src/components/enterprise-eip-brief.tsx
+++ b/src/components/enterprise-eip-brief.tsx
@@ -434,10 +434,10 @@ function getParticipation(proposal: ProposalData, upgrades: UpgradeInclusion[]) 
   return { state: 'Open for feedback', open: true, note: 'Still proposed or under consideration — a meaningful window to shape the outcome.' };
 }
 
-type TrackStep = { label: string; description: string; status: 'completed' | 'current' | 'upcoming'; date: string | null; detail: string | null };
+export type TrackStep = { label: string; description: string; status: 'completed' | 'current' | 'upcoming'; date: string | null; detail: string | null };
 
 /** Governance status — the EIP's own process (independent of any fork). */
-function getStatusTrack(proposal: ProposalData, statusEvents: StatusEvent[]): TrackStep[] {
+export function getStatusTrack(proposal: ProposalData, statusEvents: StatusEvent[]): TrackStep[] {
   const order = ['Draft', 'Review', 'Last Call', 'Final'];
   const descs = ['Submitted', 'Under review', 'Last call for comments', 'Finalized'];
   const cur = (proposal.status ?? '').toLowerCase();
@@ -454,7 +454,7 @@ function getStatusTrack(proposal: ProposalData, statusEvents: StatusEvent[]): Tr
 }
 
 /** Upgrade stage — inclusion in a network fork (independent of EIP status). */
-function getStageTrack(upgrades: UpgradeInclusion[]): TrackStep[] {
+export function getStageTrack(upgrades: UpgradeInclusion[]): TrackStep[] {
   const steps = [
     { label: 'Proposed', description: 'Proposed for inclusion (PFI)' },
     { label: 'Considered', description: 'Considered for inclusion (CFI)' },
@@ -477,17 +477,9 @@ function getStageTrack(upgrades: UpgradeInclusion[]): TrackStep[] {
   }));
 }
 
-export function EnterpriseEIPBrief({ proposal, upgrades, statusEvents, governanceState, proposalRequires, curation }: EnterpriseEIPBriefProps) {
+export function EnterpriseEIPBrief({ proposal, upgrades, proposalRequires, curation }: EnterpriseEIPBriefProps) {
   const enterpriseRisk = getEnterpriseRisk(proposal, upgrades);
   const enterpriseAction = getEnterpriseAction(proposal, upgrades);
-
-  const latestUpgrade = upgrades.find((u) => u.bucket.toLowerCase() === 'included') ?? upgrades[0] ?? null;
-
-  // Two independent axes — never mixed into one bar:
-  //   • Governance status = the EIP's own process (Draft → Review → Last Call → Final)
-  //   • Upgrade stage     = inclusion in a network fork (Proposed → Considered → Scheduled → Included)
-  const statusTrack = getStatusTrack(proposal, statusEvents);
-  const stageTrack = getStageTrack(upgrades);
 
   // Every section below is grounded in the curated per-EIP record when present
   // (editable in admin), so the brief reads specific — not the same template on
@@ -655,25 +647,8 @@ export function EnterpriseEIPBrief({ proposal, upgrades, statusEvents, governanc
         </div>
       </div>
 
-      {/* Two separate axes — governance status and upgrade stage are never mixed. */}
-      <div className="rounded-xl border border-border bg-card/60 shadow-sm overflow-hidden">
-        <div className="border-b border-border/60 bg-muted/40 px-5 py-3">
-          <div className="flex items-center justify-between">
-            <p className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground flex items-center gap-2">
-              <Network className="h-3.5 w-3.5" /> Status &amp; upgrade stage
-            </p>
-            {governanceState?.days_since_last_action && (
-              <span className="text-[10px] text-muted-foreground font-medium">
-                Last activity: {governanceState.days_since_last_action} days ago
-              </span>
-            )}
-          </div>
-        </div>
-        <div className="divide-y divide-border/50">
-          <LifecycleTrack title="Governance status" subtitle="the EIP's own process — independent of any fork" steps={statusTrack} />
-          <LifecycleTrack title="Upgrade stage" subtitle="inclusion in a network fork — independent of EIP status" steps={stageTrack} />
-        </div>
-      </div>
+      {/* Governance status + upgrade stage are shown by the unified ProposalTimeline
+          on the page (not duplicated here). */}
 
       {/* Related dependencies (real — from the EIP's `requires`) */}
       {proposalRequires.length > 0 && (
@@ -705,7 +680,7 @@ export function EnterpriseEIPBrief({ proposal, upgrades, statusEvents, governanc
 }
 
 /** One progress bar for a single axis (status OR stage) — kept deliberately separate. */
-function LifecycleTrack({ title, subtitle, steps }: { title: string; subtitle: string; steps: TrackStep[] }) {
+export function LifecycleTrack({ title, subtitle, steps }: { title: string; subtitle: string; steps: TrackStep[] }) {
   const reachedIdx = steps.reduce((acc, s, i) => (s.status === 'completed' || s.status === 'current' ? i : acc), -1);
   const anyReached = reachedIdx >= 0;
   return (

--- a/src/components/proposal-timeline.tsx
+++ b/src/components/proposal-timeline.tsx
@@ -1,0 +1,396 @@
+'use client';
+
+import React, { useState } from 'react';
+import { motion } from 'motion/react';
+import Link from 'next/link';
+import {
+  Activity,
+  ChevronDown,
+  ChevronRight,
+  Github,
+  ExternalLink,
+  GitPullRequest,
+  ArrowRight,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { getStatusTrack, getStageTrack, LifecycleTrack } from '@/components/enterprise-eip-brief';
+import { normalizeUpgradeBucket, stageAbbreviation, stageBadgeClass } from '@/lib/upgrade-stages';
+
+interface StatusEvent {
+  from: string | null;
+  to: string;
+  changed_at: string;
+  commit_sha?: string;
+}
+
+interface StageEvent {
+  upgrade_id: number | null;
+  upgrade: string;
+  slug: string;
+  bucket: string;
+  commit_sha: string | null;
+  commit_date: string | null;
+}
+
+interface UpgradeInclusion {
+  upgrade_id: number;
+  name: string;
+  slug: string;
+  bucket: string;
+  commit_date: string | null;
+  layer?: string | null;
+}
+
+interface GovernanceState {
+  pr_number: number | null;
+  pr_url: string | null;
+  current_pr_state: string | null;
+  waiting_on: string | null;
+  days_since_last_action: number | null;
+  review_velocity: number | null;
+}
+
+interface ProposalLike {
+  number: number;
+  status: string;
+  type?: string | null;
+  category?: string | null;
+  title?: string;
+  authors?: string[];
+  created?: string | null;
+  repo?: string;
+}
+
+interface ProposalTimelineProps {
+  proposal: ProposalLike;
+  statusEvents: StatusEvent[];
+  stageEvents: StageEvent[];
+  upgrades: UpgradeInclusion[];
+  governanceState: GovernanceState | null;
+  repoPath: string; // "EIPs" | "ERCs" | "RIPs"
+  normalizedRepo: string; // "eip" | "erc" | "rip"
+}
+
+// Status → dot + badge colors (matches the original Lifecycle Timeline).
+const STATUS_STYLE: Record<string, { dot: string; badge: string }> = {
+  draft: { dot: 'bg-cyan-500', badge: 'border-cyan-400/40 bg-cyan-500/10 text-cyan-700 dark:text-cyan-200' },
+  review: { dot: 'bg-blue-500', badge: 'border-blue-400/40 bg-blue-500/10 text-blue-700 dark:text-blue-200' },
+  'last call': { dot: 'bg-amber-500', badge: 'border-amber-400/40 bg-amber-500/10 text-amber-700 dark:text-amber-200' },
+  final: { dot: 'bg-emerald-500', badge: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200' },
+  living: { dot: 'bg-cyan-500', badge: 'border-cyan-400/40 bg-cyan-500/10 text-cyan-700 dark:text-cyan-200' },
+  stagnant: { dot: 'bg-slate-500', badge: 'border-slate-400/30 bg-slate-500/10 text-slate-700 dark:text-slate-300' },
+  withdrawn: { dot: 'bg-red-500', badge: 'border-red-400/40 bg-red-500/10 text-red-700 dark:text-red-200' },
+};
+const statusStyle = (s: string | null | undefined) =>
+  STATUS_STYLE[(s ?? '').toLowerCase()] ?? { dot: 'bg-slate-500', badge: 'border-slate-400/30 bg-slate-500/10 text-slate-700 dark:text-slate-300' };
+
+const STAGE_DOT: Record<string, string> = {
+  proposed: 'bg-slate-400',
+  considered: 'bg-blue-500',
+  scheduled: 'bg-amber-500',
+  included: 'bg-emerald-500',
+  declined: 'bg-red-500',
+};
+
+function durationBetween(prev: string | null, current: string): string | null {
+  if (!prev) return null;
+  const days = Math.floor((new Date(current).getTime() - new Date(prev).getTime()) / (1000 * 60 * 60 * 24));
+  if (days <= 0) return null;
+  return `${days} day${days !== 1 ? 's' : ''}`;
+}
+
+function formatWaitingOn(state: string | null): string {
+  if (!state) return '';
+  return state
+    .replace(/WAITING_ON_/g, 'Waiting on ')
+    .replace(/_/g, ' ')
+    .toLowerCase()
+    .replace(/\b\w/g, (l) => l.toUpperCase());
+}
+
+const fmtDate = (d: string) => new Date(d).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+
+/** Shared horizontal timeline shell — the original Lifecycle Timeline look. */
+function HorizontalTimeline({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative overflow-x-auto pb-2 pt-1">
+      <div className="absolute left-6 right-6 top-4 h-px bg-border/80" />
+      <div className="relative flex min-w-max items-start gap-4 pr-4">{children}</div>
+    </div>
+  );
+}
+
+function TimelineNode({ dot, isLatest, isLast, children }: { dot: string; isLatest?: boolean; isLast?: boolean; children: React.ReactNode }) {
+  return (
+    <div className="w-[250px] shrink-0">
+      <div className="mb-3 flex items-center gap-2">
+        <span className={cn('h-3 w-3 rounded-full ring-2 ring-background', dot, isLatest && 'shadow-md shadow-primary/30')} />
+        {!isLast && <div className="h-px flex-1 bg-border/70" />}
+      </div>
+      <div className={cn('rounded-lg border p-3.5', isLatest ? 'border-primary/30 bg-primary/5' : 'border-border/70 bg-muted/30')}>{children}</div>
+    </div>
+  );
+}
+
+/** A collapsible track: overview stepper always visible, detail revealed on expand. */
+function CollapsibleTrack({
+  open,
+  onToggle,
+  detailLabel,
+  stepper,
+  children,
+}: {
+  open: boolean;
+  onToggle: () => void;
+  detailLabel: string;
+  stepper: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="px-1 py-1">
+      {stepper}
+      <div className="mt-1 px-4">
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={open}
+          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          {open ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+          {open ? 'Hide' : 'Show'} {detailLabel}
+        </button>
+        {open && <div className="mt-2 mb-1">{children}</div>}
+      </div>
+    </div>
+  );
+}
+
+export function ProposalTimeline({
+  proposal,
+  statusEvents,
+  stageEvents,
+  upgrades,
+  governanceState,
+  repoPath,
+  normalizedRepo,
+}: ProposalTimelineProps) {
+  const statusTrack = getStatusTrack(proposal as never, statusEvents as never);
+  const stageTrack = getStageTrack(upgrades as never);
+
+  const hasPr = !!governanceState?.pr_number;
+  const stageDetailCount = stageEvents.length || upgrades.length;
+  const [openStatus, setOpenStatus] = useState(false);
+  const [openStage, setOpenStage] = useState(false);
+  const [openPr, setOpenPr] = useState(false);
+
+  const allOpen = openStatus && openStage && (hasPr ? openPr : true);
+  const toggleAll = () => {
+    const next = !allOpen;
+    setOpenStatus(next);
+    setOpenStage(next);
+    if (hasPr) setOpenPr(next);
+  };
+
+  return (
+    <motion.div
+      id="lifecycle"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay: 0.1 }}
+      className="scroll-mt-28 overflow-hidden rounded-xl border border-border bg-card/60"
+    >
+      {/* Header */}
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/60 bg-muted/30 px-5 py-3">
+        <div className="flex items-center gap-2">
+          <Activity className="h-4 w-4 text-primary" />
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Lifecycle &amp; Upgrade Timeline</h3>
+        </div>
+        <div className="flex items-center gap-2">
+          {governanceState?.days_since_last_action != null && (
+            <span className="hidden text-[10px] font-medium text-muted-foreground sm:inline">
+              Last activity {governanceState.days_since_last_action === 0 ? 'today' : `${governanceState.days_since_last_action}d ago`}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={toggleAll}
+            className="inline-flex items-center gap-1 rounded-md border border-border bg-card/70 px-2.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            {allOpen ? 'Collapse all' : 'Expand all'}
+          </button>
+          <Link
+            href={`/timeline?repo=${normalizedRepo}s&number=${proposal.number}`}
+            className="inline-flex items-center gap-1 rounded-md border border-border bg-card/70 px-2.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            Full timeline
+            <ExternalLink className="h-3 w-3 opacity-60" />
+          </Link>
+        </div>
+      </div>
+
+      <div className="divide-y divide-border/50 p-3">
+        {/* Governance status track */}
+        <CollapsibleTrack
+          open={openStatus}
+          onToggle={() => setOpenStatus((o) => !o)}
+          detailLabel={`status history (${statusEvents.length})`}
+          stepper={<LifecycleTrack title="Governance status" subtitle="the EIP's own process — independent of any fork" steps={statusTrack} />}
+        >
+          {statusEvents.length > 0 ? (
+            <HorizontalTimeline>
+              {statusEvents.map((event, index) => {
+                const prev = index > 0 ? statusEvents[index - 1] : null;
+                const duration = durationBetween(prev?.changed_at ?? null, event.changed_at);
+                const commitUrl = event.commit_sha && event.commit_sha.trim() !== ''
+                  ? `https://github.com/ethereum/${repoPath}/commit/${event.commit_sha}`
+                  : null;
+                const isLatest = index === statusEvents.length - 1;
+                return (
+                  <TimelineNode key={`${event.changed_at}-${event.to}-${index}`} dot={statusStyle(event.to).dot} isLatest={isLatest} isLast={index === statusEvents.length - 1}>
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      {event.from && (
+                        <>
+                          <span className={cn('rounded border px-1.5 py-0.5 text-[10px] font-semibold uppercase', statusStyle(event.from).badge)}>{event.from}</span>
+                          <ChevronRight className="h-3 w-3 text-muted-foreground" />
+                        </>
+                      )}
+                      <span className={cn('rounded border px-1.5 py-0.5 text-[10px] font-semibold uppercase', statusStyle(event.to).badge)}>{event.to}</span>
+                    </div>
+                    <div className="mt-2 text-[11px] text-muted-foreground">{new Date(event.changed_at).toLocaleString()}</div>
+                    <div className="mt-1.5 flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
+                      {duration && prev && <span>{duration} in {prev.to}</span>}
+                      {commitUrl && (
+                        <a href={commitUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-primary hover:text-primary/80">
+                          <Github className="h-3 w-3" /> {event.commit_sha!.slice(0, 8)}
+                        </a>
+                      )}
+                    </div>
+                  </TimelineNode>
+                );
+              })}
+            </HorizontalTimeline>
+          ) : (
+            <p className="text-[11px] text-muted-foreground">No recorded status changes yet.</p>
+          )}
+        </CollapsibleTrack>
+
+        {/* Upgrade stage track — historical bucket journey across forks */}
+        <CollapsibleTrack
+          open={openStage}
+          onToggle={() => setOpenStage((o) => !o)}
+          detailLabel={`stage history (${stageDetailCount})`}
+          stepper={<LifecycleTrack title="Upgrade stage" subtitle="inclusion in a network fork — independent of EIP status" steps={stageTrack} />}
+        >
+          {stageEvents.length > 0 ? (
+            <HorizontalTimeline>
+              {stageEvents.map((event, index) => {
+                const nb = normalizeUpgradeBucket(event.bucket);
+                const commitUrl = event.commit_sha ? `https://github.com/ethereum/${repoPath}/commit/${event.commit_sha}` : null;
+                const isLatest = index === stageEvents.length - 1;
+                return (
+                  <TimelineNode key={`${event.commit_date}-${event.bucket}-${index}`} dot={STAGE_DOT[event.bucket] ?? 'bg-slate-400'} isLatest={isLatest} isLast={index === stageEvents.length - 1}>
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <span className="text-xs font-semibold text-foreground">{event.upgrade || 'Upgrade'}</span>
+                      <span className={cn('rounded-full border px-1.5 py-px text-[10px] font-medium', stageBadgeClass(nb))}>
+                        {(nb && stageAbbreviation(nb)) || event.bucket}
+                      </span>
+                    </div>
+                    <div className="mt-2 text-[11px] text-muted-foreground">{event.commit_date ? fmtDate(event.commit_date) : 'date unknown'}</div>
+                    <div className="mt-1.5 flex flex-wrap items-center gap-3 text-[11px]">
+                      {event.slug && (
+                        <Link href={`/upgrade/${event.slug}`} className="inline-flex items-center gap-1 text-primary hover:text-primary/80">
+                          View <ArrowRight className="h-3 w-3" />
+                        </Link>
+                      )}
+                      {commitUrl && (
+                        <a href={commitUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground">
+                          <Github className="h-3 w-3" /> {event.commit_sha!.slice(0, 8)}
+                        </a>
+                      )}
+                    </div>
+                  </TimelineNode>
+                );
+              })}
+            </HorizontalTimeline>
+          ) : upgrades.length > 0 ? (
+            <div className="space-y-2">
+              {upgrades.map((upgrade) => {
+                const nb = normalizeUpgradeBucket(upgrade.bucket);
+                return (
+                  <div key={upgrade.slug || upgrade.upgrade_id} className="flex items-center justify-between gap-2 rounded-lg border border-border/60 bg-muted/20 p-2.5">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="truncate text-xs font-semibold text-foreground">{upgrade.name}</p>
+                        <span className={cn('inline-flex rounded-full border px-1.5 py-px text-[10px] font-medium', stageBadgeClass(nb))}>
+                          {(nb && stageAbbreviation(nb)) || upgrade.bucket}
+                        </span>
+                      </div>
+                      {upgrade.commit_date && <p className="mt-0.5 text-[11px] text-muted-foreground">{fmtDate(upgrade.commit_date)}</p>}
+                    </div>
+                    {upgrade.slug && (
+                      <Link href={`/upgrade/${upgrade.slug}`} className="inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-primary transition-colors hover:bg-primary/10">
+                        View <ArrowRight className="h-3 w-3" />
+                      </Link>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="text-[11px] text-muted-foreground">Not assigned to any network upgrade yet.</p>
+          )}
+        </CollapsibleTrack>
+
+        {/* Editorial PR & review */}
+        {hasPr && (
+          <div className="px-1 py-2">
+            <div className="px-4">
+              <button
+                type="button"
+                onClick={() => setOpenPr((o) => !o)}
+                aria-expanded={openPr}
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-muted"
+              >
+                {openPr ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" /> : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />}
+                <GitPullRequest className="h-3.5 w-3.5 text-primary" />
+                <span className="text-xs font-semibold text-foreground">Editorial PR &amp; review</span>
+                <span className={cn('ml-auto inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium', governanceState!.current_pr_state === 'open' ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300' : governanceState!.current_pr_state === 'merged' ? 'border-violet-500/20 bg-violet-500/10 text-violet-700 dark:text-violet-300' : 'border-slate-500/20 bg-slate-500/10 text-muted-foreground')}>
+                  PR {governanceState!.current_pr_state || 'unknown'}
+                </span>
+              </button>
+              {openPr && (
+                <div className="mt-2 grid grid-cols-1 gap-3 px-2 sm:grid-cols-3">
+                  <div>
+                    <p className="mb-0.5 text-[11px] font-medium text-muted-foreground">Active pull request</p>
+                    {governanceState!.pr_url ? (
+                      <a href={governanceState!.pr_url} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 text-sm font-semibold text-primary hover:underline">
+                        <Github className="h-4 w-4 shrink-0" /> PR #{governanceState!.pr_number}
+                        <ExternalLink className="h-3 w-3 opacity-60" />
+                      </a>
+                    ) : (
+                      <p className="text-sm font-semibold text-foreground">#{governanceState!.pr_number}</p>
+                    )}
+                  </div>
+                  {governanceState!.waiting_on && (
+                    <div>
+                      <p className="mb-0.5 text-[11px] font-medium text-muted-foreground">Review stage / waiting on</p>
+                      <p className="text-sm font-semibold text-emerald-600 dark:text-emerald-400">{formatWaitingOn(governanceState!.waiting_on)}</p>
+                    </div>
+                  )}
+                  {governanceState!.days_since_last_action != null && (
+                    <div>
+                      <p className="mb-0.5 text-[11px] font-medium text-muted-foreground">Last queue update</p>
+                      <p className="text-sm font-semibold text-foreground">
+                        {governanceState!.days_since_last_action === 0 ? 'Updated today' : `${governanceState!.days_since_last_action} day${governanceState!.days_since_last_action !== 1 ? 's' : ''} ago`}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </motion.div>
+  );
+}

--- a/src/server/orpc/procedures/proposals.ts
+++ b/src/server/orpc/procedures/proposals.ts
@@ -349,6 +349,48 @@ export const proposalsProcedures = {
       }));
     }),
 
+  // B2. Upgrade stage history — the EIP's journey through fork buckets
+  // (proposed → considered → scheduled → included, plus declines/re-proposals).
+  // Each "added" event is one entry into a bucket; ordered oldest → newest.
+  getStageEvents: optionalAuthProcedure
+    .input(z.object({
+      repo: z.enum(['eip', 'erc', 'rip', 'eips', 'ercs', 'rips']),
+      number: z.number(),
+    }))
+    .handler(async ({ input }) => {
+      const events = await prisma.upgrade_composition_events.findMany({
+        where: {
+          eip_number: input.number,
+          event_type: 'added',
+          bucket: { in: ['included', 'considered', 'scheduled', 'proposed', 'declined'] },
+        },
+        orderBy: [{ commit_date: 'asc' }, { id: 'asc' }],
+        select: { upgrade_id: true, bucket: true, commit_sha: true, commit_date: true },
+      });
+      if (events.length === 0) return [];
+
+      const upgradeIds = Array.from(
+        new Set(events.map((e) => e.upgrade_id).filter((v): v is number => v != null)),
+      );
+      const upgrades = await prisma.upgrades.findMany({
+        where: { id: { in: upgradeIds } },
+        select: { id: true, name: true, slug: true },
+      });
+      const byId = new Map(upgrades.map((u) => [u.id, u]));
+
+      return events.map((e) => {
+        const u = e.upgrade_id != null ? byId.get(e.upgrade_id) : undefined;
+        return {
+          upgrade_id: e.upgrade_id,
+          upgrade: u?.name ?? '',
+          slug: u?.slug ?? '',
+          bucket: (e.bucket ?? '').toLowerCase(),
+          commit_sha: e.commit_sha && e.commit_sha.trim() !== '' ? e.commit_sha : null,
+          commit_date: e.commit_date?.toISOString() ?? null,
+        };
+      });
+    }),
+
   // C. Type Timeline
   getTypeEvents: optionalAuthProcedure
     .input(z.object({


### PR DESCRIPTION
This pull request significantly refactors the proposal detail page to unify and streamline the display of proposal lifecycle, upgrade participation, and editorial review information. The main change is the introduction of a new `ProposalTimeline` component, which consolidates the previously separate lifecycle timeline, upgrade participation, and PR coordination sections into a single, cohesive timeline view. Several helper functions and status color definitions that were only used in the old timeline have been removed, and the data fetching logic has been updated to support the new timeline.

**Major refactor: Unified Proposal Timeline**
- The separate "Lifecycle Timeline", "Editorial Review & PR Coordination", and "Upgrade Participation" sections have been removed from the page and replaced with a single `ProposalTimeline` component that presents a unified view of all proposal events. (F616062cL893, F616062cL903, F616062cL828)

**Component and data changes**
- Added a new `stageEvents` state and corresponding interface to support historical upgrade stage events, and updated data fetching to retrieve these events. (F616062cL56, F616062cL270, F616062cL350, F616062cL364)
- The `ProposalTimeline` component is now imported and rendered immediately after the enterprise assessment section, before the proposal preamble, to provide context for the proposal's journey. (F616062cL28, F616062cL828)

**Cleanup of unused code**
- Removed the `statusColors` mapping, helper functions for badge classes, inclusion bucket formatting, waiting-on formatting, and duration calculation, as these are now handled within the new timeline component or are no longer needed. (F616062cL28, F616062cL186, F616062cL220, F616062cL578)

Overall, this refactor improves the user experience by presenting a clearer, more integrated view of a proposal's progress, and simplifies the codebase by removing redundant logic and UI components.