### PR TITLE
Enhance proposal details and enterprise impact data structure

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -383,6 +383,9 @@ model eip_curations {
   layer               String?
   /// [{ question: string, answer: string }] — AI-generated FAQ
   faq                 Json?
+  /// { tier, summary, organizations: [{ role, level, why }], readiness } —
+  /// enterprise/institutional impact, curated for a finance audience
+  enterprise_impact   Json?
   updated_by          String?
   created_at          DateTime @default(now())
   updated_at          DateTime @default(now()) @updatedAt

--- a/src/app/(proposal)/[repo]/[number]/page.tsx
+++ b/src/app/(proposal)/[repo]/[number]/page.tsx
@@ -867,18 +867,6 @@ export default function ProposalDetailPage() {
             normalizedRepo={normalizedRepo}
           />
 
-          <ProposalSubscriptionCard
-            repo={normalizedRepo as 'eip' | 'erc' | 'rip'}
-            number={number}
-            currentStatus={proposal.status}
-          />
-
-          <RepositorySubscriptionCard
-            repo={normalizedRepo as 'eip' | 'erc' | 'rip'}
-          />
-
-
-
           {/* 6. Proposal Body */}
           <motion.div
             id="proposal-text"
@@ -1072,6 +1060,18 @@ export default function ProposalDetailPage() {
               </div>
             </div>
           </motion.section>
+
+          {/* Email updates — end-of-page CTA, two compact cards side by side */}
+          <div className="grid gap-4 md:grid-cols-2">
+            <ProposalSubscriptionCard
+              repo={normalizedRepo as 'eip' | 'erc' | 'rip'}
+              number={number}
+              currentStatus={proposal.status}
+            />
+            <RepositorySubscriptionCard
+              repo={normalizedRepo as 'eip' | 'erc' | 'rip'}
+            />
+          </div>
           </div>
         </div>
     </div>

--- a/src/app/(proposal)/[repo]/[number]/page.tsx
+++ b/src/app/(proposal)/[repo]/[number]/page.tsx
@@ -772,7 +772,34 @@ export default function ProposalDetailPage() {
                     </div>
                   </div>
                 )}
-                
+
+                {/* Created date + dependencies (the only preamble fields not already in the header) */}
+                {(proposal.created || proposalRequires.length > 0) && (
+                  <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                    {proposal.created && (
+                      <span>
+                        <span className="font-medium text-foreground/70">Created</span>{' '}
+                        {Number.isNaN(Date.parse(proposal.created))
+                          ? proposal.created
+                          : new Date(proposal.created).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })}
+                      </span>
+                    )}
+                    {proposalRequires.length > 0 && (
+                      <span className="flex flex-wrap items-center gap-1">
+                        <span className="font-medium text-foreground/70">Requires</span>
+                        {proposalRequires.map((r, i) => (
+                          <React.Fragment key={r}>
+                            <Link href={`/${normalizedRepo}s/${r}`} className="font-mono text-primary hover:underline">
+                              {repoDisplayName}-{r}
+                            </Link>
+                            {i < proposalRequires.length - 1 && <span>,</span>}
+                          </React.Fragment>
+                        ))}
+                      </span>
+                    )}
+                  </div>
+                )}
+
                 {/* AI Summary toggle (collapsible inline) */}
                 <div className="mt-4">
                   <button
@@ -839,59 +866,6 @@ export default function ProposalDetailPage() {
             repoPath={repoPath}
             normalizedRepo={normalizedRepo}
           />
-
-          {/* 2. Preamble Table (RFC-style, flat, authoritative) */}
-          <div id="preamble" className="scroll-mt-28">
-            <div className="overflow-hidden rounded-xl border border-border bg-card/60">
-              <table className="w-full border-collapse">
-                <tbody className="divide-y divide-border/70">
-                  <tr>
-                    <td className="w-40 bg-muted/50 px-6 py-4 align-top text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">EIP</td>
-                    <td className="px-6 py-4 font-mono text-sm text-foreground">{proposalId}</td>
-                  </tr>
-                  <tr>
-                    <td className="w-40 bg-muted/50 px-6 py-4 align-top text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Title</td>
-                    <td className="px-6 py-4 text-sm text-foreground">{proposal.title}</td>
-                  </tr>
-                  {proposal.authors.length > 0 && (
-                    <tr>
-                      <td className="w-40 bg-muted/50 px-6 py-4 align-top text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Author</td>
-                      <td className="px-6 py-4 text-sm text-foreground">{proposal.authors.join(', ')}</td>
-                    </tr>
-                  )}
-                  {proposal.created && (
-                    <tr>
-                      <td className="w-40 bg-muted/50 px-6 py-4 align-top text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Created</td>
-                      <td className="px-6 py-4 text-sm text-foreground">{proposal.created}</td>
-                    </tr>
-                  )}
-                  {proposalRequires.length > 0 && (
-                    <tr>
-                      <td className="w-40 bg-muted/50 px-6 py-4 align-top text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Requires</td>
-                      <td className="px-6 py-4 font-mono text-sm text-foreground">
-                        {proposalRequires.map(r => `${repoDisplayName}-${r}`).join(', ')}
-                      </td>
-                    </tr>
-                  )}
-                  {(proposal.discussions_to || discussionsTo) && (
-                    <tr>
-                      <td className="w-40 bg-muted/50 px-6 py-4 align-top text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Discussions-To</td>
-                      <td className="px-6 py-4 text-sm">
-                        <a 
-                          href={proposal.discussions_to || discussionsTo || '#'} 
-                          target="_blank" 
-                          rel="noopener noreferrer" 
-                          className="break-all text-primary transition-colors hover:text-primary/80"
-                        >
-                          {proposal.discussions_to || discussionsTo}
-                        </a>
-                      </td>
-                    </tr>
-                  )}
-                </tbody>
-              </table>
-            </div>
-          </div>
 
           <ProposalSubscriptionCard
             repo={normalizedRepo as 'eip' | 'erc' | 'rip'}

--- a/src/components/enterprise-eip-brief.tsx
+++ b/src/components/enterprise-eip-brief.tsx
@@ -22,6 +22,8 @@ import {
   ClipboardCheck,
   Scale,
   MessageSquarePlus,
+  ChevronDown,
+  ChevronRight,
   type LucideIcon,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -88,7 +90,8 @@ export interface EipCuration {
 export interface EnterpriseImpactData {
   tier?: string | null;
   summary?: string | null;
-  organizations?: Array<{ role?: string; level?: string; why?: string }> | null;
+  organizations?: Array<{ role?: string; level?: string; summary?: string; how?: string; why?: string; action?: string }> | null;
+  businessImpact?: Array<{ area?: string; summary?: string; detail?: string }> | null;
   readiness?: string | null;
 }
 
@@ -366,6 +369,9 @@ const ENTERPRISE_ROLE_ICON: Record<string, LucideIcon> = {
   'digital-asset advisors': Users,
 };
 
+/** Unified card shape across the curated / mapped / inferred paths. */
+type OrgItem = { role: string; icon: LucideIcon; affected: string; summary: string; how: string | null; why: string; action: string | null };
+
 const TIER_META: Record<'direct' | 'limited' | 'none', { label: string; note: string; cls: string }> = {
   direct: { label: 'Direct impact', note: 'At least one institution type must plan or test before this ships.', cls: 'border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-400' },
   limited: { label: 'Limited impact', note: 'Mostly indirect — monitor readiness; no major workstream expected.', cls: 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400' },
@@ -533,25 +539,36 @@ export function EnterpriseEIPBrief({ proposal, upgrades, proposalRequires, curat
   //   2. Ecosystem stakeholder curation mapped onto finance roles
   //   3. Conservative keyword inference (labelled "Auto-inferred")
   const enterprise = curation?.enterprise_impact ?? null;
-  const enterpriseOrgs = (Array.isArray(enterprise?.organizations) ? enterprise!.organizations : [])
+  const enterpriseOrgs: OrgItem[] = (Array.isArray(enterprise?.organizations) ? enterprise!.organizations : [])
     .filter((o) => o && o.role)
     .map((o) => {
       const level = (o.level ?? '').toLowerCase();
+      const why = o.why?.trim() || 'Not directly affected by this change.';
       return {
         role: o.role!,
         icon: ENTERPRISE_ROLE_ICON[o.role!.toLowerCase()] ?? Building2,
         affected: (['high', 'medium', 'low', 'none'].includes(level) ? level : 'none') as string,
-        why: o.why?.trim() || 'Not directly affected by this change.',
+        summary: o.summary?.trim() || why,
+        how: o.how?.trim() || null,
+        why,
+        action: o.action?.trim() || null,
       };
     });
   const hasEnterprise = enterpriseOrgs.length > 0;
   const hasCuration = !!stakeholderImpacts && Object.keys(stakeholderImpacts).length > 0;
 
-  const financeStakeholders = hasEnterprise
+  // Normalize the mapped/inferred fallback to the same card shape (no how/action).
+  const financeStakeholders: OrgItem[] = hasEnterprise
     ? enterpriseOrgs
     : (hasCuration
         ? getFinanceStakeholdersFromCuration(stakeholderImpacts)
-        : getFinanceStakeholders(proposal, upgrades)) as Array<{ role: string; icon: LucideIcon; affected: string; why: string }>;
+        : getFinanceStakeholders(proposal, upgrades)
+      ).map((s) => ({ role: s.role, icon: s.icon, affected: s.affected as string, summary: s.why, how: null, why: s.why, action: null }));
+
+  const enterpriseBusiness = (Array.isArray(enterprise?.businessImpact) ? enterprise!.businessImpact : [])
+    .filter((b) => b && b.area && (b.detail || b.summary))
+    .map((b) => ({ area: b.area!, summary: b.summary?.trim() || b.detail!.trim(), detail: b.detail?.trim() || b.summary!.trim() }));
+  const hasEnterpriseBusiness = enterpriseBusiness.length > 0;
 
   const groundingLabel = hasEnterprise ? 'Enterprise-curated' : hasCuration ? 'Curated' : 'Auto-inferred';
   const groundingCurated = hasEnterprise || hasCuration;
@@ -604,22 +621,11 @@ export function EnterpriseEIPBrief({ proposal, upgrades, proposalRequires, curat
                 <p className="flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-wider text-violet-600 dark:text-violet-400"><Building2 className="h-3.5 w-3.5" /> 1 · Affected organizations</p>
                 <span className={cn('rounded-full border px-1.5 py-px text-[9px] font-semibold uppercase tracking-wide', groundingCurated ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400')}>{groundingLabel}</span>
               </div>
-              <div className="grid gap-2 sm:grid-cols-2">
-                {financeStakeholders.map((s) => {
-                  const meta = LEVEL_META[s.affected] ?? LEVEL_META.none;
-                  return (
-                    <div key={s.role} className="flex items-start gap-2 rounded-lg border border-border bg-background/40 p-2.5">
-                      <s.icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-center justify-between gap-2">
-                          <span className="text-xs font-semibold text-foreground">{s.role}</span>
-                          <span className={cn('shrink-0 rounded-full border px-1.5 py-px text-[9px] font-bold uppercase', meta.cls)}>{meta.label}</span>
-                        </div>
-                        <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground">{s.why}</p>
-                      </div>
-                    </div>
-                  );
-                })}
+              {/* Masonry columns so an expanded card doesn't stretch its row-mate. */}
+              <div className="gap-2 sm:columns-2 [column-gap:0.5rem]">
+                {financeStakeholders.map((s) => (
+                  <OrgImpactCard key={s.role} item={s} />
+                ))}
               </div>
               {/* What the priority ratings mean — context on demand */}
               <details className="mt-2 rounded-lg border border-border/60 bg-muted/20 px-3 py-2">
@@ -645,16 +651,22 @@ export function EnterpriseEIPBrief({ proposal, upgrades, proposalRequires, curat
               </details>
             </div>
 
-            {/* 2. Business impact — curated benefits/trade-offs when available (per-EIP),
-                 otherwise the generic operational read. */}
+            {/* 2. Business impact — dedicated enterprise report (collapsible) when
+                 available, else curated benefits/trade-offs, else generic. */}
             <div className="px-5 py-3.5">
               <div className="mb-2 flex items-center gap-2">
                 <p className="flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-wider text-violet-600 dark:text-violet-400"><TrendingUp className="h-3.5 w-3.5" /> 2 · Business impact</p>
-                {(benefits.length > 0 || tradeoffs.length > 0) && (
-                  <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-1.5 py-px text-[9px] font-semibold uppercase tracking-wide text-emerald-600 dark:text-emerald-400">Curated</span>
+                {(hasEnterpriseBusiness || benefits.length > 0 || tradeoffs.length > 0) && (
+                  <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-1.5 py-px text-[9px] font-semibold uppercase tracking-wide text-emerald-600 dark:text-emerald-400">{hasEnterpriseBusiness ? 'Enterprise-curated' : 'Curated'}</span>
                 )}
               </div>
-              {benefits.length > 0 || tradeoffs.length > 0 ? (
+              {hasEnterpriseBusiness ? (
+                <div className="space-y-1.5">
+                  {enterpriseBusiness.map((b) => (
+                    <BusinessAreaCard key={b.area} area={b.area} summary={b.summary} detail={b.detail} />
+                  ))}
+                </div>
+              ) : benefits.length > 0 || tradeoffs.length > 0 ? (
                 <div className="grid gap-3 sm:grid-cols-2">
                   {benefits.length > 0 && (
                     <div>
@@ -747,6 +759,86 @@ export function EnterpriseEIPBrief({ proposal, upgrades, proposalRequires, curat
         </div>
       )}
     </motion.div>
+  );
+}
+
+/** Collapsible per-organization impact card: headline collapsed, "Affected how? /
+ *  Why it matters / What to do" expanded. Only expandable when there's detail. */
+function OrgImpactCard({ item }: { item: OrgItem }) {
+  const [open, setOpen] = React.useState(false);
+  const meta = LEVEL_META[item.affected] ?? LEVEL_META.none;
+  const Icon = item.icon;
+  const hasDetail = !!(item.how || item.action || (item.why && item.why !== item.summary));
+  return (
+    <div className="mb-2 break-inside-avoid rounded-lg border border-border bg-background/40">
+      <button
+        type="button"
+        onClick={() => hasDetail && setOpen((o) => !o)}
+        aria-expanded={open}
+        className={cn('flex w-full items-start gap-2 rounded-lg p-2.5 text-left', hasDetail ? 'cursor-pointer transition-colors hover:bg-muted/40' : 'cursor-default')}
+      >
+        <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs font-semibold text-foreground">{item.role}</span>
+            <span className={cn('shrink-0 rounded-full border px-1.5 py-px text-[9px] font-bold uppercase', meta.cls)}>{meta.label}</span>
+          </div>
+          <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground">{item.summary}</p>
+        </div>
+        {hasDetail && (open
+          ? <ChevronDown className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          : <ChevronRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />)}
+      </button>
+      {open && hasDetail && (
+        <div className="space-y-2 border-t border-border/60 px-2.5 py-2.5 pl-8">
+          {item.how && (
+            <div>
+              <p className="text-[10px] font-bold uppercase tracking-wider text-violet-600 dark:text-violet-400">Affected how?</p>
+              <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground">{item.how}</p>
+            </div>
+          )}
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-wider text-violet-600 dark:text-violet-400">Why it matters</p>
+            <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground">{item.why}</p>
+          </div>
+          {item.action && (
+            <div>
+              <p className="text-[10px] font-bold uppercase tracking-wider text-violet-600 dark:text-violet-400">What to do</p>
+              <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground">{item.action}</p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Collapsible business-impact area: headline collapsed, full detail expanded. */
+function BusinessAreaCard({ area, summary, detail }: { area: string; summary: string; detail: string }) {
+  const [open, setOpen] = React.useState(false);
+  const hasDetail = !!detail && detail !== summary;
+  return (
+    <div className="rounded-lg border border-border/60 bg-background/40">
+      <button
+        type="button"
+        onClick={() => hasDetail && setOpen((o) => !o)}
+        aria-expanded={open}
+        className={cn('flex w-full items-start gap-2 rounded-lg p-2.5 text-left', hasDetail ? 'cursor-pointer transition-colors hover:bg-muted/40' : 'cursor-default')}
+      >
+        <div className="min-w-0 flex-1">
+          <span className="text-xs font-semibold text-foreground">{area}</span>
+          <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground">{summary}</p>
+        </div>
+        {hasDetail && (open
+          ? <ChevronDown className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          : <ChevronRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />)}
+      </button>
+      {open && hasDetail && (
+        <div className="border-t border-border/60 px-2.5 py-2.5">
+          <p className="text-[11px] leading-relaxed text-muted-foreground">{detail}</p>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/src/components/enterprise-eip-brief.tsx
+++ b/src/components/enterprise-eip-brief.tsx
@@ -79,8 +79,17 @@ export interface EipCuration {
   benefits?: string[] | null;
   tradeoffs?: string[] | null;
   stakeholder_impacts?: Record<string, { description?: string }> | null;
+  enterprise_impact?: EnterpriseImpactData | null;
   headliner_of?: string | null;
   headliner_note?: string | null;
+}
+
+/** Dedicated, finance-audience curation (eip_curations.enterprise_impact). */
+export interface EnterpriseImpactData {
+  tier?: string | null;
+  summary?: string | null;
+  organizations?: Array<{ role?: string; level?: string; why?: string }> | null;
+  readiness?: string | null;
 }
 
 interface EnterpriseImpactCard {
@@ -336,6 +345,33 @@ const REL_META: Record<Relevance, { label: string; cls: string }> = {
   low: { label: 'Low', cls: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' },
 };
 
+// Level styling incl. an explicit "Not affected" state for the dedicated
+// enterprise curation (which rates every organization, even the untouched ones).
+const LEVEL_META: Record<string, { label: string; cls: string }> = {
+  high: REL_META.high,
+  medium: REL_META.medium,
+  low: REL_META.low,
+  none: { label: 'Not affected', cls: 'border-border bg-muted/50 text-muted-foreground' },
+};
+
+// Map a curated enterprise role name to its icon (same set as the inferred path).
+const ENTERPRISE_ROLE_ICON: Record<string, LucideIcon> = {
+  'banks & payment providers': Landmark,
+  'auditors & accountants': ClipboardCheck,
+  'asset managers': Coins,
+  'custodians & wallets': Wallet,
+  'staking providers': ShieldCheck,
+  'infrastructure operators': Server,
+  'l2-using companies': Network,
+  'digital-asset advisors': Users,
+};
+
+const TIER_META: Record<'direct' | 'limited' | 'none', { label: string; note: string; cls: string }> = {
+  direct: { label: 'Direct impact', note: 'At least one institution type must plan or test before this ships.', cls: 'border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-400' },
+  limited: { label: 'Limited impact', note: 'Mostly indirect — monitor readiness; no major workstream expected.', cls: 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400' },
+  none: { label: 'No direct impact', note: 'Informational for institutions — no assets, controls, or operations change.', cls: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' },
+};
+
 function analyzeProposal(proposal: ProposalData, upgrades: UpgradeInclusion[]) {
   const isCore = proposal.category === 'Core';
   const layer = upgrades.find((u) => u.layer)?.layer ?? null;
@@ -489,23 +525,49 @@ export function EnterpriseEIPBrief({ proposal, upgrades, proposalRequires, curat
   const benefits = (curation?.benefits ?? []).filter((b) => b && b.trim().length > 0);
   const tradeoffs = (curation?.tradeoffs ?? []).filter((t) => t && t.trim().length > 0);
   const laymanSummary = curation?.layman_summary?.trim() || null;
-  const hasCuration = !!stakeholderImpacts && Object.keys(stakeholderImpacts).length > 0;
-  const financeStakeholders = hasCuration
-    ? getFinanceStakeholdersFromCuration(stakeholderImpacts)
-    : getFinanceStakeholders(proposal, upgrades);
   const participation = getParticipation(proposal, upgrades);
-  // Only fall back to the generic operational bullets when there's no curated
-  // benefits/trade-offs text to show.
   const businessImpact = getBusinessImpact(proposal, upgrades);
 
-  // Per-EIP impact category the user asked for: Direct / Limited / No direct.
+  // Three tiers of grounding, best first:
+  //   1. Dedicated enterprise curation (per-institution, finance-written)
+  //   2. Ecosystem stakeholder curation mapped onto finance roles
+  //   3. Conservative keyword inference (labelled "Auto-inferred")
+  const enterprise = curation?.enterprise_impact ?? null;
+  const enterpriseOrgs = (Array.isArray(enterprise?.organizations) ? enterprise!.organizations : [])
+    .filter((o) => o && o.role)
+    .map((o) => {
+      const level = (o.level ?? '').toLowerCase();
+      return {
+        role: o.role!,
+        icon: ENTERPRISE_ROLE_ICON[o.role!.toLowerCase()] ?? Building2,
+        affected: (['high', 'medium', 'low', 'none'].includes(level) ? level : 'none') as string,
+        why: o.why?.trim() || 'Not directly affected by this change.',
+      };
+    });
+  const hasEnterprise = enterpriseOrgs.length > 0;
+  const hasCuration = !!stakeholderImpacts && Object.keys(stakeholderImpacts).length > 0;
+
+  const financeStakeholders = hasEnterprise
+    ? enterpriseOrgs
+    : (hasCuration
+        ? getFinanceStakeholdersFromCuration(stakeholderImpacts)
+        : getFinanceStakeholders(proposal, upgrades)) as Array<{ role: string; icon: LucideIcon; affected: string; why: string }>;
+
+  const groundingLabel = hasEnterprise ? 'Enterprise-curated' : hasCuration ? 'Curated' : 'Auto-inferred';
+  const groundingCurated = hasEnterprise || hasCuration;
+  const summaryText = (hasEnterprise ? enterprise?.summary?.trim() : null) || laymanSummary;
+  const readinessText = hasEnterprise ? enterprise?.readiness?.trim() || null : null;
+
+  // Per-EIP impact category: Direct / Limited / No direct. Prefer the curated
+  // tier when present; otherwise derive it from the organization levels.
   const anyHigh = financeStakeholders.some((s) => s.affected === 'high');
   const anyMedium = financeStakeholders.some((s) => s.affected === 'medium');
-  const impactTier: { label: string; note: string; cls: string } = anyHigh
-    ? { label: 'Direct impact', note: 'At least one institution type must plan or test before this ships.', cls: 'border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-400' }
-    : anyMedium
-      ? { label: 'Limited impact', note: 'Mostly indirect — monitor readiness; no major workstream expected.', cls: 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400' }
-      : { label: 'No direct impact', note: 'Informational for institutions — no assets, controls, or operations change.', cls: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' };
+  const curatedTier = (hasEnterprise ? (enterprise?.tier ?? '').toLowerCase() : '') as 'direct' | 'limited' | 'none' | '';
+  const tierKey: 'direct' | 'limited' | 'none' =
+    curatedTier === 'direct' || curatedTier === 'limited' || curatedTier === 'none'
+      ? curatedTier
+      : anyHigh ? 'direct' : anyMedium ? 'limited' : 'none';
+  const impactTier = TIER_META[tierKey];
 
   return (
     <motion.div
@@ -530,8 +592,8 @@ export function EnterpriseEIPBrief({ proposal, upgrades, proposalRequires, curat
               <span className={cn('rounded-full border px-2 py-0.5 text-[11px] font-bold uppercase tracking-wide', impactTier.cls)}>{impactTier.label}</span>
               <span className="text-[11px] text-muted-foreground">{impactTier.note}</span>
             </div>
-            {laymanSummary && (
-              <p className="mt-2 text-xs leading-relaxed text-foreground/90">{laymanSummary}</p>
+            {summaryText && (
+              <p className="mt-2 text-xs leading-relaxed text-foreground/90">{summaryText}</p>
             )}
           </div>
 
@@ -540,11 +602,11 @@ export function EnterpriseEIPBrief({ proposal, upgrades, proposalRequires, curat
             <div className="px-5 py-3.5">
               <div className="mb-2 flex items-center gap-2">
                 <p className="flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-wider text-violet-600 dark:text-violet-400"><Building2 className="h-3.5 w-3.5" /> 1 · Affected organizations</p>
-                <span className={cn('rounded-full border px-1.5 py-px text-[9px] font-semibold uppercase tracking-wide', hasCuration ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400')}>{hasCuration ? 'Curated' : 'Auto-inferred'}</span>
+                <span className={cn('rounded-full border px-1.5 py-px text-[9px] font-semibold uppercase tracking-wide', groundingCurated ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400')}>{groundingLabel}</span>
               </div>
               <div className="grid gap-2 sm:grid-cols-2">
                 {financeStakeholders.map((s) => {
-                  const meta = REL_META[s.affected];
+                  const meta = LEVEL_META[s.affected] ?? LEVEL_META.none;
                   return (
                     <div key={s.role} className="flex items-start gap-2 rounded-lg border border-border bg-background/40 p-2.5">
                       <s.icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
@@ -561,7 +623,7 @@ export function EnterpriseEIPBrief({ proposal, upgrades, proposalRequires, curat
               </div>
               {/* What the priority ratings mean — context on demand */}
               <details className="mt-2 rounded-lg border border-border/60 bg-muted/20 px-3 py-2">
-                <summary className="cursor-pointer text-[11px] font-semibold text-muted-foreground">What do High / Medium / Low mean?</summary>
+                <summary className="cursor-pointer text-[11px] font-semibold text-muted-foreground">What do the ratings mean?</summary>
                 <ul className="mt-2 space-y-1.5 text-[11px] text-muted-foreground">
                   <li className="flex items-start gap-2">
                     <span className={cn('mt-px shrink-0 rounded-full border px-1.5 py-px text-[9px] font-bold uppercase', REL_META.high.cls)}>High</span>
@@ -574,6 +636,10 @@ export function EnterpriseEIPBrief({ proposal, upgrades, proposalRequires, curat
                   <li className="flex items-start gap-2">
                     <span className={cn('mt-px shrink-0 rounded-full border px-1.5 py-px text-[9px] font-bold uppercase', REL_META.low.cls)}>Low</span>
                     <span>Minimal direct impact — informational; no action anticipated.</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className={cn('mt-px shrink-0 rounded-full border px-1.5 py-px text-[9px] font-bold uppercase', LEVEL_META.none.cls)}>Not affected</span>
+                    <span>This organization type is not touched by the change.</span>
                   </li>
                 </ul>
               </details>
@@ -628,7 +694,12 @@ export function EnterpriseEIPBrief({ proposal, upgrades, proposalRequires, curat
               <p className="mb-1.5 flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-wider text-violet-600 dark:text-violet-400"><AlertTriangle className="h-3.5 w-3.5" /> 3 · Risk &amp; readiness</p>
               <p className="text-sm"><span className={cn('font-semibold', enterpriseRisk.color)}>{enterpriseRisk.level} risk</span> <span className="text-muted-foreground">— {tradeoffs.length > 0 ? tradeoffs[0] : `${enterpriseRisk.note}.`}</span></p>
               <p className="mt-1 text-[11px] text-muted-foreground">
-                <span className="font-medium text-foreground/80">What to review internally:</span> {enterpriseAction} Track testing via the upgrade&apos;s <span className="text-foreground/80">test-complexity</span> and <span className="text-foreground/80">devnet-inclusion</span> pages, and client readiness under <span className="text-foreground/80">client-priority</span>.
+                <span className="font-medium text-foreground/80">What to review internally:</span>{' '}
+                {readinessText ?? (
+                  <>
+                    {enterpriseAction} Track testing via the upgrade&apos;s <span className="text-foreground/80">test-complexity</span> and <span className="text-foreground/80">devnet-inclusion</span> pages, and client readiness under <span className="text-foreground/80">client-priority</span>.
+                  </>
+                )}
               </p>
             </div>
 

--- a/src/lib/ai-curation.ts
+++ b/src/lib/ai-curation.ts
@@ -294,27 +294,44 @@ export type EnterpriseTier = 'direct' | 'limited' | 'none';
 export interface EnterpriseOrgImpact {
   role: string;
   level: EnterpriseLevel;
+  /** One-line headline shown when the card is collapsed. */
+  summary: string;
+  /** "Affected how?" — the concrete mechanism / what changes for them. */
+  how: string;
+  /** "Why it matters" — the business consequence, in institutional terms. */
   why: string;
+  /** "What to do" — optional action / monitoring guidance. */
+  action?: string;
+}
+export interface EnterpriseBusinessArea {
+  /** e.g. "Assets & client offerings", "Costs & processing", "Accounting & reporting". */
+  area: string;
+  /** One-line headline shown when the card is collapsed. */
+  summary: string;
+  /** The detailed explanation shown when expanded. */
+  detail: string;
 }
 export interface EnterpriseImpact {
   tier: EnterpriseTier;
   summary: string;
   organizations: EnterpriseOrgImpact[];
+  businessImpact?: EnterpriseBusinessArea[];
   readiness?: string;
 }
 
-const ENTERPRISE_SYSTEM_PROMPT = `You translate Ethereum protocol changes for an ENTERPRISE and INSTITUTIONAL audience: banks & payment providers, auditors & accountants, asset managers, custodians & wallets, staking providers, infrastructure operators, companies building on L2s, and digital-asset advisors.
+const ENTERPRISE_SYSTEM_PROMPT = `You write a DETAILED enterprise impact report on Ethereum protocol changes for an INSTITUTIONAL audience: banks & payment providers, auditors & accountants, asset managers, custodians & wallets, staking providers, infrastructure operators, companies building on L2s, and digital-asset advisors.
 
-Given the real text of one EIP, assess its concrete impact on each institution type. Rules:
+Given the real text of one EIP, assess its concrete impact. Rules:
 - Base everything ONLY on the EIP text. Never invent regulatory, accounting, or financial claims.
 - Be HONEST and specific. Most protocol/developer EIPs have NO direct institutional impact — when that is the case, say so plainly and set levels to "none". Do not inflate importance.
-- "high" = the institution must actively plan, test, or change operations before this ships. "medium" = indirect exposure worth monitoring (e.g. routine client/tooling updates). "low" = minimal, informational. "none" = not affected; explain in one short clause why not.
-- Write "why" for a non-technical institutional reader (settlement, custody, reporting, controls, operations), not for protocol engineers.
+- Levels: "high" = must actively plan/test/change operations before it ships. "medium" = indirect exposure worth monitoring (e.g. routine client/tooling updates). "low" = minimal, informational. "none" = not affected.
+- For EACH organization give "how" (the concrete mechanism — what actually changes for them) and "why" (the business consequence: settlement, custody, reporting, controls, operations). For "none", "how" states there is no operational change and "why" states nothing needs attention.
+- Write for a non-technical institutional reader, not protocol engineers.
 Return a single JSON object, nothing else.`;
 
 function buildEnterpriseUserPrompt(eipNumber: number, title: string, body: string): string {
   const trimmed = body.length > 5000 ? `${body.slice(0, 5000)}\n…(truncated)` : body;
-  const roleList = ENTERPRISE_ROLES.map((r) => `    { "role": "${r}", "level": "high|medium|low|none", "why": "1-2 sentences specific to this EIP; if none, one clause on why it's unaffected" }`).join(',\n');
+  const roleList = ENTERPRISE_ROLES.map((r) => `    { "role": "${r}", "level": "high|medium|low|none", "summary": "<=90 char headline", "how": "1-2 sentences: how this EIP concretely affects them (or that it does not)", "why": "1-2 sentences: why it matters to their business (or why it doesn't)", "action": "1 short sentence, or 'No action needed.'" }`).join(',\n');
   return `EIP-${eipNumber}: ${title}
 
 --- SPEC TEXT ---
@@ -328,9 +345,16 @@ Produce this exact JSON shape:
   "organizations": [
 ${roleList}
   ],
+  "businessImpact": [
+    { "area": "Assets & client offerings", "summary": "<=90 char headline", "detail": "1-3 sentences of specifics for this EIP" },
+    { "area": "Costs & transaction processing", "summary": "…", "detail": "…" },
+    { "area": "Accounting & reporting", "summary": "…", "detail": "…" },
+    { "area": "Controls & compliance", "summary": "…", "detail": "…" },
+    { "area": "Operational procedures", "summary": "…", "detail": "…" }
+  ],
   "readiness": "1-2 sentences on what institutions should do or monitor. Use 'No action needed.' when tier is none."
 }
-Include ALL eight organizations in the same order. tier "direct" if any organization is "high"; "limited" if the highest is "medium"; otherwise "none".`;
+Include ALL eight organizations in the same order. Include the five businessImpact areas. tier "direct" if any organization is "high"; "limited" if the highest is "medium"; otherwise "none".`;
 }
 
 const LEVELS: readonly EnterpriseLevel[] = ['high', 'medium', 'low', 'none'];
@@ -339,7 +363,13 @@ export async function generateEnterpriseImpact(eipNumber: number): Promise<Enter
   const spec = await fetchEipSpec(eipNumber);
   if (!spec) return null;
 
-  const raw = await callLLM(ENTERPRISE_SYSTEM_PROMPT, buildEnterpriseUserPrompt(eipNumber, spec.title, spec.body));
+  // The enterprise report is a large output. On GROQ's free tier the 70B model's
+  // token budget is easily exhausted, so use the high-throughput 8B model when
+  // GROQ is the active provider. Gemini/Anthropic use their own defaults.
+  const groqActive = !process.env.GEMINI_API_KEY && !process.env.ANTHROPIC_API_KEY;
+  const groqModel = groqActive ? process.env.ENTERPRISE_GROQ_MODEL || 'llama-3.1-8b-instant' : undefined;
+
+  const raw = await callLLM(ENTERPRISE_SYSTEM_PROMPT, buildEnterpriseUserPrompt(eipNumber, spec.title, spec.body), groqModel);
   if (!raw) return null;
   const json = extractJson(raw);
   if (!json) return null;
@@ -347,7 +377,8 @@ export async function generateEnterpriseImpact(eipNumber: number): Promise<Enter
   let parsed: {
     tier?: string;
     summary?: string;
-    organizations?: Array<{ role?: string; level?: string; why?: string }>;
+    organizations?: Array<{ role?: string; level?: string; summary?: string; how?: string; why?: string; action?: string }>;
+    businessImpact?: Array<{ area?: string; summary?: string; detail?: string }>;
     readiness?: string;
   };
   try {
@@ -356,20 +387,32 @@ export async function generateEnterpriseImpact(eipNumber: number): Promise<Enter
     return null;
   }
 
-  // Sanitize: one entry per canonical role, valid level, in canonical order.
-  const byRole = new Map<string, { level?: string; why?: string }>();
+  // Sanitize organizations: one entry per canonical role, valid level, canonical order.
+  const byRole = new Map<string, { level?: string; summary?: string; how?: string; why?: string; action?: string }>();
   for (const o of parsed.organizations ?? []) {
-    if (o?.role) byRole.set(o.role.trim().toLowerCase(), { level: o.level, why: o.why });
+    if (o?.role) byRole.set(o.role.trim().toLowerCase(), o);
   }
   const organizations: EnterpriseOrgImpact[] = ENTERPRISE_ROLES.map((role) => {
     const found = byRole.get(role.toLowerCase());
     const level = (found?.level ?? '').toLowerCase();
+    const why = found?.why?.trim() || 'Not directly affected by this change.';
     return {
       role,
       level: (LEVELS as readonly string[]).includes(level) ? (level as EnterpriseLevel) : 'none',
-      why: found?.why?.trim() || 'Not directly affected by this change.',
+      summary: found?.summary?.trim() || why,
+      how: found?.how?.trim() || 'No operational change for this organization type.',
+      why,
+      action: found?.action?.trim() || undefined,
     };
   });
+
+  const businessImpact: EnterpriseBusinessArea[] = (parsed.businessImpact ?? [])
+    .filter((b) => b?.area && (b.detail || b.summary))
+    .map((b) => ({
+      area: b.area!.trim(),
+      summary: b.summary?.trim() || b.detail!.trim(),
+      detail: b.detail?.trim() || b.summary!.trim(),
+    }));
 
   // Derive tier from levels so it can never contradict the per-org data.
   const tier: EnterpriseTier = organizations.some((o) => o.level === 'high')
@@ -385,6 +428,7 @@ export async function generateEnterpriseImpact(eipNumber: number): Promise<Enter
     tier,
     summary,
     organizations,
+    businessImpact: businessImpact.length > 0 ? businessImpact : undefined,
     readiness: parsed.readiness?.trim() || (tier === 'none' ? 'No action needed.' : undefined),
   };
 }

--- a/src/lib/ai-curation.ts
+++ b/src/lib/ai-curation.ts
@@ -270,3 +270,121 @@ export async function generateEipCuration(
     stakeholderImpacts: Object.keys(impacts).length > 0 ? impacts : undefined,
   };
 }
+
+// ─── Enterprise / institutional impact ───────────────────────────────────────
+// A dedicated, finance-audience curation: for each institution type, a curated
+// impact level + a plain, specific reason. Non-impacted EIPs say so outright.
+
+/** Canonical institution types shown in the Enterprise view. Keep in sync with
+ *  the brief's Affected-organizations list. */
+export const ENTERPRISE_ROLES = [
+  'Banks & payment providers',
+  'Auditors & accountants',
+  'Asset managers',
+  'Custodians & wallets',
+  'Staking providers',
+  'Infrastructure operators',
+  'L2-using companies',
+  'Digital-asset advisors',
+] as const;
+
+export type EnterpriseLevel = 'high' | 'medium' | 'low' | 'none';
+export type EnterpriseTier = 'direct' | 'limited' | 'none';
+
+export interface EnterpriseOrgImpact {
+  role: string;
+  level: EnterpriseLevel;
+  why: string;
+}
+export interface EnterpriseImpact {
+  tier: EnterpriseTier;
+  summary: string;
+  organizations: EnterpriseOrgImpact[];
+  readiness?: string;
+}
+
+const ENTERPRISE_SYSTEM_PROMPT = `You translate Ethereum protocol changes for an ENTERPRISE and INSTITUTIONAL audience: banks & payment providers, auditors & accountants, asset managers, custodians & wallets, staking providers, infrastructure operators, companies building on L2s, and digital-asset advisors.
+
+Given the real text of one EIP, assess its concrete impact on each institution type. Rules:
+- Base everything ONLY on the EIP text. Never invent regulatory, accounting, or financial claims.
+- Be HONEST and specific. Most protocol/developer EIPs have NO direct institutional impact — when that is the case, say so plainly and set levels to "none". Do not inflate importance.
+- "high" = the institution must actively plan, test, or change operations before this ships. "medium" = indirect exposure worth monitoring (e.g. routine client/tooling updates). "low" = minimal, informational. "none" = not affected; explain in one short clause why not.
+- Write "why" for a non-technical institutional reader (settlement, custody, reporting, controls, operations), not for protocol engineers.
+Return a single JSON object, nothing else.`;
+
+function buildEnterpriseUserPrompt(eipNumber: number, title: string, body: string): string {
+  const trimmed = body.length > 5000 ? `${body.slice(0, 5000)}\n…(truncated)` : body;
+  const roleList = ENTERPRISE_ROLES.map((r) => `    { "role": "${r}", "level": "high|medium|low|none", "why": "1-2 sentences specific to this EIP; if none, one clause on why it's unaffected" }`).join(',\n');
+  return `EIP-${eipNumber}: ${title}
+
+--- SPEC TEXT ---
+${trimmed}
+--- END SPEC ---
+
+Produce this exact JSON shape:
+{
+  "tier": "direct | limited | none",
+  "summary": "2-4 sentences for an institutional reader: what changes and whether institutions need to care. If there is no direct enterprise impact, state that plainly.",
+  "organizations": [
+${roleList}
+  ],
+  "readiness": "1-2 sentences on what institutions should do or monitor. Use 'No action needed.' when tier is none."
+}
+Include ALL eight organizations in the same order. tier "direct" if any organization is "high"; "limited" if the highest is "medium"; otherwise "none".`;
+}
+
+const LEVELS: readonly EnterpriseLevel[] = ['high', 'medium', 'low', 'none'];
+
+export async function generateEnterpriseImpact(eipNumber: number): Promise<EnterpriseImpact | null> {
+  const spec = await fetchEipSpec(eipNumber);
+  if (!spec) return null;
+
+  const raw = await callLLM(ENTERPRISE_SYSTEM_PROMPT, buildEnterpriseUserPrompt(eipNumber, spec.title, spec.body));
+  if (!raw) return null;
+  const json = extractJson(raw);
+  if (!json) return null;
+
+  let parsed: {
+    tier?: string;
+    summary?: string;
+    organizations?: Array<{ role?: string; level?: string; why?: string }>;
+    readiness?: string;
+  };
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+
+  // Sanitize: one entry per canonical role, valid level, in canonical order.
+  const byRole = new Map<string, { level?: string; why?: string }>();
+  for (const o of parsed.organizations ?? []) {
+    if (o?.role) byRole.set(o.role.trim().toLowerCase(), { level: o.level, why: o.why });
+  }
+  const organizations: EnterpriseOrgImpact[] = ENTERPRISE_ROLES.map((role) => {
+    const found = byRole.get(role.toLowerCase());
+    const level = (found?.level ?? '').toLowerCase();
+    return {
+      role,
+      level: (LEVELS as readonly string[]).includes(level) ? (level as EnterpriseLevel) : 'none',
+      why: found?.why?.trim() || 'Not directly affected by this change.',
+    };
+  });
+
+  // Derive tier from levels so it can never contradict the per-org data.
+  const tier: EnterpriseTier = organizations.some((o) => o.level === 'high')
+    ? 'direct'
+    : organizations.some((o) => o.level === 'medium')
+      ? 'limited'
+      : 'none';
+
+  const summary = parsed.summary?.trim();
+  if (!summary) return null;
+
+  return {
+    tier,
+    summary,
+    organizations,
+    readiness: parsed.readiness?.trim() || (tier === 'none' ? 'No action needed.' : undefined),
+  };
+}

--- a/src/server/orpc/procedures/curations.ts
+++ b/src/server/orpc/procedures/curations.ts
@@ -41,6 +41,7 @@ function serializeCuration(row: {
   tradeoffs: unknown
   stakeholder_impacts: unknown
   north_star: unknown
+  enterprise_impact: unknown
   headliner_of: string | null
   headliner_note: string | null
   layer: string | null
@@ -61,6 +62,15 @@ function serializeCuration(row: {
     north_star:
       row.north_star && typeof row.north_star === 'object'
         ? (row.north_star as Record<string, { description?: string }>)
+        : null,
+    enterprise_impact:
+      row.enterprise_impact && typeof row.enterprise_impact === 'object'
+        ? (row.enterprise_impact as {
+            tier?: string
+            summary?: string
+            organizations?: Array<{ role?: string; level?: string; why?: string }>
+            readiness?: string
+          })
         : null,
     headliner_of: row.headliner_of,
     headliner_note: row.headliner_note,


### PR DESCRIPTION
This pull request introduces a dedicated enterprise/institutional curation path for EIPs, providing curated summaries, organization-level impact ratings, and business impact analysis tailored for a finance audience. It updates both the backend (`prisma/schema.prisma`) and the frontend (`enterprise-eip-brief.tsx` and proposal detail page) to support and display these new fields, alongside several UI improvements to make the information clearer and more actionable.

**Enterprise Curation Support and Display:**

* Added a new `enterprise_impact` JSON field to the `eip_curations` model in `prisma/schema.prisma` to store finance-audience, curated impact data.
* Updated the `EnterpriseEIPBrief` component to prioritize and display the dedicated enterprise curation, including per-organization impact, business area summaries, and readiness notes. This includes new types, icon mapping, tier logic, and UI for "Not affected" organizations. [[1]](diffhunk://#diff-ee22bd6fcc32e7ffd9fcffe3f9e9003f6e1bab7ec413f333853dbd49f9e486f9R84-R97) [[2]](diffhunk://#diff-ee22bd6fcc32e7ffd9fcffe3f9e9003f6e1bab7ec413f333853dbd49f9e486f9R351-R380) [[3]](diffhunk://#diff-ee22bd6fcc32e7ffd9fcffe3f9e9003f6e1bab7ec413f333853dbd49f9e486f9L492-R587) [[4]](diffhunk://#diff-ee22bd6fcc32e7ffd9fcffe3f9e9003f6e1bab7ec413f333853dbd49f9e486f9L533-R613) [[5]](diffhunk://#diff-ee22bd6fcc32e7ffd9fcffe3f9e9003f6e1bab7ec413f333853dbd49f9e486f9L543-R632) [[6]](diffhunk://#diff-ee22bd6fcc32e7ffd9fcffe3f9e9003f6e1bab7ec413f333853dbd49f9e486f9R646-R669) [[7]](diffhunk://#diff-ee22bd6fcc32e7ffd9fcffe3f9e9003f6e1bab7ec413f333853dbd49f9e486f9L631-R714)

**Proposal Detail Page UI Improvements:**

* Moved the created date and dependencies ("Requires") to a more visible preamble section above the proposal body, improving clarity and reducing redundancy. ([src/app/(proposal)/[repo]/[number]/page.tsxR776-R802](diffhunk://#diff-d2778efaba6f980b03664c91301e04f196ccd05770066bdcd9ed46f04d8ef3a3R776-R802))
* Relocated the proposal and repository subscription cards to the end of the page as a compact CTA, streamlining the page layout. ([src/app/(proposal)/[repo]/[number]/page.tsxL843-L907](diffhunk://#diff-d2778efaba6f980b03664c91301e04f196ccd05770066bdcd9ed46f04d8ef3a3L843-L907), [src/app/(proposal)/[repo]/[number]/page.tsxR1063-R1074](diffhunk://#diff-d2778efaba6f980b03664c91301e04f196ccd05770066bdcd9ed46f04d8ef3a3R1063-R1074))

These changes collectively provide a more tailored and actionable experience for institutional users reviewing EIPs, while also improving the clarity and maintainability of the proposal detail page.